### PR TITLE
Use cluster-local DNS to reduce lookups

### DIFF
--- a/faas.yml
+++ b/faas.yml
@@ -72,7 +72,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: functions_provider_url
-          value: "http://faas-netesd.default:8080/"
+          value: "http://faas-netesd.default.svc.cluster.local:8080/"
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -15,6 +15,8 @@ import (
 
 	"io/ioutil"
 
+	"os"
+
 	"github.com/gorilla/mux"
 )
 
@@ -52,7 +54,12 @@ func MakeProxy() http.HandlerFunc {
 			watchdogPort := 8080
 			var addr string
 
-			entries, lookupErr := net.LookupIP(fmt.Sprintf("%s.default", service))
+			dnsSuffix := "default.svc.cluster.local"
+			if envSuffix, has := os.LookupEnv("dns_function_suffix"); has && len(envSuffix) > 0 {
+				dnsSuffix = envSuffix
+			}
+
+			entries, lookupErr := net.LookupIP(fmt.Sprintf("%s.%s", service, dnsSuffix))
 			if lookupErr == nil && len(entries) > 0 {
 				index := randomInt(0, len(entries))
 				addr = entries[index].String()


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

Fixes #12 

I'm not sure why Play-with-k8s has so many DNS search paths, but I've allowed an override for functions and updated the faas.yml file to use a more qualified cluster-local path.