### PR TITLE
we should explicitly choose a versioned one.

### DIFF
--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -37,7 +37,7 @@ func MakeDeleteHandler(functionNamespace string, clientset *kubernetes.Clientset
 		getOpts := metav1.GetOptions{}
 
 		// This makes sure we don't delete non-labelled deployments
-		deployment, findDeployErr := clientset.Extensions().Deployments(functionNamespace).Get(request.FunctionName, getOpts)
+		deployment, findDeployErr := clientset.ExtensionsV1beta1().Deployments(functionNamespace).Get(request.FunctionName, getOpts)
 
 		if findDeployErr != nil {
 			if errors.IsNotFound(err) {
@@ -73,7 +73,7 @@ func isFunction(deployment *v1beta1.Deployment) bool {
 func deleteFunction(functionNamespace string, clientset *kubernetes.Clientset, request requests.DeleteFunctionRequest, w http.ResponseWriter) {
 	opts := &metav1.DeleteOptions{}
 
-	if deployErr := clientset.Extensions().Deployments(functionNamespace).Delete(request.FunctionName, opts); deployErr != nil {
+	if deployErr := clientset.ExtensionsV1beta1().Deployments(functionNamespace).Delete(request.FunctionName, opts); deployErr != nil {
 		if errors.IsNotFound(deployErr) {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
@@ -83,7 +83,7 @@ func deleteFunction(functionNamespace string, clientset *kubernetes.Clientset, r
 		return
 	}
 
-	if svcErr := clientset.Core().Services(functionNamespace).Delete(request.FunctionName, opts); svcErr != nil {
+	if svcErr := clientset.CoreV1().Services(functionNamespace).Delete(request.FunctionName, opts); svcErr != nil {
 		if errors.IsNotFound(svcErr) {
 			w.WriteHeader(http.StatusNotFound)
 		} else {

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// DefaultFunctionNamespace define default work namespace
 const DefaultFunctionNamespace string = "default"
 
 // ValidateDeployRequest validates that the service name is valid for Kubernetes

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// MakeUpdateHandler update specified function
 func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -29,7 +30,7 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 
 		getOpts := metav1.GetOptions{}
 
-		deployment, findDeployErr := clientset.Extensions().Deployments(functionNamespace).Get(request.Service, getOpts)
+		deployment, findDeployErr := clientset.ExtensionsV1beta1().Deployments(functionNamespace).Get(request.Service, getOpts)
 		if findDeployErr != nil {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(findDeployErr.Error()))
@@ -42,7 +43,7 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 			deployment.Spec.Template.Labels["uid"] = fmt.Sprintf("%d", time.Now().Nanosecond())
 		}
 
-		if _, updateErr := clientset.Extensions().Deployments(functionNamespace).Update(deployment); updateErr != nil {
+		if _, updateErr := clientset.ExtensionsV1beta1().Deployments(functionNamespace).Update(deployment); updateErr != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(updateErr.Error()))
 		}


### PR DESCRIPTION
Signed-off-by: zou nengren <zouyee1989@gmail.com>
According to the comment for [Extensions](https://github.com/kubernetes/client-go/blob/master/kubernetes/clientset.go#L71-L73), it is deprecated, we should explicitly choose a versioned one.
@alexellis PTAL