### PR TITLE
Setting Propagation Policy to Foreground for Delete Options

### DIFF
--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -71,7 +71,8 @@ func isFunction(deployment *v1beta1.Deployment) bool {
 }
 
 func deleteFunction(functionNamespace string, clientset *kubernetes.Clientset, request requests.DeleteFunctionRequest, w http.ResponseWriter) {
-	opts := &metav1.DeleteOptions{}
+	foregroundPolicy := metav1.DeletePropagationForeground
+	opts := &metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy}
 
 	if deployErr := clientset.Extensions().Deployments(functionNamespace).Delete(request.FunctionName, opts); deployErr != nil {
 		if errors.IsNotFound(deployErr) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On Kubernetes v1.6 clusters there are orphan ReplicaSet and Pods after the deletion of a function. After setting the Propagation Policy to Foreground for Delete Options, this looks okay. Fixes #34 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a v1.6 Kubernetes cluster. After the deletion of a function the related Service, Deployment, ReplicaSet and Pod objects are deleted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
