### PR TITLE
[Helm chart] Add ingress and option to change external service type

### DIFF
--- a/HELM.md
+++ b/HELM.md
@@ -54,14 +54,33 @@ $ helm upgrade --install --debug --namespace openfaas \
 
 If you would like to enable asynchronous functions then use `--set async=true`. You can read more about asynchronous functions in the [OpenFaaS guides](https://github.com/openfaas/faas/tree/master/guide).
 
+### Deploy with ingress
+
+NOTE: you need ingress controller in your k8s cluster for ingress resources to have any effect.
+
+Add `--set ingress.enabled` to enable ingress:
+
+```
+$ helm upgrade --install --debug --reset-values --set async=false --set ingress.enabled=true openfaas openfaas/
+```
+
+By default services will be exposed with following hostnames (can be changed, see values.yaml for details):
+* `faas-netesd.openfaas.local`
+* `gateway.openfaas.local`
+* `prometheus.openfaas.local`
+* `alertmanager.openfaas.local`
+
+
 ### OpenFaaS Helm chart options:
 
 ```
 functionNamespace=defaults to the deployed namespace, kube namespace to create function deployments in
 async=true/false defaults to false, deploy nats if true
 armhf=true/false, defaults to false, use arm images if true (missing images for async)
-exposeServices=true/false, defaults to true, will always create `ClusterIP` services, and expose `NodePorts` if true
+exposeServices=true/false, defaults to true, will always create `ClusterIP` services, and expose `NodePorts/LoadBalancer` if true (based on serviceType)
+serviceType=NodePort/LoadBalancer, defaults to NodePort, type of external service to use when exposeServices is set to true
 rbac=true/false defaults to true, if true create roles
+ingress.enabled=true/false defaults to false, set to true to create ingress resources. See openfaas/values.yaml for detailed Ingress configuration.
 ```
 
 

--- a/openfaas/templates/external-service-access.yaml
+++ b/openfaas/templates/external-service-access.yaml
@@ -12,12 +12,14 @@ metadata:
   name: faas-netesd-external
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: NodePort
+  type: {{ .Values.serviceType }}
   ports:
     - port: 8080
       protocol: TCP
       targetPort: 8080
+      {{- if contains "NodePort" .Values.serviceType }}
       nodePort: 31111
+      {{- end }}
   selector:
     app: faas-netesd
 ---
@@ -33,12 +35,14 @@ metadata:
   name: gateway-external
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: NodePort
+  type: {{ .Values.serviceType }}
   ports:
     - port: 8080
       protocol: TCP
       targetPort: 8080
+      {{- if contains "NodePort" .Values.serviceType }}
       nodePort: 31112
+      {{- end }}
   selector:
     app: gateway
 ---
@@ -54,12 +58,14 @@ metadata:
   name: prometheus-external
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: NodePort
+  type: {{ .Values.serviceType }}
   ports:
     - port: 9090
       protocol: TCP
       targetPort: 9090
+      {{- if contains "NodePort" .Values.serviceType }}
       nodePort: 31119
+      {{- end }}
   selector:
     app: prometheus
 ---
@@ -75,12 +81,14 @@ metadata:
   name: alertmanager-external
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: NodePort
+  type: {{ .Values.serviceType }}
   ports:
     - port: 9093
       protocol: TCP
       targetPort: 9093
+      {{- if contains "NodePort" .Values.serviceType }}
       nodePort: 31113
+      {{- end }}
   selector:
     app: alertmanager
 ---
@@ -97,12 +105,14 @@ metadata:
   name: nats-external
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: NodePort
+  type: {{ .Values.serviceType }}
   ports:
     - port: 4222
       protocol: TCP
       targetPort: 4222
+      {{- if contains "NodePort" .Values.serviceType }}
       nodePort: 31114
+      {{- end }}
   selector:
     app: nats
 {{- end }}

--- a/openfaas/templates/ingress.yaml
+++ b/openfaas/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "faas-netesd.name" . }}-ingress
+  labels:
+    app: {{ template "faas-netesd.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host.host }}
+      http:
+        paths:
+          - path: {{ $host.path }}
+            backend:
+              serviceName: {{ $host.serviceName }}
+              servicePort: {{ $host.servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/openfaas/values.yaml
+++ b/openfaas/values.yaml
@@ -2,6 +2,7 @@ functionNamespace:
 async: false
 armhf: false
 exposeServices: true
+serviceType: NodePort
 rbac: true
 
 # images
@@ -23,3 +24,29 @@ images:
 
   queueWorker: functions/queue-worker:0.1
   queueWorkerArmhf:
+
+# ingress configuration
+ingress:
+  enabled: false
+  # Used to create Ingress record (should be used with exposeServices: false).
+  hosts:
+    - host: faas-netesd.openfaas.local
+      serviceName: faas-netesd
+      servicePort: 8080
+      path: /
+    - host: gateway.openfaas.local
+      serviceName: gateway
+      servicePort: 8080
+      path: /
+    - host: prometheus.openfaas.local
+      serviceName: prometheus
+      servicePort: 9090
+      path: /
+    - host: alertmanager.openfaas.local
+      serviceName: alertmanager
+      servicePort: 9093
+      path: /
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  tls:
+    # Secrets must be manually created in the namespace.


### PR DESCRIPTION
Adds ingress (default set to false) and service Type option (default
set to NodePort) to Faas-netes helm chart.

Signed-off-by: Karol Stepniewski <karol.stepniewski@gmail.com>

## Description
Adds following things:
* option to change external Service type (default stays NodePort, can be changed via `helm --set` to LoadBalancer)
* option to deploy ingress resource to expose OpenFaaS via ingress.
## Motivation and Context
Enables chart consumers to use different ways of exposing OpenFaaS externally:
* via LoadBalancer service type (for k8s users with cloud provider)
* via Ingress resource


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When running helm with no extra flags, there are no changes:
```
$ helm install --namespace=openfaas .
...
==> v1/Service
NAME                   CLUSTER-IP      EXTERNAL-IP  PORT(S)         AGE
alertmanager-external  10.251.101.4    <nodes>      9093:31113/TCP  2s
faas-netesd-external   10.251.212.222  <nodes>      8080:31111/TCP  2s
prometheus-external    10.249.155.0    <nodes>      9090:31119/TCP  2s
gateway-external       10.251.164.195  <nodes>      8080:31112/TCP  2s
gateway                10.248.146.188  <none>       8080/TCP        2s
faas-netesd            10.248.62.140   <none>       8080/TCP        2s
prometheus             10.251.110.20   <none>       9090/TCP        2s
alertmanager           10.249.32.6     <none>       9093/TCP        2s
```

When running with serviceType set to LoadBalancer, services are exposed via external LB:
```
$ helm install --namespace=openfaas --set serviceType=LoadBalancer .
...
==> v1/Service
NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(S)          AGE
alertmanager            ClusterIP      10.251.166.18    <none>             9093/TCP         24m
alertmanager-external   LoadBalancer   10.250.64.105    10.126.236.42...   9093:31281/TCP   24m
faas-netesd             ClusterIP      10.250.25.120    <none>             8080/TCP         24m
faas-netesd-external    LoadBalancer   10.251.61.102    10.126.236.43...   8080:31497/TCP   24m
gateway                 ClusterIP      10.248.22.96     <none>             8080/TCP         24m
gateway-external        LoadBalancer   10.250.208.204   10.126.236.31...   8080:32322/TCP   24m
prometheus              ClusterIP      10.250.63.61     <none>             9090/TCP         24m
prometheus-external     LoadBalancer   10.250.81.244    10.126.236.33...   9090:32729/TCP   24m
```

When running with exposeServices=false and ingress.enabled=true, Ingress resource is created:
```
$ helm install --namespace=openfaas --set exposeServices=false --set ingress.enabled=true .
...
==> v1/Service
NAME          CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE
faas-netesd   10.249.26.160   <none>       8080/TCP  3s
gateway       10.251.101.70   <none>       8080/TCP  2s
alertmanager  10.248.90.15    <none>       9093/TCP  2s
prometheus    10.251.135.212  <none>       9090/TCP  2s

==> v1beta1/Ingress
NAME              HOSTS                                                                                    ADDRESS  PORTS  AGE
openfaas-ingress  faas-netesd.openfaas.local,gateway.openfaas.local,prometheus.openfaas.local + 1 more...  80       2s


$ kubectl describe ingress/openfaas-ingress -n openfaas
Name:             openfaas-ingress
Namespace:        openfaas
Address:          192.168.19.11
Default backend:  default-http-backend:80 (<none>)
Rules:
  Host                         Path  Backends
  ----                         ----  --------
  faas-netesd.openfaas.local
                               /   faas-netesd:8080 (<none>)
  gateway.openfaas.local
                               /   gateway:8080 (<none>)
  prometheus.openfaas.local
                               /   prometheus:9090 (<none>)
  alertmanager.openfaas.local
                               /   alertmanager:9093 (<none>)
Annotations:
Events:
  Type    Reason  Age   From                Message
  ----    ------  ----  ----                -------
  Normal  CREATE  50s   ingress-controller  Ingress openfaas/openfaas-ingress
  Normal  UPDATE  36s   ingress-controller  Ingress openfaas/openfaas-ingress
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
