### PR TITLE
Monitoring: Switch to using mounted configmaps and use library images

### DIFF
--- a/monitoring-config.yml
+++ b/monitoring-config.yml
@@ -1,0 +1,137 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    # my global config
+    global:
+      scrape_interval:     15s # By default, scrape targets every 15 seconds.
+      evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+      # scrape_timeout is set to the global default (10s).
+
+      # Attach these labels to any time series or alerts when communicating with
+      # external systems (federation, remote storage, Alertmanager).
+      external_labels:
+          monitor: 'faas-monitor'
+
+    # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+    rule_files:
+        - 'alert.rules'
+
+    # A scrape configuration containing exactly one endpoint to scrape:
+    # Here it's Prometheus itself.
+    scrape_configs:
+      # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+      - job_name: 'prometheus'
+
+        # Override the global default and scrape targets from this job every 5 seconds.
+        scrape_interval: 5s
+
+        # metrics_path defaults to '/metrics'
+        # scheme defaults to 'http'.
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: "gateway"
+        scrape_interval: 5s
+        dns_sd_configs:
+          - names: ['gateway']
+            port: 8080
+            type: A
+            refresh_interval: 5s
+
+  alert.rules: |
+    ALERT service_down
+      IF up == 0
+
+    ALERT APIHighInvocationRate
+      IF sum ( rate(gateway_function_invocation_total{code="200"}[10s]) ) by (function_name) > 5
+      FOR 5s
+      LABELS {
+        service = "gateway",
+        severity = "major",
+        value = "{{$value}}"
+      }
+      ANNOTATIONS {
+        summary = "High invocation total on {{ $labels.instance }}",
+        description =  "High invocation total on {{ $labels.instance }}"
+      }
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: alertmanager
+  name: alertmanager-config
+data:
+  alertmanager.yml: |
+    global:
+      # The smarthost and SMTP sender used for mail notifications.
+      smtp_smarthost: 'localhost:25'
+      smtp_from: 'alertmanager@example.org'
+      smtp_auth_username: 'alertmanager'
+      smtp_auth_password: 'password'
+      # The auth token for Hipchat.
+      hipchat_auth_token: '1234556789'
+      # Alternative host for Hipchat.
+      hipchat_url: 'https://hipchat.foobar.org/'
+
+    # The directory from which notification templates are read.
+    templates:
+    - '/etc/alertmanager/template/*.tmpl'
+
+    # The root route on which each incoming alert enters.
+    route:
+      # The labels by which incoming alerts are grouped together. For example,
+      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+      # be batched into a single group.
+      group_by: ['alertname', 'cluster', 'service']
+
+      # When a new group of alerts is created by an incoming alert, wait at
+      # least 'group_wait' to send the initial notification.
+      # This way ensures that you get multiple alerts for the same group that start
+      # firing shortly after another are batched together on the first
+      # notification.
+      group_wait: 5s
+
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+      group_interval: 10s
+
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+      repeat_interval: 30s
+
+      # A default receiver
+      receiver: scale-up
+
+      # All the above attributes are inherited by all child routes and can
+      # overwritten on each.
+
+      # The child route trees.
+      routes:
+      - match:
+          service: gateway
+          receiver: scale-up
+          severity: major
+
+    # Inhibition rules allow to mute a set of alerts given that another alert is
+    # firing.
+    # We use this to mute any warning-level notifications if the same alert is
+    # already critical.
+    inhibit_rules:
+    - source_match:
+        severity: 'critical'
+      target_match:
+        severity: 'warning'
+      # Apply inhibition if the alertname is the same.
+      equal: ['alertname', 'cluster', 'service']
+
+    receivers:
+    - name: 'scale-up'
+      webhook_configs:
+        - url: http://gateway:8080/system/alert
+          send_resolved: true

--- a/monitoring.armhf.yml
+++ b/monitoring.armhf.yml
@@ -27,12 +27,30 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: alexellis2/prometheus-armhf:1.5.2-k8s # alexellis2/prometheus-armhf:1.5.2
+        image: alexellis2/prometheus-armhf:1.5.2
         command: ["prometheus","-config.file=/etc/prometheus/prometheus.yml", "-storage.local.path=/prometheus", "-storage.local.memory-chunks=10000", "--alertmanager.url=http://alertmanager.default:9093"]
         imagePullPolicy: Always
         ports:
         - containerPort: 9090
           protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/prometheus/prometheus.yml
+          name: prometheus-config
+          subPath: prometheus.yml
+        - mountPath: /etc/prometheus/alert.rules
+          name: prometheus-config
+          subPath: alert.rules
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+                mode: 0644
+              - key: alert.rules
+                path: alert.rules
+                mode: 0644
 ---
 apiVersion: v1
 kind: Service
@@ -69,3 +87,15 @@ spec:
         ports:
         - containerPort: 9003
           protocol: TCP
+        volumeMounts:
+        - mountPath: /alertmanager.yml
+          name: alertmanager-config
+          subPath: alertmanager.yml
+      volumes:
+        - name: alertmanager-config
+          configMap:
+            name: alertmanager-config
+            items:
+              - key: alertmanager.yml
+                path: alertmanager.yml
+                mode: 0644

--- a/monitoring.yml
+++ b/monitoring.yml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: functions/prometheus:latest-k8s
+        image: prom/prometheus:v1.5.2
         command: ["prometheus","-config.file=/etc/prometheus/prometheus.yml", "-storage.local.path=/prometheus", "-storage.local.memory-chunks=10000", "--alertmanager.url=http://alertmanager.default:9093"]
         imagePullPolicy: Always
         ports:
@@ -38,7 +38,24 @@ spec:
             memory: 512Mi
           limits:
             memory: 512Mi
-
+        volumeMounts:
+        - mountPath: /etc/prometheus/prometheus.yml
+          name: prometheus-config
+          subPath: prometheus.yml
+        - mountPath: /etc/prometheus/alert.rules
+          name: prometheus-config
+          subPath: alert.rules
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+                mode: 0644
+              - key: alert.rules
+                path: alert.rules
+                mode: 0644
 ---
 apiVersion: v1
 kind: Service
@@ -69,7 +86,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: functions/alertmanager:latest-k8s
+        image: prom/alertmanager:v0.7.1
         imagePullPolicy: Always
         command: ["/bin/alertmanager","-config.file=/alertmanager.yml", "-storage.path=/alertmanager"]
         ports:
@@ -80,3 +97,15 @@ spec:
             memory: 20Mi
           limits:
             memory: 30Mi
+        volumeMounts:
+        - mountPath: /alertmanager.yml
+          name: alertmanager-config
+          subPath: alertmanager.yml
+      volumes:
+        - name: alertmanager-config
+          configMap:
+            name: alertmanager-config
+            items:
+              - key: alertmanager.yml
+                path: alertmanager.yml
+                mode: 0644


### PR DESCRIPTION
## Description
This changes the standard `kubectl` `.yml` deployments to use mounted `ConfigMap`s for setting up alertmanager and prometheus. Deprecating the need for custom images of those services. The helm charts already use `ConfigMap`s.

## Motivation and Context

This gets us one step closer to having less images to maintain. Provides feature parity with https://github.com/openfaas/faas/issues/282 and eases transition for https://github.com/openfaas/faas/issues/283.


## How Has This Been Tested?

Tested by deploying `faas` using the readme in additional to the new configmap.

```
NAME                              READY     STATUS    RESTARTS   AGE
po/alertmanager-cb8f57c6d-4xqfk   1/1       Running   0          3s
po/faas-netesd-5b9db8777d-k9qlf   1/1       Running   0          3s
po/gateway-799dfdd695-mpfjg       1/1       Running   0          3s
po/prometheus-75b55cf4db-ml9xv    1/1       Running   0          3s

NAME               CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
svc/alertmanager   10.3.245.203   <nodes>       9093:30010/TCP   3s
svc/faas-netesd    10.3.37.154    <nodes>       8080:31111/TCP   3s
svc/gateway        10.3.146.75    <nodes>       8080:30002/TCP   3s
svc/kubernetes     10.3.0.1       <none>        443/TCP          7m
svc/prometheus     10.3.61.248    <nodes>       9090:30009/TCP   3s

NAME                  DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deploy/alertmanager   1         1         1            1           3s
deploy/faas-netesd    1         1         1            1           3s
deploy/gateway        1         1         1            1           3s
deploy/prometheus     1         1         1            1           3s

NAME                        DESIRED   CURRENT   READY     AGE
rs/alertmanager-cb8f57c6d   1         1         1         3s
rs/faas-netesd-5b9db8777d   1         1         1         3s
rs/gateway-799dfdd695       1         1         1         3s
rs/prometheus-75b55cf4db    1         1         1         3s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.