### PR TITLE
Helm: Fix ClusterRoleBinding for fns in different namespace

### DIFF
--- a/openfaas/templates/rbac.yaml
+++ b/openfaas/templates/rbac.yaml
@@ -65,7 +65,7 @@ metadata:
     component: faas-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: faas-controller
+  name: faas-controller-fn
   namespace: {{ $functionNs | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
`ClusterRoleBinding` names are cluster wide unique, without this change, it would conflict with the control plane binding.