### PR TITLE
Add Replica Status count and expose as AvailableCount

### DIFF
--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -34,12 +34,12 @@ func getServiceList(functionNamespace string, clientset *kubernetes.Clientset) (
 
 		labels := item.Spec.Template.Labels
 		function := requests.Function{
-			Name:            item.Name,
-			Replicas:        replicas,
-			Image:           item.Spec.Template.Spec.Containers[0].Image,
-			ReplicaCount:    int(item.Status.ReadyReplicas),
-			InvocationCount: 0,
-			Labels:          &labels,
+			Name:              item.Name,
+			Replicas:          replicas,
+			Image:             item.Spec.Template.Spec.Containers[0].Image,
+			AvailableReplicas: int(item.Status.ReadyReplicas),
+			InvocationCount:   0,
+			Labels:            &labels,
 		}
 
 		functions = append(functions, function)

--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -37,6 +37,7 @@ func getServiceList(functionNamespace string, clientset *kubernetes.Clientset) (
 			Name:            item.Name,
 			Replicas:        replicas,
 			Image:           item.Spec.Template.Spec.Containers[0].Image,
+			ReplicaCount:    int(item.Status.ReadyReplicas),
 			InvocationCount: 0,
 			Labels:          &labels,
 		}

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -51,12 +51,13 @@ type FunctionResources struct {
 
 // Function exported for system/functions endpoint
 type Function struct {
-	Name            string  `json:"name"`
-	Image           string  `json:"image"`
-	InvocationCount float64 `json:"invocationCount"` // TODO: shouldn't this be int64?
-	Replicas        uint64  `json:"replicas"`
-	EnvProcess      string  `json:"envProcess"`
-	ReplicaCount    int     `json:"replicaCount"`
+	Name              string  `json:"name"`
+	Image             string  `json:"image"`
+	InvocationCount   float64 `json:"invocationCount"` // TODO: shouldn't this be int64?
+	Replicas          uint64  `json:"replicas"`
+	EnvProcess        string  `json:"envProcess"`
+	ReplicaCount      int     `json:"replicaCount"`
+	AvailableReplicas int     `json:"availableReplicas"`
 
 	// Labels are metadata for functions which may be used by the
 	// back-end for making scheduling or routing decisions

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -56,6 +56,7 @@ type Function struct {
 	InvocationCount float64 `json:"invocationCount"` // TODO: shouldn't this be int64?
 	Replicas        uint64  `json:"replicas"`
 	EnvProcess      string  `json:"envProcess"`
+	ReplicaCount    int     `json:"replicaCount"`
 
 	// Labels are metadata for functions which may be used by the
 	// back-end for making scheduling or routing decisions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change is to add replica status reporting from `faas-cli list` command, on `faas-netes`.

## Description
<!--- Describe your changes in detail -->
In order to make this change work, you need to change the following:

1. Build the `faas-netesd` image and push to your docker hub, for example, I need to change the `Makefile` to the following:

```
@ -19,10 +19,10 @@ build-legacy:
        docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}"  -t functions/faas-netesd:$(TAG) . -f Dockerfile.non-multi --squash=${SQUASH}
 
 build:
-       docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t functions/faas-netesd:$(TAG) . --squash=${SQUASH}
+       docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t ems5311/faas-netesd:$(TAG) . --squash=${SQUASH}
 
 push:
-       docker push alexellis2/faas-netes:$(TAG)
+       docker push ems5311/faas-netesd:$(TAG)
```

2. `./build.sh` and `make push`
3. On your kubernetes machine, run `kubectl delete -f faas.yml`, change `faas.yml` to the following, then re-deploy with `kubectl apply -f faas.yml`. The `gateway` needs to be built from this version: (https://github.com/ericstoekl/faas/tree/replicaStatus). The reason is because the `Function` struct in `gateway/requests/request.go` needs to be updated to include the `AvailableCount` field. See [here](https://github.com/ericstoekl/faas/commit/90a3004a4167f9c77ed610fd6696f03bfce269dd#diff-3573ce8d9d6b16d746730ad1216eca1d)

`faas.yml` for me is:
```
+++ b/faas.yml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: faas-controller
       containers:
       - name: faas-netesd
-        image: functions/faas-netesd:0.3.1c
+        image: ems5311/faas-netesd:latest
 
         imagePullPolicy: Always
         ports:
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: functions/gateway:0.6.6b
+        image: ems5311/gateway:latest-dev
 #k8s-monitoring-dev
         imagePullPolicy: Always
         env:
```

4. Update `faas-cli` to this version: ([here](https://github.com/ericstoekl/faas-cli/tree/replicaStatus)), or alternatively just run:
```
$ curl http://<gateway-ip>:8080/system/functions?v=true
```
And you should see:
```
ubuntu@ip-172-31-1-145:~/faas-netes$ curl http://<gateway-ip>:8080/system/functions?v=true
[{"name":"markdownrender","image":"functions/markdownrender:latest","invocationCount":0,"replicas":1,"availableCount":1,"envProcess":""}]
```

5. If it works, you should be able to run the following command and see the replica status for each of your functions:
```
ubuntu@ip-172-31-1-145:~/faas/sample-functions$ fc ls --gateway http://10.244.0.28:8080 --verbose
Function                      	Image                                   	Invocations    	Replicas
markdownrender                	functions/markdownrender:latest         	0              	1/1
nodeinfo                      	functions/node-info:latest              	0              	1/1
sentimentanalysis             	functions/sentimentanalysis:latest      	0              	0/1
wordcountfunction             	functions/wordcount:latest              	0              	1/1
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Continuing with the research item linked here: https://github.com/openfaas/faas/issues/273

We need a way to report to the user whether their function is ready-to-go, without making them examine the output of `kubectl get pods`, for kubernetes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with a kubernetes deployment, deployed with these instructions:
https://blog.alexellis.io/kubernetes-in-10-minutes/

I can see the functions come online when I deploy a function that will take some time to download, and the function goes from `0/1` to `1/1`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
