### PR TITLE
Node selector support via constraints

### DIFF
--- a/handlers/update.go
+++ b/handlers/update.go
@@ -41,6 +41,8 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 			deployment.Spec.Template.Spec.Containers[0].Image = request.Image
 			deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
 
+			deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
+
 			labels := map[string]string{
 				"faas_function": request.Service,
 				"uid":           fmt.Sprintf("%d", time.Now().Nanosecond()),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Brings parity with Docker Swarm implementation.

We can now pin a function to a specific node such as:

```
constraints:
  - environment=production
```

*`faas-cli` YAML*

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Test plan:

First label a node using `kubectl`:

```
$ kubectl label node/node1 environment=true
```

* Next add a constraint to a function using the YAML example above and deploy. 

* You should see that the function is scheduled on the node. Now try removing the function and the constraint and schedule again. 

* Finally add a constraint that can never be matched and then reschedule the function, you should see it sitting at 0/1 replicas.

Next - do all of the above using the `--update=true --replace=false` flag to `faas-cli deploy`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
