### PR TITLE
Lock down Prometheus Alertmanager and NATS ports by default + bump images/tags

### DIFF
--- a/HELM.md
+++ b/HELM.md
@@ -15,15 +15,15 @@ Instructions for Kubernetes on Linux
 * Install Helm
 
 ```
-$ wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.2-linux-amd64.tar.gz && \
-  sudo tar -xvf helm-v2.6.2-linux-amd64.tar.gz --strip-components=1 -C /usr/local/bin/
+$ wget https://storage.googleapis.com/kubernetes-helm/helm-v2.7.0-linux-amd64.tar.gz && \
+  sudo tar -xvf helm-v2.7.0-linux-amd64.tar.gz --strip-components=1 -C /usr/local/bin/
 ```
 
 On Mac/Darwin:
 
 ```
-$ wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.2-darwin-amd64.tar.gz && \
-  sudo tar -xvf helm-v2.6.2-darwin-amd64.tar.gz --strip-components=1 -C /usr/local/bin/
+$ wget https://storage.googleapis.com/kubernetes-helm/helm-v2.7.0-darwin-amd64.tar.gz && \
+  sudo tar -xvf helm-v2.7.0-darwin-amd64.tar.gz --strip-components=1 -C /usr/local/bin/
 
 ```
 
@@ -92,10 +92,8 @@ $ helm upgrade --install --debug --reset-values --set async=false --set ingress.
 ```
 
 By default services will be exposed with following hostnames (can be changed, see values.yaml for details):
-* `faas-netesd.openfaas.local`
 * `gateway.openfaas.local`
 * `prometheus.openfaas.local`
-* `alertmanager.openfaas.local`
 
 ### Additional OpenFaaS Helm chart options:
 

--- a/faas.arm64.yml
+++ b/faas.arm64.yml
@@ -5,12 +5,10 @@ metadata:
   labels:
     app: faas-netesd
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31111
   selector:
     app: faas-netesd
 ---

--- a/faas.armhf.yml
+++ b/faas.armhf.yml
@@ -5,12 +5,10 @@ metadata:
   labels:
     app: faas-netesd
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31111
   selector:
     app: faas-netesd
 ---
@@ -71,7 +69,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: functions/gateway:0.6.7-armhf
+        image: functions/gateway:0.6.9-armhf
 #k8s-monitoring-dev
         imagePullPolicy: Always
         env:

--- a/faas.async.armhf.yml
+++ b/faas.async.armhf.yml
@@ -5,12 +5,10 @@ metadata:
   labels:
     app: faas-netesd
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31111
   selector:
     app: faas-netesd
 ---
@@ -71,7 +69,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: functions/gateway:0.6.7-armhf
+        image: functions/gateway:0.6.9-armhf
         imagePullPolicy: Always
         env:
         - name: functions_provider_url

--- a/faas.async.yml
+++ b/faas.async.yml
@@ -5,12 +5,10 @@ metadata:
   labels:
     app: faas-netesd
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31111
   selector:
     app: faas-netesd
 ---

--- a/faas.yml
+++ b/faas.yml
@@ -5,12 +5,10 @@ metadata:
   labels:
     app: faas-netesd
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31111
   selector:
     app: faas-netesd
 ---

--- a/monitoring-config.armhf.yml
+++ b/monitoring-config.armhf.yml
@@ -5,12 +5,10 @@ metadata:
   labels:
     app: alertmanager
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 9093
       protocol: TCP
-      targetPort: 9093
-      nodePort: 31113
   selector:
     app: alertmanager
 ---
@@ -31,7 +29,7 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/alertmanager","-config.file=/alertmanager.yml", "-storage.path=/alertmanager"]
         ports:
-        - containerPort: 9003
+        - containerPort: 9093
           protocol: TCP
         volumeMounts:
         - mountPath: /alertmanager.yml

--- a/monitoring.armhf.yml
+++ b/monitoring.armhf.yml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: alexellis2/prometheus-armhf:1.5.2-k8s # alexellis2/prometheus-armhf:1.5.2
+        image: alexellis2/prometheus-armhf:1.5.2
         command: ["prometheus","-config.file=/etc/prometheus/prometheus.yml", "-storage.local.path=/prometheus", "-storage.local.memory-chunks=10000", "--alertmanager.url=http://alertmanager.default:9093"]
         imagePullPolicy: Always
         ports:
@@ -41,12 +41,10 @@ metadata:
   labels:
     app: alertmanager
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 9093
       protocol: TCP
-      targetPort: 9093
-      nodePort: 31113
   selector:
     app: alertmanager
 ---
@@ -67,5 +65,5 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/alertmanager","-config.file=/etc/alertmanager/config.yml", "-storage.path=/alertmanager"]
         ports:
-        - containerPort: 9003
+        - containerPort: 9093
           protocol: TCP

--- a/monitoring.yml
+++ b/monitoring.yml
@@ -33,6 +33,24 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/prometheus/prometheus.yml
+          name: prometheus-config
+          subPath: prometheus.yml
+        - mountPath: /etc/prometheus/alert.rules
+          name: prometheus-config
+          subPath: alert.rules
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+                mode: 0644
+              - key: alert.rules
+                path: alert.rules
+                mode: 0644
 ---
 apiVersion: v1
 kind: Service
@@ -79,6 +97,68 @@ spec:
               - key: alertmanager.yml
                 path: alertmanager.yml
                 mode: 0644
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    # my global config
+    global:
+      scrape_interval:     15s # By default, scrape targets every 15 seconds.
+      evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+      # scrape_timeout is set to the global default (10s).
+
+      # Attach these labels to any time series or alerts when communicating with
+      # external systems (federation, remote storage, Alertmanager).
+      external_labels:
+          monitor: 'faas-monitor'
+
+    # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+    rule_files:
+        - 'alert.rules'
+
+    # A scrape configuration containing exactly one endpoint to scrape:
+    # Here it's Prometheus itself.
+    scrape_configs:
+      # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+      - job_name: 'prometheus'
+
+        # Override the global default and scrape targets from this job every 5 seconds.
+        scrape_interval: 5s
+
+        # metrics_path defaults to '/metrics'
+        # scheme defaults to 'http'.
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: "gateway"
+        scrape_interval: 5s
+        dns_sd_configs:
+          - names: ['gateway.default.svc.cluster.local']
+            port: 8080
+            type: A
+            refresh_interval: 5s
+
+  alert.rules: |
+    ALERT service_down
+      IF up == 0
+
+    ALERT APIHighInvocationRate
+      IF sum ( rate(gateway_function_invocation_total{code="200"}[10s]) ) by (function_name) > 5
+      FOR 5s
+      LABELS {
+        service = "gateway",
+        severity = "major",
+        value = "{{$value}}"
+      }
+      ANNOTATIONS {
+        summary = "High invocation total on {{ $labels.instance }}",
+        description =  "High invocation total on {{ $labels.instance }}"
+      }
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/monitoring.yml
+++ b/monitoring.yml
@@ -67,3 +67,81 @@ spec:
         ports:
         - containerPort: 9093
           protocol: TCP
+        volumeMounts:
+        - mountPath: /alertmanager.yml
+          name: alertmanager-config
+          subPath: alertmanager.yml
+      volumes:
+        - name: alertmanager-config
+          configMap:
+            name: alertmanager-config
+            items:
+              - key: alertmanager.yml
+                path: alertmanager.yml
+                mode: 0644
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: alertmanager
+  name: alertmanager-config
+data:
+  alertmanager.yml: |
+    global:
+      # The smarthost and SMTP sender used for mail notifications.
+      smtp_smarthost: 'localhost:25'
+      smtp_from: 'alertmanager@example.org'
+      smtp_auth_username: 'alertmanager'
+      smtp_auth_password: 'password'
+      # The auth token for Hipchat.
+      hipchat_auth_token: '1234556789'
+      # Alternative host for Hipchat.
+      hipchat_url: 'https://hipchat.foobar.org/'
+    # The directory from which notification templates are read.
+    templates:
+    - '/etc/alertmanager/template/*.tmpl'
+    # The root route on which each incoming alert enters.
+    route:
+      # The labels by which incoming alerts are grouped together. For example,
+      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+      # be batched into a single group.
+      group_by: ['alertname', 'cluster', 'service']
+      # When a new group of alerts is created by an incoming alert, wait at
+      # least 'group_wait' to send the initial notification.
+      # This way ensures that you get multiple alerts for the same group that start
+      # firing shortly after another are batched together on the first
+      # notification.
+      group_wait: 5s
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+      group_interval: 10s
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+      repeat_interval: 30s
+      # A default receiver
+      receiver: scale-up
+      # All the above attributes are inherited by all child routes and can
+      # overwritten on each.
+      # The child route trees.
+      routes:
+      - match:
+          service: gateway
+          receiver: scale-up
+          severity: major
+    # Inhibition rules allow to mute a set of alerts given that another alert is
+    # firing.
+    # We use this to mute any warning-level notifications if the same alert is
+    # already critical.
+    inhibit_rules:
+    - source_match:
+        severity: 'critical'
+      target_match:
+        severity: 'warning'
+      # Apply inhibition if the alertname is the same.
+      equal: ['alertname', 'cluster', 'service']
+    receivers:
+    - name: 'scale-up'
+      webhook_configs:
+        - url: http://gateway:8080/system/alert
+          send_resolved: true

--- a/monitoring.yml
+++ b/monitoring.yml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: functions/prometheus:latest-k8s
+        image: prom/prometheus:v1.5.2
         command: ["prometheus","-config.file=/etc/prometheus/prometheus.yml", "-storage.local.path=/prometheus", "-storage.local.memory-chunks=10000", "--alertmanager.url=http://alertmanager.default:9093"]
         imagePullPolicy: Always
         ports:
@@ -41,12 +41,10 @@ metadata:
   labels:
     app: alertmanager
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 9093
       protocol: TCP
-      targetPort: 9093
-      nodePort: 31113
   selector:
     app: alertmanager
 ---
@@ -63,9 +61,9 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: functions/alertmanager:latest-k8s
+        image: prom/alertmanager:v0.7.1
         imagePullPolicy: Always
         command: ["/bin/alertmanager","-config.file=/alertmanager.yml", "-storage.path=/alertmanager"]
         ports:
-        - containerPort: 9003
+        - containerPort: 9093
           protocol: TCP

--- a/nats.armhf.yml
+++ b/nats.armhf.yml
@@ -6,12 +6,10 @@ metadata:
   labels:
     app: nats
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 4222
       protocol: TCP
-      targetPort: 4222
-      nodePort: 31114
   selector:
     app: nats
 ---

--- a/nats.yml
+++ b/nats.yml
@@ -6,12 +6,10 @@ metadata:
   labels:
     app: nats
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 4222
       protocol: TCP
-      targetPort: 4222
-      nodePort: 31114
   selector:
     app: nats
 ---
@@ -57,6 +55,6 @@ spec:
     spec:
       containers:
       - name:  queue-worker
-        image: functions/queue-worker:0.1 
+        image: functions/queue-worker:0.2
         imagePullPolicy: Always
 

--- a/openfaas/Chart.yaml
+++ b/openfaas/Chart.yaml
@@ -1,6 +1,6 @@
 name: openfaas
 home: https://blog.alexellis.io/introducing-functions-as-a-service/
-version: 1.0.0
+version: 1.1.0
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 sources:
 - https://github.com/openfaas/faas

--- a/openfaas/templates/external-service-access.yaml
+++ b/openfaas/templates/external-service-access.yaml
@@ -6,29 +6,6 @@ metadata:
   labels:
     app: {{ template "faas-netesd.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: faas-netesd
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: faas-netesd-external
-  namespace: {{ .Release.Namespace | quote }}
-spec:
-  type: {{ .Values.serviceType }}
-  ports:
-    - port: 8080
-      protocol: TCP
-      targetPort: 8080
-      {{- if contains "NodePort" .Values.serviceType }}
-      nodePort: 31111
-      {{- end }}
-  selector:
-    app: faas-netesd
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: {{ template "faas-netesd.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: gateway
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -68,53 +45,5 @@ spec:
       {{- end }}
   selector:
     app: prometheus
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: {{ template "faas-netesd.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: alertmanager
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: alertmanager-external
-  namespace: {{ .Release.Namespace | quote }}
-spec:
-  type: {{ .Values.serviceType }}
-  ports:
-    - port: 9093
-      protocol: TCP
-      targetPort: 9093
-      {{- if contains "NodePort" .Values.serviceType }}
-      nodePort: 31113
-      {{- end }}
-  selector:
-    app: alertmanager
----
-{{- if .Values.async }}
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: {{ template "faas-netesd.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: nats
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: nats-external
-  namespace: {{ .Release.Namespace | quote }}
-spec:
-  type: {{ .Values.serviceType }}
-  ports:
-    - port: 4222
-      protocol: TCP
-      targetPort: 4222
-      {{- if contains "NodePort" .Values.serviceType }}
-      nodePort: 31114
-      {{- end }}
-  selector:
-    app: nats
-{{- end }}
 ---
 {{- end }}

--- a/openfaas/templates/monitoring.yaml
+++ b/openfaas/templates/monitoring.yaml
@@ -124,7 +124,7 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/alertmanager","-config.file=/alertmanager.yml", "-storage.path=/alertmanager"]
         ports:
-        - containerPort: 9003
+        - containerPort: 9093
           protocol: TCP
         volumeMounts:
         - mountPath: /alertmanager.yml

--- a/openfaas/values.yaml
+++ b/openfaas/values.yaml
@@ -8,10 +8,10 @@ rbac: true
 # images
 images:
   controller: functions/faas-netesd:0.3.3a
-  controllerArmhf: functions/faas-netesd-armhf
+  controllerArmhf: functions/faas-netesd:armhf-0.1
 
   gateway: functions/gateway:0.6.9
-  gatewayArmhf: functions/gateway:0.6.7-armhf
+  gatewayArmhf: functions/gateway:0.6.9-armhf
 
   prometheus: prom/prometheus:v1.5.2
   prometheusArmhf: alexellis2/prometheus-armhf:1.5.2
@@ -22,18 +22,14 @@ images:
   nats: nats-streaming:0.5.0
   natsArmhf:
 
-  queueWorker: functions/queue-worker:0.1
-  queueWorkerArmhf:
+  queueWorker: functions/queue-worker:0.2
+  queueWorkerArmhf: functions/queue-worker:0.2-armhf
 
 # ingress configuration
 ingress:
   enabled: false
   # Used to create Ingress record (should be used with exposeServices: false).
   hosts:
-    - host: faas-netesd.openfaas.local
-      serviceName: faas-netesd
-      servicePort: 8080
-      path: /
     - host: gateway.openfaas.local
       serviceName: gateway
       servicePort: 8080
@@ -41,10 +37,6 @@ ingress:
     - host: prometheus.openfaas.local
       serviceName: prometheus
       servicePort: 9090
-      path: /
-    - host: alertmanager.openfaas.local
-      serviceName: alertmanager
-      servicePort: 9093
       path: /
   annotations:
     kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Signed-off-by: John McCabe <john@johnmccabe.net>

## Description
<!--- Describe your changes in detail -->
Currently we map NodePorts for the AlarmManager, NATS client and NATS management ports. None of these are currently intended for exposure outside of the cluster. This PR stops exposing those ports.

The Helm chart version is bumped to `1.1.0` as a result.

It also updates the image versions in use, and attempts to re-align the images/tags being used in the Helm Chart and resouce yaml as they had diverged.

As a result of updating the images, specifically the move to the prom/alertmanager and prom/prometheus images its been necessary to add config for both as ConfigMaps.

A full list of changes are:

- Stop exposing the alarmmanager externally
- Stop exposing the NATS ports externally
- Stop exposing the faas-netes ports externally
- Updates the container Ports for the alarm manager deployment resources.
- Bump image versions in values.yaml
- functions/faas-netesd:armhf-0.1 is now used in the Helm chart to match the resource yaml
- functions/gateway using 0.6.9 for amd64 and armhf (arm64 unchanged)
- monitoring.yml now uses prom/prometheus:v1.5.2 and prom/alertmanager:v0.7.1 to match helm chart
- monitoring.armhf.yml uses alexellis2/prometheus-armhf:1.5.2 to match helm chart
- have NOT altered nats-streaming tag, left at 0.5.0 (latest is 0.6.0) for everything except the nats.armhf.yml (@alexellis any idea why this is different?)
- bumped functions/queue-worker to 0.2
- add alertmanager.yml ConfigMap and map to deployment [ will revert this on rebase]
- add prometheus.yml/alert.rules ConfigMap and map to deployment [ will revert this on rebase]

**TODO**
Just spotted @weikinhuang #52 where the ConfigMaps have already been added, I'll test it, and if we can get that merged first I'll rebase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- openfaas/faas#356 - also attempts to update/align images/tags between Helm chart and resource yaml which had diverged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Deployed Helm non-async + tested function deploy/invocation and autoscaling
- [x] Deployed Helm async + tested function async invocation
- [x] Deployed resource yaml non-async + tested function deploy/invocation and autoscaling
- [ ] Deployed resource yaml async + tested function async invocation (@alexellis have you ever noticed the gateway and queue-worker restarting when deploying async via yml?)
- [ ] Deployed to ARM Kubernetes cluster [need help with this as I don't have an ARM cluster yet]

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
