### PR TITLE
add environment faas_function_suffix

### DIFF
--- a/openfaas/templates/nats.yaml
+++ b/openfaas/templates/nats.yaml
@@ -83,5 +83,10 @@ spec:
         image: {{ .Values.images.queueWorker }}
         {{- end }}
         imagePullPolicy: Always
+        {{- if .Values.functionNamespace }}
+        env:
+        - name: faas_function_suffix
+          value: .{{ .Values.functionNamespace }}
+        {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
faas_function_suffix is needed when functionNamespace is not empty. Otherwise queue-worker could not call function successfully.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required]
 (https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#83


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reinstall with / without functionNamespace set, call async function. Works fine.

helm upgrade --install --debug --namespace openfaas  --reset-values --set async=true --set ingress.enabled=true --set functionNamespace=openfaas-fn openfaas openfaas/



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
