### PR TITLE
Add cpu constraint

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -291,19 +291,41 @@ func createResources(request requests.CreateFunctionRequest) (*apiv1.ResourceReq
 		Requests: apiv1.ResourceList{},
 	}
 
-	if request.Limits != nil && len(request.Limits.Memory) > 0 {
+	// No resources set return blank section
+	if request.Limits == nil {
+		return resources, nil
+	}
+
+	// Set Memory limits
+	if len(request.Limits.Memory) > 0 {
 		qty, err := resource.ParseQuantity(request.Limits.Memory)
 		if err != nil {
 			return resources, err
 		}
 		resources.Limits[apiv1.ResourceMemory] = qty
 	}
-	if request.Requests != nil && len(request.Requests.Memory) > 0 {
+	if len(request.Requests.Memory) > 0 {
 		qty, err := resource.ParseQuantity(request.Requests.Memory)
 		if err != nil {
 			return resources, err
 		}
 		resources.Requests[apiv1.ResourceMemory] = qty
+	}
+
+	// Set CPU limits
+	if len(request.Limits.CPU) > 0 {
+		qty, err := resource.ParseQuantity(request.Limits.CPU)
+		if err != nil {
+			return resources, err
+		}
+		resources.Limits[apiv1.ResourceCPU] = qty
+	}
+	if len(request.Requests.CPU) > 0 {
+		qty, err := resource.ParseQuantity(request.Requests.CPU)
+		if err != nil {
+			return resources, err
+		}
+		resources.Requests[apiv1.ResourceCPU] = qty
 	}
 
 	return resources, nil
@@ -314,9 +336,9 @@ func getMinReplicaCount(labels map[string]string) *int32 {
 		minReplicas, err := strconv.Atoi(value)
 		if err == nil && minReplicas > 0 {
 			return int32p(int32(minReplicas))
-		} else {
-			log.Println(err)
 		}
+
+		log.Println(err)
 	}
 
 	return nil


### PR DESCRIPTION
Changed deployment options to adding ability to add CPU based constraints for a pod.

[https://github.com/openfaas/faas-netes/issues/103](https://github.com/openfaas/faas-netes/issues/103)

## Description
deploy.go has been changed adding the additional constraints to be set when a deployment api request is created.

## Motivation and Context
CPU and Memory constraints should be supported
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested locally with MiniKube, the image https://hub.docker.com/r/nicholasjackson/faas-netesd/ can be used for testing this change.

*Example config*
```yaml
provider:
  name: faas
  gateway: http://192.168.99.100:31112

functions:
  facedetect:
    lang: go-opencv
    handler: ./facedetect
    image: nicholasjackson/func_facedetect
    limits:
      memory: 10Mi
      cpu: 100m
```
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.