### PR TITLE
Patch to accept timeouts as Go durations

### DIFF
--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -19,16 +19,16 @@ import (
 )
 
 // MakeProxy creates a proxy for HTTP web requests which can be routed to a function.
-func MakeProxy(functionNamespace string) http.HandlerFunc {
+func MakeProxy(functionNamespace string, timeout time.Duration) http.HandlerFunc {
 	proxyClient := http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   3 * time.Second,
-				KeepAlive: 0,
+                               Timeout:   timeout,
+                               KeepAlive: 1 * time.Second,
 			}).DialContext,
-			MaxIdleConns:          1,
-			DisableKeepAlives:     true,
+                       // MaxIdleConns:          1,
+                       // DisableKeepAlives:     false,
 			IdleConnTimeout:       120 * time.Millisecond,
 			ExpectContinueTimeout: 1500 * time.Millisecond,
 		},

--- a/server.go
+++ b/server.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	bootstrapHandlers := bootTypes.FaaSHandlers{
-		FunctionProxy:  handlers.MakeProxy(functionNamespace),
+               FunctionProxy:  handlers.MakeProxy(functionNamespace, cfg.ReadTimeout),
 		DeleteHandler:  handlers.MakeDeleteHandler(functionNamespace, clientset),
 		DeployHandler:  handlers.MakeDeployHandler(functionNamespace, clientset, deployConfig),
 		FunctionReader: handlers.MakeFunctionReader(functionNamespace, clientset),

--- a/test/read_config_test.go
+++ b/test/read_config_test.go
@@ -44,7 +44,7 @@ func TestRead_EmptyTimeoutConfig(t *testing.T) {
 	}
 }
 
-func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
+func TestRead_ReadAndWriteIntegerTimeoutConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	defaults.Setenv("read_timeout", "10")
 	defaults.Setenv("write_timeout", "60")
@@ -60,6 +60,24 @@ func TestRead_ReadAndWriteTimeoutConfig(t *testing.T) {
 		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
 		t.Fail()
 	}
+}
+
+func TestRead_ReadAndWriteDurationTimeoutConfig(t *testing.T) {
+       defaults := NewEnvBucket()
+       defaults.Setenv("read_timeout", "10s")
+       defaults.Setenv("write_timeout", "60s")
+
+       readConfig := types.ReadConfig{}
+       config := readConfig.Read(defaults)
+
+       if (config.ReadTimeout) != time.Duration(10)*time.Second {
+               t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
+               t.Fail()
+       }
+       if (config.WriteTimeout) != time.Duration(60)*time.Second {
+               t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
+               t.Fail()
+       }
 }
 
 func TestRead_EmptyProbeConfig(t *testing.T) {
@@ -81,7 +99,7 @@ func TestRead_EnableFunctionReadinessProbeConfig(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if config.EnableFunctionReadinessProbe {
-		t.Logf("EnableFunctionReadinessProbe incorrect, got: %s\n", config.EnableFunctionReadinessProbe)
+               t.Logf("EnableFunctionReadinessProbe incorrect, got: %v\n", config.EnableFunctionReadinessProbe)
 		t.Fail()
 	}
 }
@@ -94,7 +112,7 @@ func TestRead_EnableFunctionReadinessProbeConfig_true(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if !config.EnableFunctionReadinessProbe {
-		t.Logf("EnableFunctionReadinessProbe incorrect, got: %s\n", config.EnableFunctionReadinessProbe)
+               t.Logf("EnableFunctionReadinessProbe incorrect, got: %v\n", config.EnableFunctionReadinessProbe)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Part of Trello board item on enabling KeepAlive. This improves performance under stress tests, but removes the ability to observe round-robbin load-balancing between replicas. This still happens but not for every call - every few calls.

Also adds ability to specify timeouts in a Golang duration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With Kubeadm

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
