### PR TITLE
Upgrade prometheus to v2.1

### DIFF
--- a/chart/openfaas/templates/configmaps.yaml
+++ b/chart/openfaas/templates/configmaps.yaml
@@ -49,22 +49,28 @@ data:
             type: A
             refresh_interval: 5s
 
-  alert.rules: |
-    ALERT service_down
-      IF up == 0
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager:9093
 
-    ALERT APIHighInvocationRate
-      IF sum ( rate(gateway_function_invocation_total{code="200"}[10s]) ) by (function_name) > 5
-      FOR 5s
-      LABELS {
-        service = "gateway",
-        severity = "major",
-        value = "{{ "{{" }}$value{{ "}}" }}"
-      }
-      ANNOTATIONS {
-        summary = "High invocation total on {{ "{{" }} $labels.instance {{ "}}" }}",
-        description =  "High invocation total on {{ "{{" }} $labels.instance {{ "}}" }}"
-      }
+  alert.rules: |
+    groups:
+      - name: prometheus/alert.rules
+        rules:
+        - alert: service_down
+          expr: up == 0
+        - alert: APIHighInvocationRate
+          expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+          for: 5s
+          labels:
+            service: gateway
+            severity: major
+            value: '{{ "{{" }}$value{{ "}}" }}'
+          annotations:
+            description: High invocation total on "{{ "{{" }}$labels.instance{{ "}}" }}"
+            summary: High invocation total on "{{ "{{" }}$labels.instance{{ "}}" }}"
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/chart/openfaas/templates/prometheus.yaml
+++ b/chart/openfaas/templates/prometheus.yaml
@@ -47,10 +47,7 @@ spec:
         {{- end }}
         command:
           - prometheus
-          - -config.file=/etc/prometheus/prometheus.yml
-          - -storage.local.path=/prometheus
-          - -storage.local.memory-chunks=10000
-          - --alertmanager.url=http://alertmanager:9093
+          - --config.file=/etc/prometheus/prometheus.yml
         imagePullPolicy: Always
         ports:
         - containerPort: 9090

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -15,7 +15,7 @@ images:
   gateway: functions/gateway:0.7.0
   gatewayArmhf: functions/gateway:0.7.0-armhf
 
-  prometheus: prom/prometheus:v1.5.2
+  prometheus: prom/prometheus:v2.1.0
   prometheusArmhf: alexellis2/prometheus-armhf:1.5.2
 
   alertmanager: prom/alertmanager:v0.7.1

--- a/monitoring-config.yml
+++ b/monitoring-config.yml
@@ -1,0 +1,67 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus-config
+  labels:
+    app: prometheus
+data:
+  prometheus.yml: |
+    # my global config
+    global:
+      scrape_interval:     15s # By default, scrape targets every 15 seconds.
+      evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+      # scrape_timeout is set to the global default (10s).
+
+      # Attach these labels to any time series or alerts when communicating with
+      # external systems (federation, remote storage, Alertmanager).
+      external_labels:
+          monitor: 'faas-monitor'
+
+    # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+    rule_files:
+        - 'alert.rules'
+
+
+    # A scrape configuration containing exactly one endpoint to scrape:
+    # Here it's Prometheus itself.
+    scrape_configs:
+      # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+      - job_name: 'prometheus'
+
+        # Override the global default and scrape targets from this job every 5 seconds.
+        scrape_interval: 5s
+
+        # metrics_path defaults to '/metrics'
+        # scheme defaults to 'http'.
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: "gateway"
+        scrape_interval: 5s
+        dns_sd_configs:
+          - names: ['gateway.default.svc.cluster.local']
+            port: 8080
+            type: A
+            refresh_interval: 5s
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager.default:9093
+
+  alert.rules: |
+    groups:
+    - name: prometheus/alert.rules
+      rules:
+      - alert: service_down
+        expr: up == 0
+      - alert: APIHighInvocationRate
+        expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+        for: 5s
+        labels:
+          service: gateway
+          severity: major
+          value: '{{$value}}'
+        annotations:
+          description: High invocation total on {{ $labels.instance }}
+          summary: High invocation total on {{ $labels.instance }}


### PR DESCRIPTION
Upgrades the prometheus monitoring to version 2.1

A migration guide is still needed due to the [Prometheus 1.8 -> 2.0 not being backwards compatible](https://github.com/prometheus/prometheus/blob/master/docs/migration.md)

## Description
- Update docker image tags
- Remove `storage.local` flags because these have been removed per
  https://github.com/prometheus/prometheus/blob/master/docs/migration.md#flags
- Convert `config` flag to a double dash, per the instructions in
  https://github.com/prometheus/prometheus/blob/master/docs/migration.md#flags
- Remove alert manager flag and add alert manager config to match the
  instuctions in
  https://github.com/prometheus/prometheus/blob/master/docs/migration.md#alertmanager-service-discovery
- Update helm config map for the alerts to be compatible with v2.1
- Add config map for the flat YAML manifest files

Note that this does not address the ARM configurations, this will be addressed in a future pull request.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #129

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Flat YAML files**
- I have deployed in the new Edge Docker for Mac using 
```
$ kubectl apply -f faas.yml -f monitoring-config.yml -f monitoring.ym
$ kubectl port-forward prometheus-559fd6df8d-wmq2z 31119:31119
$ kubectl port-forward prometheus-559fd6df8d-wmq2z 31119:31119
```
- Then using the web UI I deployed the basic node info function using the `functions/nodeinfo:latest` image
- Invoke the function 
```sh
while [ true ] ; do curl http://localhost:31112/function/info -d "" ; sleep $(( ( RANDOM % 10 )  )) ; done`
```
- Finally I opened the prometheus and queried the metrics using `rate(gateway_function_invocation_total[20s])` to produce the following graph
![image](https://user-images.githubusercontent.com/891889/35767285-d290057a-08e9-11e8-82b6-ce8bfd326622.png)

**Helm chart**
Basically followed the same instructions as above
- Installed helm `helm init`
- Install the openfaas chart `helm install --values openfaas/values.yaml ./openfaas`
- Add the nodeinfo function as above  using the `functions/nodeinfo:latest` image
- Invoke the function 
```sh
while [ true ] ; do curl http://localhost:31112/function/info -d "" ; sleep $(( ( RANDOM % 10 )  )) ; done`
```
- Query the function invocation metric `rate(gateway_function_invocation_total[20s])`  to generate the following chart 
![image](https://user-images.githubusercontent.com/891889/35767507-a0096476-08ed-11e8-96a3-a8e3c9e9dc03.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
