### PR TITLE
Ensure that the ServiceAccout is always created

### DIFF
--- a/chart/openfaas/templates/gateway.yaml
+++ b/chart/openfaas/templates/gateway.yaml
@@ -1,6 +1,18 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: faas-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: faas-controller
+  namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:

--- a/chart/openfaas/templates/rbac.yaml
+++ b/chart/openfaas/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if .Values.rbac }}
+{{- if (ne .Release.Namespace $functionNs) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -12,6 +12,8 @@ metadata:
     release: {{ .Release.Name }}
   name: faas-controller
   namespace: {{ $functionNs | quote }}
+{{- end }}
+{{- if .Values.rbac }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole


### PR DESCRIPTION
## Description
- Always create the ServiceAccount, regardless of the rbac setting
- Ensure that the ServiceAccount for the faasnetesd is always defined for the release namespace
- Ensure that the ServiceAccount is created for the `functionNamespace`, if it is different from the release namespace

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The is needed because some components assume the ServiceAccount exists, so it is easiest
to always create it.

- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Address #136 

## How Has This Been Tested?

**The default namespace**
Manually testing in minikube using 

```
helm install --values openfaas/values.yaml --set "rbac=false" ./openfaas
```

**A custom namespace**
```
kubectl create namespace openfaas
helm install --namespace openfaas --values openfaas/values.yaml --set "rbac=false" --set  ./openfaas
```

**Using two namespaces**
```
kubectl create namespace openfaas
kubectl create namespace minitest
helm install --namespace openfaas --values openfaas/values.yaml --set "rbac=false" --set "functionNamespace=minitest" ./openfaas
```

I then opened the web UI and deployed a function (certinfo) from the function store. 

Once the deploy finished, I was able to test the function and have it return the expected results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
