### PR TITLE
Adding in namespace for the gateway when using LoadBalancer

### DIFF
--- a/cloud/lb.yml
+++ b/cloud/lb.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gateway
+  namespace: openfaas
   labels:
     app: gateway
 spec:


### PR DESCRIPTION
Signed-off-by: Justin Davies <juda@microsoft.com>

## Description
The lb.yml doesn't state the namespace for the service, so would go into the default.  This blocks the service from being correctly plumbed in.

## Motivation and Context
Following the yaml definitions for the namespaces and the deployments, the LoadBalancer configuration should follow the same format.

- [x] I have raised an issue to propose this change
Fixes #140 


## How Has This Been Tested?
After removing the NodePort Service for the Gateway, I applied the modified lb.yml and am able to connect to the gateway and endpoints correctly.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
