### PR TITLE
Move timeouts from 8 second default to 10, update tests to use Logf w…

### DIFF
--- a/test/read_config_test.go
+++ b/test/read_config_test.go
@@ -33,13 +33,13 @@ func TestRead_EmptyTimeoutConfig(t *testing.T) {
 	readConfig := types.ReadConfig{}
 
 	config := readConfig.Read(defaults)
-
-	if (config.ReadTimeout) != time.Duration(8)*time.Second {
-		t.Log("ReadTimeout incorrect")
+	defaultVal := time.Duration(10) * time.Second
+	if (config.ReadTimeout) != defaultVal {
+		t.Logf("ReadTimeout want: %s, got %s", defaultVal.String(), config.ReadTimeout.String())
 		t.Fail()
 	}
-	if (config.WriteTimeout) != time.Duration(8)*time.Second {
-		t.Log("WriteTimeout incorrect")
+	if (config.WriteTimeout) != defaultVal {
+		t.Logf("WriteTimeout want: %s, got %s", defaultVal.String(), config.ReadTimeout.String())
 		t.Fail()
 	}
 }
@@ -63,21 +63,21 @@ func TestRead_ReadAndWriteIntegerTimeoutConfig(t *testing.T) {
 }
 
 func TestRead_ReadAndWriteDurationTimeoutConfig(t *testing.T) {
-       defaults := NewEnvBucket()
-       defaults.Setenv("read_timeout", "10s")
-       defaults.Setenv("write_timeout", "60s")
+	defaults := NewEnvBucket()
+	defaults.Setenv("read_timeout", "10s")
+	defaults.Setenv("write_timeout", "60s")
 
-       readConfig := types.ReadConfig{}
-       config := readConfig.Read(defaults)
+	readConfig := types.ReadConfig{}
+	config := readConfig.Read(defaults)
 
-       if (config.ReadTimeout) != time.Duration(10)*time.Second {
-               t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
-               t.Fail()
-       }
-       if (config.WriteTimeout) != time.Duration(60)*time.Second {
-               t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
-               t.Fail()
-       }
+	if (config.ReadTimeout) != time.Duration(10)*time.Second {
+		t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
+		t.Fail()
+	}
+	if (config.WriteTimeout) != time.Duration(60)*time.Second {
+		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
+		t.Fail()
+	}
 }
 
 func TestRead_EmptyProbeConfig(t *testing.T) {
@@ -99,7 +99,7 @@ func TestRead_EnableFunctionReadinessProbeConfig(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if config.EnableFunctionReadinessProbe {
-               t.Logf("EnableFunctionReadinessProbe incorrect, got: %v\n", config.EnableFunctionReadinessProbe)
+		t.Logf("EnableFunctionReadinessProbe incorrect, got: %v\n", config.EnableFunctionReadinessProbe)
 		t.Fail()
 	}
 }
@@ -112,7 +112,7 @@ func TestRead_EnableFunctionReadinessProbeConfig_true(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if !config.EnableFunctionReadinessProbe {
-               t.Logf("EnableFunctionReadinessProbe incorrect, got: %v\n", config.EnableFunctionReadinessProbe)
+		t.Logf("EnableFunctionReadinessProbe incorrect, got: %v\n", config.EnableFunctionReadinessProbe)
 		t.Fail()
 	}
 }

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -55,8 +55,8 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 
 	enableProbe := parseBoolValue(hasEnv.Getenv("enable_function_readiness_probe"), true)
 
-	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*8)
-	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*8)
+	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10)
+	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10)
 
 	cfg.ReadTimeout = readTimeout
 	cfg.WriteTimeout = writeTimeout


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Move timeouts from 8 second default to 10, update tests to use `Logf` with want/got values for better test results.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/openfaas/faas/pull/514

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on DfM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
