### PR TITLE
Move to Prometheus 2.2

### DIFF
--- a/yaml/alertmanager.yml
+++ b/yaml/alertmanager.yml
@@ -12,20 +12,20 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: functions/alertmanager:latest-k8s
+        image: prom/alertmanager:v0.15.0-rc.0
         imagePullPolicy: Always
         command: 
-          - "/bin/alertmanager"
-          - "-config.file=/alertmanager.yml"
-          - "-storage.path=/alertmanager"
+          - "alertmanager"
+          - "--config.file=/alertmanager.yml"
+          - "--storage.path=/alertmanager"
         ports:
         - containerPort: 9003
           protocol: TCP
         resources:
           requests:
-            memory: 20Mi
+            memory: 25Mi
           limits:
-            memory: 30Mi
+            memory: 50Mi
         volumeMounts:
         - mountPath: /alertmanager.yml
           name: alertmanager-config

--- a/yaml/alertmanager_config.yml
+++ b/yaml/alertmanager_config.yml
@@ -7,57 +7,22 @@ metadata:
   namespace: openfaas
 data:
   alertmanager.yml: |
-    global:
-      # The smarthost and SMTP sender used for mail notifications.
-      smtp_smarthost: 'localhost:25'
-      smtp_from: 'alertmanager@example.org'
-      smtp_auth_username: 'alertmanager'
-      smtp_auth_password: 'password'
-      # The auth token for Hipchat.
-      hipchat_auth_token: '1234556789'
-      # Alternative host for Hipchat.
-      hipchat_url: 'https://hipchat.foobar.org/'
-    # The directory from which notification templates are read.
-    templates:
-    - '/etc/alertmanager/template/*.tmpl'
-    # The root route on which each incoming alert enters.
     route:
-      # The labels by which incoming alerts are grouped together. For example,
-      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
-      # be batched into a single group.
       group_by: ['alertname', 'cluster', 'service']
-      # When a new group of alerts is created by an incoming alert, wait at
-      # least 'group_wait' to send the initial notification.
-      # This way ensures that you get multiple alerts for the same group that start
-      # firing shortly after another are batched together on the first
-      # notification.
       group_wait: 5s
-      # When the first notification was sent, wait 'group_interval' to send a batch
-      # of new alerts that started firing for that group.
       group_interval: 10s
-      # If an alert has successfully been sent, wait 'repeat_interval' to
-      # resend them.
       repeat_interval: 30s
-      # A default receiver
       receiver: scale-up
-      # All the above attributes are inherited by all child routes and can
-      # overwritten on each.
-      # The child route trees.
       routes:
       - match:
           service: gateway
           receiver: scale-up
           severity: major
-    # Inhibition rules allow to mute a set of alerts given that another alert is
-    # firing.
-    # We use this to mute any warning-level notifications if the same alert is
-    # already critical.
     inhibit_rules:
     - source_match:
         severity: 'critical'
       target_match:
         severity: 'warning'
-      # Apply inhibition if the alertname is the same.
       equal: ['alertname', 'cluster', 'service']
     receivers:
     - name: 'scale-up'

--- a/yaml/prometheus.yml
+++ b/yaml/prometheus.yml
@@ -12,13 +12,10 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: functions/prometheus:latest-k8s
+        image: prom/prometheus:v2.2.0
         command: 
           - "prometheus"
-          - "-config.file=/etc/prometheus/prometheus.yml"
-          - "-storage.local.path=/prometheus" 
-          - "-storage.local.memory-chunks=10000"
-          - "--alertmanager.url=http://alertmanager.openfaas:9093"
+          - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: Always
         ports:
         - containerPort: 9090
@@ -32,9 +29,9 @@ spec:
         - mountPath: /etc/prometheus/prometheus.yml
           name: prometheus-config
           subPath: prometheus.yml
-        - mountPath: /etc/prometheus/alert.rules
+        - mountPath: /etc/prometheus/alert.rules.yml
           name: prometheus-config
-          subPath: alert.rules
+          subPath: alert.rules.yml
       volumes:
         - name: prometheus-config
           configMap:
@@ -43,8 +40,8 @@ spec:
               - key: prometheus.yml
                 path: prometheus.yml
                 mode: 0644
-              - key: alert.rules
-                path: alert.rules
+              - key: alert.rules.yml
+                path: alert.rules.yml
                 mode: 0644
 ---
 apiVersion: v1

--- a/yaml/prometheus_config.yml
+++ b/yaml/prometheus_config.yml
@@ -7,27 +7,16 @@ metadata:
   namespace: openfaas
 data:
   prometheus.yml: |
-    # my global config
     global:
-      scrape_interval:     15s # By default, scrape targets every 15 seconds.
-      evaluation_interval: 15s # By default, scrape targets every 15 seconds.
-      # scrape_timeout is set to the global default (10s).
-      # Attach these labels to any time series or alerts when communicating with
-      # external systems (federation, remote storage, Alertmanager).
+      scrape_interval:     15s
+      evaluation_interval: 15s
       external_labels:
           monitor: 'faas-monitor'
-    # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
     rule_files:
-        - 'alert.rules'
-    # A scrape configuration containing exactly one endpoint to scrape:
-    # Here it's Prometheus itself.
+        - 'alert.rules.yml'
     scrape_configs:
-      # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
       - job_name: 'prometheus'
-        # Override the global default and scrape targets from this job every 5 seconds.
         scrape_interval: 5s
-        # metrics_path defaults to '/metrics'
-        # scheme defaults to 'http'.
         static_configs:
           - targets: ['localhost:9090']
       - job_name: "gateway"
@@ -37,19 +26,26 @@ data:
             port: 8080
             type: A
             refresh_interval: 5s
-  alert.rules: |
-    ALERT service_down
-      IF up == 0
-    ALERT APIHighInvocationRate
-      IF sum ( rate(gateway_function_invocation_total{code="200"}[10s]) ) by (function_name) > 5
-      FOR 5s
-      LABELS {
-        service = "gateway",
-        severity = "major",
-        value = "{{$value}}"
-      }
-      ANNOTATIONS {
-        summary = "High invocation total on {{ $labels.instance }}",
-        description =  "High invocation total on {{ $labels.instance }}"
-      }
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager.openfaas:9093
+  alert.rules.yml: |
+    groups:
+    - name: openfaas
+      rules:
+      - alert: service_down
+        expr: up == 0
+      - alert: APIHighInvocationRate
+        expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name)
+          > 5
+        for: 5s
+        labels:
+          service: gateway
+          severity: major
+          value: '{{$value}}'
+        annotations:
+          description: High invocation total on {{ $labels.instance }}
+          summary: High invocation total on {{ $labels.instance }}
 ---


### PR DESCRIPTION
Prometheus 2.2 needs a new config file format - the alerts also
have a new format.

Alert manager RC is required for compatibility with Prometheus.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Testing

* Deployment on Kubernetes 1.9.6 works
* Metrics are recorded
* Haven't triggered auto-scaling yet

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
