### PR TITLE
Update README.md to current values.yaml

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -74,12 +74,12 @@ Additional OpenFaaS options.
 | `exposeServices` | Expose `NodePorts/LoadBalancer`  | `true` |
 | `serviceType` | Type of external service to use `NodePort/LoadBalancer` | `NodePort` |
 | `ingress.enabled` | Create ingress resources | `false` |
-| `rbac` | Enable RBAC | `false` |
-| `faasnetesd.readTimeout` | Queue worker read timeout | `20` |
-| `faasnetesd.writeTimeout` | Queue worker write timeout | `20` |
-| `gateway.readTimeout` | Queue worker read timeout | `20` |
-| `gateway.writeTimeout` | Queue worker write timeout | `20` |
-| `queueWorker.ackWait` | Max duration of any async task/request | `30` |
+| `rbac` | Enable RBAC | `true` |
+| `faasnetesd.readTimeout` | Queue worker read timeout | `20s` |
+| `faasnetesd.writeTimeout` | Queue worker write timeout | `20s` |
+| `gateway.readTimeout` | Queue worker read timeout | `20s` |
+| `gateway.writeTimeout` | Queue worker write timeout | `20s` |
+| `queueWorker.ackWait` | Max duration of any async task/request | `30s` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 See values.yaml for detailed configuration.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes https://github.com/openfaas/faas-netes/issues/174

## Description
In https://github.com/openfaas/faas-netes/commit/7d2a21a0ce33edfc860af82bae586b806e0183db in which the chart was created, rbac was actually set to true. Previous to this commit, it was actually set to `false` in the README while set to `true` in the values.yaml
In https://github.com/openfaas/faas-netes/commit/05a54ce209283a9f73810fda7678e6e8edeaec22 and https://github.com/openfaas/faas-netes/commit/8f34239808ed04be0425fae5d46f85eec42b5e31 we began to use golang duration format.  Previous to this commit, it was actually set to non golang duration in the README while using golang duration in the values.yaml

This PR just updates the README to reflect the real values in the values.yaml
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas-netes/issues/174

