### PR TITLE
Attach SecretTypeDockerConfigJson secret type for deployments

### DIFF
--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/openfaas/faas/gateway/requests"
+	apiv1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// getSecrets queries Kubernetes for a list of secrets by name in the given k8s namespace.
+func getSecrets(clientset *kubernetes.Clientset, namespace string, secretNames []string) (map[string]*apiv1.Secret, error) {
+	secrets := map[string]*apiv1.Secret{}
+
+	for _, secretName := range secretNames {
+		secret, err := clientset.Core().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+		if err != nil {
+			return secrets, err
+		}
+		secrets[secretName] = secret
+	}
+
+	return secrets, nil
+}
+
+// UpdateSecrets will update the Deployment spec to include secrets that have beenb deployed
+// in the kubernetes cluster.  For each requested secret, we inspect the type and add it to the
+// deployment spec as appropriat: secrets with type `SecretTypeDockercfg/SecretTypeDockerjson`
+// are added as ImagePullSecrets all other secrets are mounted as files in the deployments containers.
+func UpdateSecrets(request requests.CreateFunctionRequest, deployment *v1beta1.Deployment, existingSecrets map[string]*apiv1.Secret) error {
+	// Add / reference pre-existing secrets within Kubernetes
+	secretVolumeProjections := []apiv1.VolumeProjection{}
+
+	for _, secretName := range request.Secrets {
+		deployedSecret, ok := existingSecrets[secretName]
+		if !ok {
+			return fmt.Errorf("Required secret '%s' was not found in the cluster", secretName)
+		}
+
+		switch deployedSecret.Type {
+
+		case apiv1.SecretTypeDockercfg,
+			apiv1.SecretTypeDockerConfigJson:
+
+			deployment.Spec.Template.Spec.ImagePullSecrets = append(
+				deployment.Spec.Template.Spec.ImagePullSecrets,
+				apiv1.LocalObjectReference{
+					Name: secretName,
+				},
+			)
+
+			break
+
+		default:
+
+			projectedPaths := []apiv1.KeyToPath{}
+			for secretKey := range deployedSecret.Data {
+				projectedPaths = append(projectedPaths, apiv1.KeyToPath{Key: secretKey, Path: secretKey})
+			}
+
+			projection := &apiv1.SecretProjection{Items: projectedPaths}
+			projection.Name = secretName
+			secretProjection := apiv1.VolumeProjection{
+				Secret: projection,
+			}
+			secretVolumeProjections = append(secretVolumeProjections, secretProjection)
+
+			break
+		}
+	}
+
+	if len(secretVolumeProjections) > 0 {
+		volumeName := fmt.Sprintf("%s-projected-secrets", request.Service)
+		projectedSecrets := apiv1.Volume{
+			Name: volumeName,
+			VolumeSource: apiv1.VolumeSource{
+				Projected: &apiv1.ProjectedVolumeSource{
+					Sources: secretVolumeProjections,
+				},
+			},
+		}
+
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, projectedSecrets)
+
+		// add mount secret as a file
+		updatedContainers := []apiv1.Container{}
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			mount := apiv1.VolumeMount{
+				Name:      volumeName,
+				ReadOnly:  true,
+				MountPath: "/run/secrets",
+			}
+			container.VolumeMounts = append(container.VolumeMounts, mount)
+			updatedContainers = append(updatedContainers, container)
+		}
+
+		deployment.Spec.Template.Spec.Containers = updatedContainers
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This change allows SecretTypeDockerConfigJson as a parallel option
to the existing option SecretTypeDockercfg.

[0] https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

The SecretTypeDockerConfigJson is now used as of Kubernetes 1.9
to store image pull secrets for fetching images from private
repositories. [0] as referenced in #176 

## How Has This Been Tested?

This change needs testing with a newer Kubernetes cluster using the
SecretTypeDockerConfigJson type as a secret. I'd like help with this.

Change for review at: https://github.com/openfaas/faas-netes/pull/177/files#diff-1d147804cec0e8b9c624b312ff9df6a4R44

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
