### PR TITLE
changed the url for kubernetes deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The [OpenFaaS complete walk-through on Kubernetes Video](https://www.youtube.com
 
 ### Explore OpenFaaS / FaaS-netes with minikube
 
-> These instructions may be out of sync with the latest changes. If you're looking to just get OpenFaaS deployed on Kubernetes follow the [OpenFaaS and Kubernetes Deployment Guide](https://github.com/openfaas/faas/blob/master/guide/deployment_k8s.md).
+> These instructions may be out of sync with the latest changes. If you're looking to just get OpenFaaS deployed on Kubernetes follow the [OpenFaaS and Kubernetes Deployment Guide](https://docs.openfaas.com/deployment/kubernetes/).
 
 Let's try it out:
 


### PR DESCRIPTION
## Description
previous link was pointing to a read me which was pointing to this url.
it says 
This page has moved to the official documentation site:
https://docs.openfaas.com/deployment/kubernetes/


so i changed the link

## Motivation and Context
moved the reference link to official document site.

Signed-off-by: Esref Durna edurna@email.com