### PR TITLE
Update chart for image_pull_policy

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 1.0.10
+version: 1.0.11
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -77,6 +77,7 @@ Additional OpenFaaS options.
 | `rbac` | Enable RBAC | `true` |
 | `faasnetesd.readTimeout` | Queue worker read timeout | `20s` |
 | `faasnetesd.writeTimeout` | Queue worker write timeout | `20s` |
+| `faasnetesd.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
 | `gateway.readTimeout` | Queue worker read timeout | `20s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `20s` |
 | `queueWorker.ackWait` | Max duration of any async task/request | `30s` |

--- a/chart/openfaas/templates/faasnetesd.yaml
+++ b/chart/openfaas/templates/faasnetesd.yaml
@@ -49,6 +49,8 @@ spec:
           value: "{{ .Values.faasnetesd.readTimeout }}"
         - name: write_timeout
           value: "{{ .Values.faasnetesd.writeTimeout }}"
+        - name: image_pull_policy
+          value: {{ .Values.faasnetesd.imagePullPolicy | quote }}
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -19,7 +19,7 @@ queueWorker:
 
 # images
 images:
-  controller: functions/faas-netesd:0.4.6
+  controller: functions/faas-netesd:0.4.8
   gateway: functions/gateway:0.7.8
   prometheus: prom/prometheus:v2.2.0
   alertmanager: prom/alertmanager:v0.15.0-rc.0


### PR DESCRIPTION
## Description
This adds support for an optional value `faasnetesd.imagePullPolicy` which drives the environment variable `image_pull_policy` in faasnetesd.

## Motivation and Context
Now that faasnetesd supports configurable image policy, the chart should support it too.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested supported and unexpected values by hand locally in minikube.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
