### PR TITLE
Ensure that UpdateSecrets removes existing secrets before appending the new volume definitions

### DIFF
--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -112,24 +112,30 @@ func UpdateSecrets(request requests.CreateFunctionRequest, deployment *v1beta1.D
 	return nil
 }
 
-// removeVolume returns a Volume slice with any volumes matching volumeName removed
+// removeVolume returns a Volume slice with any volumes matching volumeName removed.
+// Uses the filter without allocation technique
+// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 func removeVolume(volumeName string, volumes []apiv1.Volume) []apiv1.Volume {
-	for i, v := range volumes {
-		if v.Name == volumeName {
-			volumes = append(volumes[:i], volumes[i+1:]...)
+	newVolumes := volumes[:0]
+	for _, v := range volumes {
+		if v.Name != volumeName {
+			newVolumes = append(newVolumes, v)
 		}
 	}
 
-	return volumes
+	return newVolumes
 }
 
 // removeVolumeMount returns a VolumeMount slice with any mounts matching volumeName removed
+// Uses the filter without allocation technique
+// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 func removeVolumeMount(volumeName string, mounts []apiv1.VolumeMount) []apiv1.VolumeMount {
-	for i, v := range mounts {
-		if v.Name == volumeName {
-			mounts = append(mounts[:i], mounts[i+1:]...)
+	newMounts := mounts[:0]
+	for _, v := range mounts {
+		if v.Name != volumeName {
+			newMounts = append(newMounts, v)
 		}
 	}
 
-	return mounts
+	return newMounts
 }

--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -83,14 +83,10 @@ func UpdateSecrets(request requests.CreateFunctionRequest, deployment *v1beta1.D
 		}
 
 		existingVolumes := deployment.Spec.Template.Spec.Volumes
-		existingVolumeIndex := -1
 		for i, v := range existingVolumes {
 			if v.Name == volumeName {
-				existingVolumeIndex = i
+				existingVolumes = append(existingVolumes[:i], existingVolumes[i+1:]...)
 			}
-		}
-		if existingVolumeIndex > -1 {
-			existingVolumes = append(existingVolumes[:existingVolumeIndex], existingVolumes[existingVolumeIndex+1:]...)
 		}
 		deployment.Spec.Template.Spec.Volumes = append(existingVolumes, projectedSecrets)
 
@@ -104,14 +100,10 @@ func UpdateSecrets(request requests.CreateFunctionRequest, deployment *v1beta1.D
 			}
 
 			existingVolumeMounts := container.VolumeMounts
-			existingVolumeMountIndex := -1
 			for i, v := range existingVolumeMounts {
 				if v.Name == volumeName {
-					existingVolumeMountIndex = i
+					existingVolumeMounts = append(existingVolumeMounts[:i], existingVolumeMounts[i+1:]...)
 				}
-			}
-			if existingVolumeMountIndex > -1 {
-				existingVolumeMounts = append(existingVolumeMounts[:existingVolumeMountIndex], existingVolumeMounts[existingVolumeMountIndex+1:]...)
 			}
 
 			container.VolumeMounts = append(existingVolumeMounts, mount)

--- a/handlers/secrets_test.go
+++ b/handlers/secrets_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/openfaas/faas/gateway/requests"
+	apiv1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+func Test_UpdateSecrets(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{"pullsecret", "testsecret"},
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
+
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
+					},
+				},
+			},
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
+
+	numVolumes := len(deployment.Spec.Template.Spec.Volumes)
+	if numVolumes != 1 {
+		t.Errorf("Incorrect number of volumes: expected 1, got %d", numVolumes)
+	}
+
+	volume := deployment.Spec.Template.Spec.Volumes[0]
+	if volume.Name != "testfunc-projected-secrets" {
+		t.Errorf("Incorrect volume name: expected \"testfunc-projected-secrets\", got \"%s\"", volume.Name)
+	}
+
+	if volume.VolumeSource.Projected == nil {
+		t.Error("Secrets volume is not a projected volume type")
+	}
+
+	if volume.VolumeSource.Projected.Sources[0].Secret.Items[0].Key != "filename" {
+		t.Error("Project secret not constructed correctly")
+	}
+
+	c := deployment.Spec.Template.Spec.Containers[0]
+	numVolumeMounts := len(c.VolumeMounts)
+	if numVolumeMounts != 1 {
+		t.Errorf("Incorrect number of volumes mounts: expected 1, got %d", numVolumeMounts)
+	}
+
+	mount := c.VolumeMounts[0]
+	if mount.Name != "testfunc-projected-secrets" {
+		t.Errorf("Incorrect volume mounts: expected \"testfunc-projected-secrets\", got \"%s\"", mount.Name)
+	}
+
+}
+
+func Test_UpdateSecrets_ReplacesPreviousSecretMount(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{"pullsecret", "testsecret"},
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
+
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
+					},
+				},
+			},
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
+	// mimic the deployment already existing and deployed with the same secrets by running
+	// UpdateSecrets twice, the first run represents the original deployment, the second run represents
+	// retrieving the deployment from the k8s api and applying the update to it
+	err = UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
+
+	numVolumes := len(deployment.Spec.Template.Spec.Volumes)
+	if numVolumes != 1 {
+		t.Errorf("Incorrect number of volumes: expected 1, got %d", numVolumes)
+	}
+
+	volume := deployment.Spec.Template.Spec.Volumes[0]
+	if volume.Name != "testfunc-projected-secrets" {
+		t.Errorf("Incorrect volume name: expected \"testfunc-projected-secrets\", got \"%s\"", volume.Name)
+	}
+
+	if volume.VolumeSource.Projected == nil {
+		t.Error("Secrets volume is not a projected volume type")
+	}
+
+	if volume.VolumeSource.Projected.Sources[0].Secret.Items[0].Key != "filename" {
+		t.Error("Project secret not constructed correctly")
+	}
+
+	c := deployment.Spec.Template.Spec.Containers[0]
+	numVolumeMounts := len(c.VolumeMounts)
+	if numVolumeMounts != 1 {
+		t.Errorf("Incorrect number of volumes mounts: expected 1, got %d", numVolumeMounts)
+	}
+
+	mount := c.VolumeMounts[0]
+	if mount.Name != "testfunc-projected-secrets" {
+		t.Errorf("Incorrect volume mounts: expected \"testfunc-projected-secrets\", got \"%s\"", mount.Name)
+	}
+
+}

--- a/handlers/secrets_test.go
+++ b/handlers/secrets_test.go
@@ -9,7 +9,7 @@ import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
-func Test_UpdateSecrets(t *testing.T) {
+func Test_UpdateSecretsAddOrUpdatesTheVolumeSpec(t *testing.T) {
 	t.Run("No volume added if request secrets is nil", func(t *testing.T) {
 		request := requests.CreateFunctionRequest{
 			Service: "testfunc",

--- a/handlers/secrets_test.go
+++ b/handlers/secrets_test.go
@@ -9,173 +9,171 @@ import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
-func Test_UpdateSecretsAddOrUpdatesTheVolumeSpec(t *testing.T) {
-	t.Run("No volume added if request secrets is nil", func(t *testing.T) {
-		request := requests.CreateFunctionRequest{
-			Service: "testfunc",
-			Secrets: nil,
-		}
-		existingSecrets := map[string]*apiv1.Secret{
-			"pullsecret": {Type: apiv1.SecretTypeDockercfg},
-			"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
-		}
+func Test_UpdateSecrets_DoesNotAddVolumeIfRequestSecretsIsNil(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: nil,
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
 
-		deployment := &v1beta1.Deployment{
-			Spec: v1beta1.DeploymentSpec{
-				Template: apiv1.PodTemplateSpec{
-					Spec: apiv1.PodSpec{
-						Containers: []apiv1.Container{
-							{Name: "testfunc", Image: "alpine:latest"},
-						},
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
 					},
 				},
 			},
-		}
-		err := UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
 
-		validateEmptySecretVolumesAndMounts(t, deployment)
+	validateEmptySecretVolumesAndMounts(t, deployment)
 
-	})
+}
 
-	t.Run("No volume added if request secrets is the empty slice", func(t *testing.T) {
-		request := requests.CreateFunctionRequest{
-			Service: "testfunc",
-			Secrets: []string{},
-		}
-		existingSecrets := map[string]*apiv1.Secret{
-			"pullsecret": {Type: apiv1.SecretTypeDockercfg},
-			"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
-		}
+func Test_UpdateSecrets_DoesNotAddVolumeIfRequestSecretsIsEmpty(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{},
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
 
-		deployment := &v1beta1.Deployment{
-			Spec: v1beta1.DeploymentSpec{
-				Template: apiv1.PodTemplateSpec{
-					Spec: apiv1.PodSpec{
-						Containers: []apiv1.Container{
-							{Name: "testfunc", Image: "alpine:latest"},
-						},
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
 					},
 				},
 			},
-		}
-		err := UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
 
-		validateEmptySecretVolumesAndMounts(t, deployment)
+	validateEmptySecretVolumesAndMounts(t, deployment)
 
-	})
+}
 
-	t.Run("Adds New Secrets Volume", func(t *testing.T) {
-		request := requests.CreateFunctionRequest{
-			Service: "testfunc",
-			Secrets: []string{"pullsecret", "testsecret"},
-		}
-		existingSecrets := map[string]*apiv1.Secret{
-			"pullsecret": {Type: apiv1.SecretTypeDockercfg},
-			"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
-		}
+func Test_UpdateSecrets_AddNewSecretVolume(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{"pullsecret", "testsecret"},
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
 
-		deployment := &v1beta1.Deployment{
-			Spec: v1beta1.DeploymentSpec{
-				Template: apiv1.PodTemplateSpec{
-					Spec: apiv1.PodSpec{
-						Containers: []apiv1.Container{
-							{Name: "testfunc", Image: "alpine:latest"},
-						},
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
 					},
 				},
 			},
-		}
-		err := UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
 
-		validateNewSecretVolumesAndMounts(t, deployment)
+	validateNewSecretVolumesAndMounts(t, deployment)
 
-	})
+}
 
-	t.Run("Replaces Previous SecretMount with new mount", func(t *testing.T) {
-		request := requests.CreateFunctionRequest{
-			Service: "testfunc",
-			Secrets: []string{"pullsecret", "testsecret"},
-		}
-		existingSecrets := map[string]*apiv1.Secret{
-			"pullsecret": {Type: apiv1.SecretTypeDockercfg},
-			"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
-		}
+func Test_UpdateSecrets_ReplacesPreviousSecretMountWithNewMount(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{"pullsecret", "testsecret"},
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
 
-		deployment := &v1beta1.Deployment{
-			Spec: v1beta1.DeploymentSpec{
-				Template: apiv1.PodTemplateSpec{
-					Spec: apiv1.PodSpec{
-						Containers: []apiv1.Container{
-							{Name: "testfunc", Image: "alpine:latest"},
-						},
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
 					},
 				},
 			},
-		}
-		err := UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
-		// mimic the deployment already existing and deployed with the same secrets by running
-		// UpdateSecrets twice, the first run represents the original deployment, the second run represents
-		// retrieving the deployment from the k8s api and applying the update to it
-		err = UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
+	// mimic the deployment already existing and deployed with the same secrets by running
+	// UpdateSecrets twice, the first run represents the original deployment, the second run represents
+	// retrieving the deployment from the k8s api and applying the update to it
+	err = UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
 
-		validateNewSecretVolumesAndMounts(t, deployment)
+	validateNewSecretVolumesAndMounts(t, deployment)
 
-	})
+}
 
-	t.Run("Removes secrets volumes if the request is empty or nil", func(t *testing.T) {
-		request := requests.CreateFunctionRequest{
-			Service: "testfunc",
-			Secrets: []string{"pullsecret", "testsecret"},
-		}
-		existingSecrets := map[string]*apiv1.Secret{
-			"pullsecret": {Type: apiv1.SecretTypeDockercfg},
-			"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
-		}
+func Test_UpdateSecrets_RemovesSecretsVolumeIfRequestSecretsIsEmptyOrNil(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{"pullsecret", "testsecret"},
+	}
+	existingSecrets := map[string]*apiv1.Secret{
+		"pullsecret": {Type: apiv1.SecretTypeDockercfg},
+		"testsecret": {Type: apiv1.SecretTypeOpaque, Data: map[string][]byte{"filename": []byte("contents")}},
+	}
 
-		deployment := &v1beta1.Deployment{
-			Spec: v1beta1.DeploymentSpec{
-				Template: apiv1.PodTemplateSpec{
-					Spec: apiv1.PodSpec{
-						Containers: []apiv1.Container{
-							{Name: "testfunc", Image: "alpine:latest"},
-						},
+	deployment := &v1beta1.Deployment{
+		Spec: v1beta1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
 					},
 				},
 			},
-		}
-		err := UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
+		},
+	}
+	err := UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
 
-		validateNewSecretVolumesAndMounts(t, deployment)
+	validateNewSecretVolumesAndMounts(t, deployment)
 
-		request = requests.CreateFunctionRequest{
-			Service: "testfunc",
-			Secrets: []string{},
-		}
-		err = UpdateSecrets(request, deployment, existingSecrets)
-		if err != nil {
-			t.Errorf("unexpected error %s", err.Error())
-		}
+	request = requests.CreateFunctionRequest{
+		Service: "testfunc",
+		Secrets: []string{},
+	}
+	err = UpdateSecrets(request, deployment, existingSecrets)
+	if err != nil {
+		t.Errorf("unexpected error %s", err.Error())
+	}
 
-		validateEmptySecretVolumesAndMounts(t, deployment)
-	})
+	validateEmptySecretVolumesAndMounts(t, deployment)
 }
 
 func validateEmptySecretVolumesAndMounts(t *testing.T, deployment *v1beta1.Deployment) {


### PR DESCRIPTION
## Description
Loop over the Volumes and VolumeMounts to remove the existing projected secrets volume definitions before appending the new volume and volume mount.

Without removing the existing volume information, you will have
duplicate volumes during a redeploy and this will cause an error in
kubernetes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes openfaas/faas-cli#393


## How Has This Been Tested?
A new unit test has been added to verify that the volume definition is only added once.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
