### PR TITLE
Get status of a single function directly

### DIFF
--- a/handlers/replicas.go
+++ b/handlers/replicas.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/openfaas/faas-netes/types"
-	"github.com/openfaas/faas/gateway/requests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -76,18 +75,10 @@ func MakeReplicaReader(functionNamespace string, clientset *kubernetes.Clientset
 		vars := mux.Vars(r)
 		functionName := vars["name"]
 
-		functions, err := getServiceList(functionNamespace, clientset)
+		found, err := getService(functionName, functionNamespace, clientset)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
-		}
-
-		var found *requests.Function
-		for _, function := range functions {
-			if function.Name == functionName {
-				found = &function
-				break
-			}
 		}
 
 		if found == nil {


### PR DESCRIPTION
instead of listing ALL deployed functions and potentially iterating
over all of them.

Signed-off-by: Ivan Mikushin <imikushin@vmware.com>