### PR TITLE
add gateway's upstream_timeout support in chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -65,7 +65,7 @@ By default services will be exposed with following hostnames (can be changed, se
 
 ## Configuration
 
-Additional OpenFaaS options.
+Additional OpenFaaS options in `values.yaml`.
 
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
@@ -80,6 +80,7 @@ Additional OpenFaaS options.
 | `faasnetesd.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
 | `gateway.readTimeout` | Queue worker read timeout | `20s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `20s` |
+| `gateway.upstreamTimeout` | Maximum duration of upstream function call | `20s` |
 | `queueWorker.ackWait` | Max duration of any async task/request | `30s` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/chart/openfaas/templates/gateway.yaml
+++ b/chart/openfaas/templates/gateway.yaml
@@ -58,6 +58,8 @@ spec:
           value: "{{ .Values.gateway.readTimeout }}"
         - name: write_timeout
           value: "{{ .Values.gateway.writeTimeout }}"
+        - name: upstream_timeout
+          value: "{{ .Values.gateway.upstreamTimeout }}"
         - name: functions_provider_url
           value: "http://faas-netesd.{{ .Release.Namespace }}.svc.cluster.local.:8080/"
         - name: functions_dns_suffix

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -9,10 +9,12 @@ rbac: true
 faasnetesd:
   readTimeout : "20s"
   writeTimeout : "20s"
+  imagePullPolicy : "Always"    # Image pull policy for deployed functions
 
 gateway:
   readTimeout : "20s"
   writeTimeout : "20s"
+  upstreamTimeout : "15s"  # Must be smaller than read/write_timeout
 
 queueWorker:
   ackWait : "30s"


### PR DESCRIPTION
close #203  & add missing parameter 

## Description
* Add `upstream_timeout` support for gateway in chart
* Add missing parameter `faasnetesd.imagePullPolicy` in `values.yaml`. see [code](https://github.com/openfaas/faas-netes/blob/master/chart/openfaas/templates/faasnetesd.yaml#L53) 

## Motivation and Context
Fixes #203
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested in my k8s cluster and it works well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
