### PR TITLE
Move secrets mount path to /var/openfaas/secrets

### DIFF
--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	secretsMountPath = "/var/openfaas/secrets"
+)
+
 // getSecrets queries Kubernetes for a list of secrets by name in the given k8s namespace.
 func getSecrets(clientset *kubernetes.Clientset, namespace string, secretNames []string) (map[string]*apiv1.Secret, error) {
 	secrets := map[string]*apiv1.Secret{}
@@ -95,7 +99,7 @@ func UpdateSecrets(request requests.CreateFunctionRequest, deployment *v1beta1.D
 		mount := apiv1.VolumeMount{
 			Name:      volumeName,
 			ReadOnly:  true,
-			MountPath: "/run/secrets",
+			MountPath: secretsMountPath,
 		}
 
 		// remove the existing secrets volume mount, if we can find it. We update it later.

--- a/handlers/secrets_test.go
+++ b/handlers/secrets_test.go
@@ -269,4 +269,8 @@ func validateNewSecretVolumesAndMounts(t *testing.T, deployment *v1beta1.Deploym
 	if mount.Name != "testfunc-projected-secrets" {
 		t.Errorf("Incorrect volume mounts: expected \"testfunc-projected-secrets\", got \"%s\"", mount.Name)
 	}
+
+	if mount.MountPath != secretsMountPath {
+		t.Errorf("Incorrect volume mount path: expected \"%s\", got \"%s\"", secretsMountPath, mount.MountPath)
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- create `secretsMountPath` constant
- update the volume mount to set the mount path to the `secretsMountPath`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This change will ensure that the secrets required for the function business logic do not interfer with standard locations that other systems may want to modify.

Implements openfaas/faas#692
Closes #188

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a new unit test to ensure that the path is set as expected.   I have  also tested deployment of a function on `docker-for-desktop`.

Changes will need to be made to the documentation and example functions in the [openfaas/faas](https://github.com/openfaas/faas) repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
