### PR TITLE
Helm Chart: Add openfaas-operator as a faas-netes replacement

### DIFF
--- a/chart/openfaas/templates/crd.yaml
+++ b/chart/openfaas/templates/crd.yaml
@@ -1,0 +1,14 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.operator.create }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: functions.openfaas.com
+spec:
+  group: openfaas.com
+  version: v1alpha2
+  names:
+    kind: Function
+    plural: functions
+  scope: Namespaced
+{{- end }}

--- a/chart/openfaas/templates/faasnetesd-dep.yaml
+++ b/chart/openfaas/templates/faasnetesd-dep.yaml
@@ -1,4 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if eq .Values.operator.create false }}
 apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
 kind: Deployment
 metadata:
@@ -34,3 +35,4 @@ spec:
         ports:
         - containerPort: 8080
           protocol: TCP
+{{- end }}

--- a/chart/openfaas/templates/faasnetesd-external-svc.yaml
+++ b/chart/openfaas/templates/faasnetesd-external-svc.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.exposeServices }}
+{{- if eq .Values.operator.create false }}
 ---
 apiVersion: v1
 kind: Service
@@ -19,4 +20,5 @@ spec:
       targetPort: 8080
   selector:
     app: faas-netesd
+{{- end }}
 {{- end }}

--- a/chart/openfaas/templates/faasnetesd-svc.yaml
+++ b/chart/openfaas/templates/faasnetesd-svc.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.operator.create false }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
       protocol: TCP
   selector:
     app: faas-netesd
+{{- end }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -11,12 +11,18 @@ metadata:
   name: gateway
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.gateway.replicas }}
   template:
     metadata:
       labels:
         app: gateway
     spec:
+      {{- if .Values.operator.create }}
+      serviceAccountName: openfaas-operator
+      {{- end }}
+      securityContext:
+        readOnlyRootFilesystem: true
+        runAsUser: 10001
       containers:
       - name: gateway
         image: {{ .Values.images.gateway }}
@@ -28,7 +34,6 @@ spec:
           initialDelaySeconds: 2
           periodSeconds: 10
           timeoutSeconds: 2
-
         env:
         - name: read_timeout
           value: "{{ .Values.gateway.readTimeout }}"
@@ -36,10 +41,17 @@ spec:
           value: "{{ .Values.gateway.writeTimeout }}"
         - name: upstream_timeout
           value: "{{ .Values.gateway.upstreamTimeout }}"
+        {{- if .Values.operator.create }}
+        - name: functions_provider_url
+          value: "http://localhost:8081/"
+        {{ else }}
         - name: functions_provider_url
           value: "http://faas-netesd.{{ .Release.Namespace }}.svc.cluster.local.:8080/"
-        - name: functions_dns_suffix
-          value: "svc.cluster.local."
+        {{- end }}
+        - name: direct_functions
+          value: "true"
+        - name: direct_functions_suffix
+          value: "{{ $functionNs }}.svc.cluster.local."
         {{- if .Values.async }}
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.cluster.local."
@@ -53,3 +65,24 @@ spec:
         ports:
         - containerPort: 8080
           protocol: TCP
+      {{- if .Values.operator.create }}
+      - name: operator
+        image: {{ .Values.images.operator }}
+        imagePullPolicy: Always
+        command:
+          - ./openfaas-operator
+          - -logtostderr
+          - -v=2
+        env:
+        - name: function_namespace
+          value: {{ $functionNs | quote }}
+        - name: read_timeout
+          value: "{{ .Values.faasnetesd.readTimeout }}"
+        - name: write_timeout
+          value: "{{ .Values.faasnetesd.writeTimeout }}"
+        - name: image_pull_policy
+          value: {{ .Values.faasnetesd.imagePullPolicy | quote }}
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+      {{- end }}

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -11,7 +11,7 @@ metadata:
   name: queue-worker
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.queueWorker.replicas }}
   template:
     metadata:
       labels:

--- a/chart/openfaas/templates/rbac.yaml
+++ b/chart/openfaas/templates/rbac.yaml
@@ -100,3 +100,98 @@ subjects:
 {{- end }}
 ---
 {{- end }}
+{{- if .Values.operator.create }}
+{{- if .Values.rbac }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openfaas-operator
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openfaas-operator
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["openfaas.com"]
+  resources: ["functions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openfaas-operator
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openfaas-operator
+subjects:
+- kind: ServiceAccount
+  name: openfaas-operator
+  namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openfaas-operator-rw
+  namespace: {{ $functionNs | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps", "extensions"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openfaas-operator-rw
+  namespace: {{ $functionNs | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openfaas-operator-rw
+subjects:
+- kind: ServiceAccount
+  name: openfaas-operator
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+---
+{{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -15,12 +15,18 @@ gateway:
   readTimeout : "20s"
   writeTimeout : "20s"
   upstreamTimeout : "15s"  # Must be smaller than read/write_timeout
+  replicas: 1
 
 queueWorker:
   ackWait : "30s"
+  replicas: 1
 
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
 openfaasImagePullPolicy: "Always"
+
+# replaces faas-netes with openfaas-operator
+operator:
+  create: true
 
 # images of openfaas components
 images:
@@ -30,6 +36,7 @@ images:
   alertmanager: prom/alertmanager:v0.15.0-rc.0
   nats: nats-streaming:0.6.0
   queueWorker: functions/queue-worker:0.4.3
+  operator: functions/openfaas-operator:0.7.0
 
 # ingress configuration
 ingress:


### PR DESCRIPTION
Add the option to the Helm chart to use openfaas-operator instead of faas-netes.

## Description

- run openfaas-operator as a gateway sidecar
- enable gateway direct function calls
- add openfaas-operator account, RBAC and CRD
- make the gateway and worker replicas configurable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

Tested on GKE using https://github.com/stefanprodan/openfaas-flux/tree/master/charts/openfaas

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.