### PR TITLE
[WIP] Adding support for optional read-only fs for functions 

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -167,6 +167,9 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 		imagePullPolicy = apiv1.PullAlways
 	}
 
+	// TODO: Will be replaced by flag in
+	isReadOnly := true
+
 	deploymentSpec := &v1beta1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -216,10 +219,24 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 							ImagePullPolicy: imagePullPolicy,
 							LivenessProbe:   probe,
 							ReadinessProbe:  probe,
+							SecurityContext: &v1.SecurityContext{
+								ReadOnlyRootFilesystem: &isReadOnly,
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{Name: "temp", MountPath: "/tmp", ReadOnly: false},
+							},
 						},
 					},
 					RestartPolicy: v1.RestartPolicyAlways,
 					DNSPolicy:     v1.DNSClusterFirst,
+					Volumes: []v1.Volume{
+						{
+							Name: "temp",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
I have pushed a temporary image to the harbor for checking, please fill free to test it `templum/faas-netes:latest`. In that image every function will have a read-only fs. The `/tmp` folder, where also .lock is placed, can be used for temporary writes. However, they will only be existing as long as the container exists.

Later this behaviour will be controlled by the flag introduced in openfaas/faas#723 and is disabled by default.

## Description
The deployment spec for the function was modified to have `ReadOnlyRootFilesystem` to true. Additional a writable volume (called temp) gets mounted onto `/tmp`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (openfaas/faas#590)

## How Has This Been Tested?
Currently, I did local testing and successfully was able to deploy figlet and nodeinfo. And invoke both.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.