### PR TITLE
Update Prometheus and AlertManager versions

### DIFF
--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -23,8 +23,8 @@ queueWorker:
 images:
   controller: functions/faas-netesd:0.5.5
   gateway: functions/gateway:0.8.2
-  prometheus: prom/prometheus:v2.2.0
-  alertmanager: prom/alertmanager:v0.15.0-rc.0
+  prometheus: prom/prometheus:v2.3.1
+  alertmanager: prom/alertmanager:v0.15.0
   nats: nats-streaming:0.6.0
   queueWorker: functions/queue-worker:0.4.3
 

--- a/yaml/alertmanager-dep.yml
+++ b/yaml/alertmanager-dep.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: prom/alertmanager:v0.15.0-rc.0
+        image: prom/alertmanager:v0.15.0
         imagePullPolicy: Always
         command: 
           - "alertmanager"

--- a/yaml/prometheus-dep.yml
+++ b/yaml/prometheus-dep.yml
@@ -12,8 +12,8 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.2.0
-        command: 
+        image: prom/prometheus:v2.3.1
+        command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: Simon Pasquier <spasquie@redhat.com>

## Description
Bump Prometheus and AlertManager to v2.3.1 and v.015.0 respectively.

## Motivation and Context
Those versions are the current stable releases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
