### PR TITLE
Move faas-netesd from functions/ to openfaas/ ns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ local-go:
 local: 	local-fmt 	local-go
 
 build-arm64:
-	docker build -t functions/faas-netesd:$(TAG)-arm64 . -f Dockerfile.arm64
+	docker build -t openfaas/faas-netesd:$(TAG)-arm64 . -f Dockerfile.arm64
 
 build-armhf:
-	docker build -t functions/faas-netesd:$(TAG)-armhf . -f Dockerfile.armhf
+	docker build -t openfaas/faas-netesd:$(TAG)-armhf . -f Dockerfile.armhf
 
 build:
-	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t functions/faas-netesd:$(TAG) . --squash=${SQUASH}
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/faas-netesd:$(TAG) . --squash=${SQUASH}
 
 push:
 	docker push alexellis2/faas-netes:$(TAG)


### PR DESCRIPTION
This moves faas-netesd to a better name for images and also gives
free image-scanning  and  gives  more  confidence  to  users  that
components  ship  regularly  and  makes  any  vulnerabilities  in
components clear

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

[#741](https://github.com/openfaas/faas/issues/741)

## How Has This Been Tested?

Tested with local build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.