### PR TITLE
Restructure chart values to enable Weave Flux automatic updates

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 1.0.21
+version: 1.1.0
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes
@@ -15,3 +15,5 @@ maintainers:
   email: alex@openfaas.com
 - name: rimusz
   email: rmocius@gmail.com
+- name: stefanprodan
+  email: stefan.prodan@gmail.com

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -43,7 +43,9 @@ $ helm upgrade openfaas --install openfaas/openfaas \
 
 ## OpenFaaS Operator / CRD controller
 
-If you would like to work with CRDs there is an alternative controller to faas-netes named [OpenFaaS Operator](https://github.com/openfaas-incubator/openfaas-operator) which can be swapped in at deployment time. The OpenFaaS Operator is suitable for development and testing and may replace the faas-netes controller in the future.
+If you would like to work with CRDs there is an alternative controller to faas-netes named [OpenFaaS Operator](https://github.com/openfaas-incubator/openfaas-operator) which can be swapped in at deployment time.
+The OpenFaaS Operator is suitable for development and testing and may replace the faas-netes controller in the future.
+The Operator is compatible with Kubernetes 1.9 or later.
 
 To use it, add the flag: `--set operator.create=true` when installing with Helm.
 

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: {{ .Values.images.alertmanager }}
+        image: {{ .Values.alertmanager.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - "alertmanager"

--- a/chart/openfaas/templates/faasnetesd-dep.yaml
+++ b/chart/openfaas/templates/faasnetesd-dep.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: faas-controller
       containers:
       - name: faas-netesd
-        image: {{ .Values.images.controller }}
+        image: {{ .Values.faasnetesd.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         env:
         - name: function_namespace

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 10001
       containers:
       - name: gateway
-        image: {{ .Values.images.gateway }}
+        image: {{ .Values.gateway.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         livenessProbe:
           httpGet:
@@ -67,7 +67,7 @@ spec:
           protocol: TCP
       {{- if .Values.operator.create }}
       - name: operator
-        image: {{ .Values.images.operator }}
+        image: {{ .Values.operator.image }}
         imagePullPolicy: Always
         command:
           - ./openfaas-operator

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name:  nats
-        image: {{ .Values.images.nats }}
+        image: {{ .Values.nats.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         ports:
         - containerPort: 4222

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: {{ .Values.images.prometheus }}
+        image: {{ .Values.prometheus.image }}
         command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name:  queue-worker
-        image: {{ .Values.images.queueWorker }}
+        image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.functionNamespace }}
         env:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -31,12 +31,12 @@ operator:
 # images of openfaas components
 images:
   controller: functions/faas-netesd:0.5.5
-  gateway: functions/gateway:0.8.2
+  gateway: openfaas/gateway:0.8.4
   prometheus: prom/prometheus:v2.3.1
   alertmanager: prom/alertmanager:v0.15.0
   nats: nats-streaming:0.6.0
   queueWorker: functions/queue-worker:0.4.3
-  operator: functions/openfaas-operator:0.7.0
+  operator: functions/openfaas-operator:0.8.0
 
 # ingress configuration
 ingress:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -7,17 +7,20 @@ serviceType: NodePort
 rbac: true
 
 faasnetesd:
+  image: functions/faas-netesd:0.5.5
   readTimeout : "20s"
   writeTimeout : "20s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
 
 gateway:
+  image: openfaas/gateway:0.8.4
   readTimeout : "20s"
   writeTimeout : "20s"
   upstreamTimeout : "15s"  # Must be smaller than read/write_timeout
   replicas: 1
 
 queueWorker:
+  image: functions/queue-worker:0.4.3
   ackWait : "30s"
   replicas: 1
 
@@ -26,17 +29,18 @@ openfaasImagePullPolicy: "Always"
 
 # replaces faas-netes with openfaas-operator
 operator:
+  image: functions/openfaas-operator:0.8.0
   create: false
 
-# images of openfaas components
-images:
-  controller: functions/faas-netesd:0.5.5
-  gateway: openfaas/gateway:0.8.4
-  prometheus: prom/prometheus:v2.3.1
-  alertmanager: prom/alertmanager:v0.15.0
-  nats: nats-streaming:0.6.0
-  queueWorker: functions/queue-worker:0.4.3
-  operator: functions/openfaas-operator:0.8.0
+# monitoring and auto-scaling components
+prometheus:
+  image: prom/prometheus:v2.3.1
+alertmanager:
+  image: prom/alertmanager:v0.15.0
+
+# async provider
+nats:
+  image: nats-streaming:0.6.0
 
 # ingress configuration
 ingress:


### PR DESCRIPTION
## Description
- restructure images format to enable [Weave Flux](https://github.com/weaveworks/flux) automatic updates
- change gateway Docker repo to `openfaas` and update to 0.8.4
- update openfaas-operator to 0.8.0
- bump chart version to 1.1.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested on GKE 1.10 with https://github.com/stefanprodan/openfaas-flux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
