### PR TITLE
Update helm chart for nats-queue-worker PR 29

### DIFF
--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -21,11 +21,13 @@ spec:
       - name:  queue-worker
         image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
-        {{- if .Values.functionNamespace }}
         env:
+        {{- if .Values.functionNamespace }}
         - name: faas_function_suffix
           value: .{{ .Values.functionNamespace }}
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
         {{- end }}
+        - name: write_debug # Write output of async function invocation in queue-worker logs
+          value: "{{ .Values.queueWorker.writeDebug }}"
 {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -25,6 +25,7 @@ queueWorker:
   image: openfaas/queue-worker:0.4.8
   ackWait : "30s"
   replicas: 1
+  writeDebug: false
 
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
 openfaasImagePullPolicy: "Always"


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is an update to the helm chart to reflect the work in [PR 29 of the nats-queue-worker repo](https://github.com/openfaas/nats-queue-worker/pull/29).

This PR adds the `write_debug` env variable to the helm YAML for the `queueworker` function.

The PR in the nats-queue-worker repo will need to be merged, and the image will need to be published before this PR can be merged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/nats-queue-worker/pull/29

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploying with my own image, which was build with the [code in the queue-worker PR](https://github.com/openfaas/nats-queue-worker/pull/29). Checking with `kubectl describe` that the proper env variable is set, and the output is logged to console.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
