### PR TITLE
Reduce the readiness checks for functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ FaaS-netes can be configured via environment variables.
 
 | Option                 | Usage                                                                                          |
 |------------------------|------------------------------------------------------------------------------------------------|
-| `enable_function_readiness_probe` | Boolean - enable a readiness probe to test functions. Default: `true`               |
+| `httpProbe`            | Boolean - use http probe type for function readiness and liveness. Default: `false`            |
 | `write_timeout`        | HTTP timeout for writing a response body from your function (in seconds). Default: `8`         |
 | `read_timeout`         | HTTP timeout for reading the payload from the client caller (in seconds). Default: `8`         |
 | `image_pull_policy`    | Image pull policy for deployed functions (`Always`, `IfNotPresent`, `Never`.  Default: `Always` |

--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 1.1.6
+version: 1.1.7
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -115,6 +115,20 @@ spec:
           value: "{{ .Values.faasnetesd.writeTimeout }}"
         - name: image_pull_policy
           value: {{ .Values.faasnetesd.imagePullPolicy | quote }}
+        - name: http_probe
+          value: "{{ .Values.faasnetesd.httpProbe }}"
+        - name: readiness_probe_initial_delay_seconds
+          value: "{{ .Values.faasnetesd.readinessProbe.initialDelaySeconds }}"
+        - name: readiness_probe_timeout_seconds
+          value: "{{ .Values.faasnetesd.readinessProbe.timeoutSeconds }}"
+        - name: readiness_probe_period_seconds
+          value: "{{ .Values.faasnetesd.readinessProbe.periodSeconds }}"
+        - name: liveness_probe_initial_delay_seconds
+          value: "{{ .Values.faasnetesd.livenessProbe.initialDelaySeconds }}"
+        - name: liveness_probe_timeout_seconds
+          value: "{{ .Values.faasnetesd.livenessProbe.timeoutSeconds }}"
+        - name: liveness_probe_period_seconds
+          value: "{{ .Values.faasnetesd.livenessProbe.periodSeconds }}"
         ports:
         - containerPort: 8081
           protocol: TCP

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -13,6 +13,15 @@ faasnetesd:
   readTimeout : "20s"
   writeTimeout : "20s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
+  httpProbe: false              # Setting to true will use a lock file for readiness and liveness
+  readinessProbe:
+    initialDelaySeconds: 0
+    timeoutSeconds: 1
+    periodSeconds: 1
+  livenessProbe:
+    initialDelaySeconds: 3
+    timeoutSeconds: 1
+    periodSeconds: 10
 
 gateway:
   image: openfaas/gateway:0.8.5

--- a/server.go
+++ b/server.go
@@ -40,11 +40,20 @@ func main() {
 
 	log.Printf("HTTP Read Timeout: %s\n", cfg.ReadTimeout)
 	log.Printf("HTTP Write Timeout: %s\n", cfg.WriteTimeout)
-	log.Printf("Function Readiness Probe Enabled: %v\n", cfg.EnableFunctionReadinessProbe)
 
 	deployConfig := &handlers.DeployHandlerConfig{
-		EnableFunctionReadinessProbe: cfg.EnableFunctionReadinessProbe,
-		ImagePullPolicy:              cfg.ImagePullPolicy,
+		HTTPProbe: cfg.HTTPProbe,
+		FunctionReadinessProbeConfig: &handlers.FunctionProbeConfig{
+			InitialDelaySeconds: int32(cfg.ReadinessProbeInitialDelaySeconds),
+			TimeoutSeconds:      int32(cfg.ReadinessProbeTimeoutSeconds),
+			PeriodSeconds:       int32(cfg.ReadinessProbePeriodSeconds),
+		},
+		FunctionLivenessProbeConfig: &handlers.FunctionProbeConfig{
+			InitialDelaySeconds: int32(cfg.LivenessProbeInitialDelaySeconds),
+			TimeoutSeconds:      int32(cfg.LivenessProbeTimeoutSeconds),
+			PeriodSeconds:       int32(cfg.LivenessProbePeriodSeconds),
+		},
+		ImagePullPolicy: cfg.ImagePullPolicy,
 	}
 
 	bootstrapHandlers := bootTypes.FaaSHandlers{

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -70,7 +70,15 @@ func parseString(val string, fallback string) string {
 func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg := BootstrapConfig{}
 
-	enableProbe := parseBoolValue(hasEnv.Getenv("enable_function_readiness_probe"), true)
+	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
+
+	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
+	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
+	readinessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_period_seconds"), 10)
+
+	livenessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("liveness_probe_initial_delay_seconds"), 3)
+	livenessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_timeout_seconds"), 1)
+	livenessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_period_seconds"), 10)
 
 	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10)
 	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10)
@@ -80,7 +88,15 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg.ReadTimeout = readTimeout
 	cfg.WriteTimeout = writeTimeout
 
-	cfg.EnableFunctionReadinessProbe = enableProbe
+	cfg.HTTPProbe = httpProbe
+
+	cfg.ReadinessProbeInitialDelaySeconds = readinessProbeInitialDelaySeconds
+	cfg.ReadinessProbeTimeoutSeconds = readinessProbeTimeoutSeconds
+	cfg.ReadinessProbePeriodSeconds = readinessProbePeriodSeconds
+
+	cfg.LivenessProbeInitialDelaySeconds = livenessProbeInitialDelaySeconds
+	cfg.LivenessProbeTimeoutSeconds = livenessProbeTimeoutSeconds
+	cfg.LivenessProbePeriodSeconds = livenessProbePeriodSeconds
 
 	cfg.ImagePullPolicy = imagePullPolicy
 
@@ -92,9 +108,17 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 
 // BootstrapConfig for the process.
 type BootstrapConfig struct {
-	EnableFunctionReadinessProbe bool
-	ReadTimeout                  time.Duration
-	WriteTimeout                 time.Duration
-	ImagePullPolicy              string
-	Port                         int
+	// HTTPProbe when set to true switches readiness and liveness probe to
+	// access /_/health over HTTP instead of accessing /tmp/.lock.
+	HTTPProbe                         bool
+	ReadinessProbeInitialDelaySeconds int
+	ReadinessProbeTimeoutSeconds      int
+	ReadinessProbePeriodSeconds       int
+	LivenessProbeInitialDelaySeconds  int
+	LivenessProbeTimeoutSeconds       int
+	LivenessProbePeriodSeconds        int
+	ReadTimeout                       time.Duration
+	WriteTimeout                      time.Duration
+	ImagePullPolicy                   string
+	Port                              int
 }


### PR DESCRIPTION
* Significantly improves scale up time for functions (when going
  from 0 -> 1)
* Health check is hit more frequently, but should not noticibly
  impact performance
* Use the httpget probe type and leverage the watchdog /healthz
  endpoint

This could be optimized a little further if new image for doing
the http probes where created which would block on connection errors
and return immediately when the response comes back, but the best
case is < 1s improvement.

Some performance numbers.  Before (there was a timeout error):

cold start: 10.240251064300537
error calling function: Command 'echo -n "Test" | faas-cli -g http://192.168.64.78:31112 invoke hello-python' returned non-zero exit status 1.
cold start: 4.621361255645752
cold start: 5.6364970207214355
cold start: 11.648431777954102
cold start: 8.450724840164185
cold start: 9.854270935058594
cold start: 12.048357009887695
cold start: 12.24026870727539

After:

cold start: 1.8590199947357178
cold start: 1.8544681072235107
cold start: 2.065181016921997
cold start: 1.8414137363433838
cold start: 1.6598482131958008
cold start: 2.4577977657318115
cold start: 2.4510068893432617
cold start: 2.244048833847046
cold start: 2.6444039344787598

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Fix #218

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
import requests
import subprocess
import time

for i in range(10):
    now = time.time()
    try:
        subprocess.check_output('echo -n "Test" | faas-cli -g http://192.168.64.78:31112 invoke hello-python', shell=True)
        print("cold start: %s" % (time.time() - now))
    except Exception as e:
        print("error calling function: %s" % e)
    resp = requests.post("http://192.168.64.78:31113/system/scale-function/hello-python", json={"serviceName": "hello-python", "replicas": 0})
    time.sleep(10)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This only breaks very old functions which use a version of the watchdog which does not have a /healtz endpoint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
