### PR TITLE
Add annotation support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -153,8 +153,8 @@
 [[projects]]
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
-  revision = "31810a4cf29a3f583c8d69b54c1eab038549ce6a"
-  version = "0.8.6"
+  revision = "4cbb7d968d21f4ae2daacfb27213c9371d4d4449"
+  version = "0.8.8"
 
 [[projects]]
   name = "github.com/openfaas/faas-provider"
@@ -365,6 +365,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "26f8f04c511de599557350f10bede61f25cb94f4dbe4f2a165f5dc404872bb3b"
+  inputs-digest = "2af6f09faa4bec09b4200b00779f0f95c3374b53394a36598a3f682965f77b35"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas"
-  version = "0.8.6"
+  version = "0.8.8"
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -196,6 +196,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 		imagePullPolicy = apiv1.PullAlways
 	}
 
+	annotations := buildAnnotations(request)
 	deploymentSpec := &v1beta1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -203,6 +204,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: request.Service,
+			Annotations: annotations,
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -229,7 +231,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        request.Service,
 					Labels:      labels,
-					Annotations: map[string]string{"prometheus.io.scrape": "false"},
+					Annotations: annotations,
 				},
 				Spec: apiv1.PodSpec{
 					NodeSelector: nodeSelector,
@@ -267,6 +269,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 }
 
 func makeServiceSpec(request requests.CreateFunctionRequest) *v1.Service {
+
 	serviceSpec := &v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -274,7 +277,7 @@ func makeServiceSpec(request requests.CreateFunctionRequest) *v1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        request.Service,
-			Annotations: map[string]string{"prometheus.io.scrape": "false"},
+			Annotations: buildAnnotations(request),
 		},
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeClusterIP,
@@ -294,6 +297,18 @@ func makeServiceSpec(request requests.CreateFunctionRequest) *v1.Service {
 		},
 	}
 	return serviceSpec
+}
+
+func buildAnnotations(request requests.CreateFunctionRequest) map[string]string {
+	var annotations map[string]string
+	if request.Annotations != nil {
+		annotations = *request.Annotations
+	} else {
+		annotations = map[string]string{}
+	}
+
+	annotations["prometheus.io.scrape"] = "false"
+	return annotations
 }
 
 func buildEnvVars(request *requests.CreateFunctionRequest) []v1.EnvVar {

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -130,6 +130,49 @@ func Test_configureReadOnlyRootFilesystem_Enabled_To_Enabled(t *testing.T) {
 	readOnlyRootEnabled(t, deployment)
 }
 
+func Test_buildAnnotations_Empty_In_CreateRequest(t *testing.T) {
+	request := requests.CreateFunctionRequest{}
+
+	annotations := buildAnnotations(request)
+
+	if len(annotations) != 1 {
+		t.Errorf("want: %d annotations got: %d", 1, len(annotations))
+	}
+
+	v, ok := annotations["prometheus.io.scrape"]
+	if !ok {
+		t.Errorf("missing prometheus.io.scrape key")
+	}
+
+	if v != "false" {
+		t.Errorf("want: %s for annotation prometheus.io.scrape got: %s", "false", v)
+	}
+}
+
+func Test_buildAnnotations_From_CreateRequest(t *testing.T) {
+	request := requests.CreateFunctionRequest{
+		Annotations: &map[string]string{
+			"date-created": "Wed 25 Jul 21:26:22 BST 2018",
+			"foo" : "bar",
+		},
+	}
+
+	annotations := buildAnnotations(request)
+
+	if len(annotations) != 3 {
+		t.Errorf("want: %d annotations got: %d", 1, len(annotations))
+	}
+
+	v, ok := annotations["date-created"]
+	if !ok {
+		t.Errorf("missing date-created key")
+	}
+
+	if v != "Wed 25 Jul 21:26:22 BST 2018" {
+		t.Errorf("want: %s for annotation date-created got: %s", "Wed 25 Jul 21:26:22 BST 2018", v)
+	}
+}
+
 func readOnlyRootDisabled(t *testing.T, deployment *v1beta1.Deployment) {
 	if len(deployment.Spec.Template.Spec.Volumes) != 0 {
 		t.Error("Volumes should be empty if ReadOnlyRootFilesystem is false")

--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -97,6 +97,7 @@ func readFunction(item v1beta1.Deployment) *requests.Function {
 		AvailableReplicas: uint64(item.Status.AvailableReplicas),
 		InvocationCount:   0,
 		Labels:            &labels,
+		Annotations: 	   &item.Spec.Template.Annotations,
 	}
 
 	return &function

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -28,81 +28,123 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 			return
 		}
 
-		getOpts := metav1.GetOptions{}
-
-		deployment, findDeployErr := clientset.ExtensionsV1beta1().
-			Deployments(functionNamespace).
-			Get(request.Service, getOpts)
-
-		if findDeployErr != nil {
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(findDeployErr.Error()))
-			return
+		annotations := buildAnnotations(request)
+		if err, status := updateDeploymentSpec(functionNamespace, clientset, request, annotations); err != nil {
+			w.WriteHeader(status)
+			w.Write([]byte(err.Error()))
 		}
 
-		if len(deployment.Spec.Template.Spec.Containers) > 0 {
-			deployment.Spec.Template.Spec.Containers[0].Image = request.Image
-
-			// Disabling update support to prevent unexpected mutations of deployed functions,
-			// since imagePullPolicy is now configurable. This could be reconsidered later depending
-			// on desired behavior, but will need to be updated to take config.
-			//deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
-
-			deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
-
-			configureReadOnlyRootFilesystem(request, deployment)
-
-			deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
-
-			labels := map[string]string{
-				"faas_function": request.Service,
-				"uid":           fmt.Sprintf("%d", time.Now().Nanosecond()),
-			}
-
-			if request.Labels != nil {
-				if min := getMinReplicaCount(*request.Labels); min != nil {
-					deployment.Spec.Replicas = min
-				}
-
-				for k, v := range *request.Labels {
-					labels[k] = v
-				}
-			}
-
-			deployment.Labels = labels
-			deployment.Spec.Template.ObjectMeta.Labels = labels
-
-			resources, resourceErr := createResources(request)
-			if resourceErr != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(resourceErr.Error()))
-				return
-			}
-
-			deployment.Spec.Template.Spec.Containers[0].Resources = *resources
-
-			existingSecrets, err := getSecrets(clientset, functionNamespace, request.Secrets)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				return
-			}
-
-			err = UpdateSecrets(request, deployment, existingSecrets)
-			if err != nil {
-				log.Println(err)
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				return
-			}
-		}
-
-		if _, updateErr := clientset.ExtensionsV1beta1().
-			Deployments(functionNamespace).
-			Update(deployment); updateErr != nil {
-
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(updateErr.Error()))
+		if err, status := updateService(functionNamespace, clientset, request, annotations); err != nil {
+			w.WriteHeader(status)
+			w.Write([]byte(err.Error()))
 		}
 	}
+}
+
+func updateDeploymentSpec(
+	functionNamespace string,
+	clientset *kubernetes.Clientset,
+	request requests.CreateFunctionRequest,
+	annotations map[string]string) (err error, httpStatus int) {
+	getOpts := metav1.GetOptions{}
+
+	deployment, findDeployErr := clientset.ExtensionsV1beta1().
+		Deployments(functionNamespace).
+		Get(request.Service, getOpts)
+
+	if findDeployErr != nil {
+		return findDeployErr, http.StatusNotFound
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) > 0 {
+		deployment.Spec.Template.Spec.Containers[0].Image = request.Image
+
+		// Disabling update support to prevent unexpected mutations of deployed functions,
+		// since imagePullPolicy is now configurable. This could be reconsidered later depending
+		// on desired behavior, but will need to be updated to take config.
+		//deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
+
+		deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
+
+		configureReadOnlyRootFilesystem(request, deployment)
+
+		deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
+
+		labels := map[string]string{
+			"faas_function": request.Service,
+			"uid":           fmt.Sprintf("%d", time.Now().Nanosecond()),
+		}
+
+		if request.Labels != nil {
+			if min := getMinReplicaCount(*request.Labels); min != nil {
+				deployment.Spec.Replicas = min
+			}
+
+			for k, v := range *request.Labels {
+				labels[k] = v
+			}
+		}
+
+		deployment.Labels = labels
+		deployment.Spec.Template.ObjectMeta.Labels = labels
+
+		deployment.Annotations = annotations
+		deployment.Spec.Template.Annotations = annotations
+		deployment.Spec.Template.ObjectMeta.Annotations = annotations
+
+		resources, resourceErr := createResources(request)
+		if resourceErr != nil {
+			return resourceErr, http.StatusBadRequest
+		}
+
+		deployment.Spec.Template.Spec.Containers[0].Resources = *resources
+
+		existingSecrets, err := getSecrets(clientset, functionNamespace, request.Secrets)
+		if err != nil {
+			return err, http.StatusBadRequest
+		}
+
+		err = UpdateSecrets(request, deployment, existingSecrets)
+		if err != nil {
+			log.Println(err)
+			return err, http.StatusBadRequest
+		}
+	}
+
+	if _, updateErr := clientset.ExtensionsV1beta1().
+		Deployments(functionNamespace).
+		Update(deployment); updateErr != nil {
+
+		return updateErr, http.StatusInternalServerError
+	}
+
+	return nil, http.StatusOK
+}
+
+func updateService(
+	functionNamespace string,
+	clientset *kubernetes.Clientset,
+	request requests.CreateFunctionRequest,
+	annotations map[string]string) (err error, httpStatus int) {
+
+	getOpts := metav1.GetOptions{}
+
+	service, findServiceErr := clientset.CoreV1().
+		Services(functionNamespace).
+		Get(request.Service, getOpts)
+
+	if findServiceErr != nil {
+		return findServiceErr, http.StatusNotFound
+	}
+
+	service.Annotations = annotations
+
+	if _, updateErr := clientset.CoreV1().
+		Services(functionNamespace).
+		Update(service); updateErr != nil {
+
+		return updateErr, http.StatusInternalServerError
+	}
+
+	return nil, http.StatusOK
 }

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -36,6 +36,10 @@ type CreateFunctionRequest struct {
 	// back-end for making scheduling or routing decisions
 	Labels *map[string]string `json:"labels"`
 
+	// Annotations are metadata for functions which may be used by the
+	// back-end for management, orchestration, events and build tasks
+	Annotations *map[string]string `json:"annotations"`
+
 	// Limits for function
 	Limits *FunctionResources `json:"limits"`
 
@@ -67,6 +71,10 @@ type Function struct {
 	// Labels are metadata for functions which may be used by the
 	// back-end for making scheduling or routing decisions
 	Labels *map[string]string `json:"labels"`
+
+	// Annotations are metadata for functions which may be used by the
+	// back-end for management, orchestration, events and build tasks
+	Annotations *map[string]string `json:"annotations"`
 }
 
 // AsyncReport is the report from a function executed on a queue worker.

--- a/yaml/gateway-dep.yml
+++ b/yaml/gateway-dep.yml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: faas-controller
       containers:
       - name: gateway
-        image: openfaas/gateway:0.8.7
+        image: openfaas/gateway:0.8.8
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Description
Store stack.yml annotation meta data in k8s service and deployment
specifications

## Motivation and Context
It is more appropriate in kubernetes to store meta data in the annotations attribute and not labels. Labels have a more restricted value range and are not designed for general purpose metadata see: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

## How Has This Been Tested?

1. Deploy openfaas using minikube and latest versions of `gateway` (currently https://github.com/openfaas/faas/commit/4cbb7d968d21f4ae2daacfb27213c9371d4d4449)

**Using a Faas-cli supporting annotations**, a patched version of the [faas-cli that supports annotation](https://github.com/ewilde/faas-cli/tree/annotations):

Using the following `stack.yml`
```yaml
provider:
  name: faas
  gateway: http://192.168.99.100:31112

functions:
  nodejs-echo:
    lang: node
    handler: ./sample/nodejs-echo
    image: alexellis/faas-nodejs-echo:0.1
    labels:
      foo: "bar"
    annotations:
      current.time: "first-deploy"
```

1. Create a new deployment
`faas-cli deploy -f ./stack.yml`

![image](https://user-images.githubusercontent.com/329397/43049618-8132c4a4-8df2-11e8-8dba-5fc360fe65d3.png)


Annotations were visible on the minikube dashboard for the following resources
* Deployment (yes)

```
 kubectl --namespace=openfaas-fn get deployment  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "first-deploy",
  "deployment.kubernetes.io/revision": "1",
  "prometheus.io.scrape": "false"
}
```

* Pods (yes)

```
$ kubectl --namespace=openfaas-fn get pod  -o json | jq '.items[].metadata.annotations

{
  "current.time": "first-deploy",
  "prometheus.io.scrape": "false"
}
```

* Replica sets (yes)

```
kubectl --namespace=openfaas-fn get replicaset  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "first-deploy",
  "deployment.kubernetes.io/desired-replicas": "1",
  "deployment.kubernetes.io/max-replicas": "2",
  "deployment.kubernetes.io/revision": "1",
  "prometheus.io.scrape": "false"
}
```

* Services (yes)

```
 kubectl --namespace=openfaas-fn get service  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "first-deploy",
  "prometheus.io.scrape": "false"
}
```

2. Updating an existing function and changing the annotation

Example yaml used in test:
```
functions:
  nodejs-echo:
    lang: node
    handler: ./sample/nodejs-echo
    image: alexellis/faas-nodejs-echo:0.1
    labels:
      foo: "bar"
    annotations:
      current.time: "update-1"
```
```
$ faas-cli deploy -f ./stack.yml
Deploying: nodejs-echo.
Function nodejs-echo already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://192.168.99.100:31112/function/nodejs-echo

```

 * Deployment (yes)

```
kubectl --namespace=openfaas-fn get deployment  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "update-1",
  "deployment.kubernetes.io/revision": "2",
  "prometheus.io.scrape": "false"
}
```

 * Pods (yes)

```
kubectl --namespace=openfaas-fn get pod  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "update-1",
  "prometheus.io.scrape": "false"
}
```
 * Replica sets (yes)

```
kubectl --namespace=openfaas-fn get replicaset  -o json | jq '.items[1].metadata.annotations'

{
  "current.time": "update-1",
  "deployment.kubernetes.io/desired-replicas": "1",
  "deployment.kubernetes.io/max-replicas": "2",
  "deployment.kubernetes.io/revision": "2",
  "prometheus.io.scrape": "false"
}
```

 * Services (no)
```
kubectl --namespace=openfaas-fn get service  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "first-deploy",
  "prometheus.io.scrape": "false"
}
```

3. Update function and add a new annotation
 * Deployment (yes)
 * Pods (yes)
 * Replica sets  (yes)
 * Services (no)

Just to contrast the above if we do this with a label we get:

4. Update with a new label
 * Deployment no
 * Pods (yes)
 * Replica sets (yes)
 * Services (n/a)

Note updating an existing label doesn't seem to work at the moment

5. Updating annotation using `kubectl`

```
$ kubectl  --namespace=openfaas-fn annotate  --overwrite deployment nodejs-echo current.time=kubectl%time
deployment.extensions/nodejs-echo annotated
```
* Deployment (yes)

```
 kubectl --namespace=openfaas-fn get deployment  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "kubectl%time",
  "deployment.kubernetes.io/revision": "3",
  "next.time": "first-1",
  "prometheus.io.scrape": "false"
}
```

* Pods (No)

```
$ kubectl --namespace=openfaas-fn get pod  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "update-1",
  "next.time": "first-1",
  "prometheus.io.scrape": "false"
}
```

* Replica sets (yes)

```
kubectl --namespace=openfaas-fn get replicaset  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "kubectl%time",
  "deployment.kubernetes.io/desired-replicas": "1",
  "deployment.kubernetes.io/max-replicas": "2",
  "deployment.kubernetes.io/revision": "3",
  "deployment.kubernetes.io/revision-history": "3,3",
  "next.time": "first-1",
  "prometheus.io.scrape": "false"
}
```

* Services (No)

```
 kubectl --namespace=openfaas-fn get service  -o json | jq '.items[].metadata.annotations'

{
  "current.time": "first-deploy",
  "prometheus.io.scrape": "false"
}
```

**Using a version of the faas-cli that doesn't support annotations, but faas-netes does**

Works as before:

![image](https://user-images.githubusercontent.com/329397/43049688-d13a6258-8df3-11e8-8e94-c5c107556af4.png)

**Using a version of the faas-cli and gateway that doesn't support annotations, but faas-netes does**

Works as before:

![image](https://user-images.githubusercontent.com/329397/43049715-51c68ab4-8df4-11e8-8e9f-bbf76d0f0566.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
