### PR TITLE
Enable function scheduling based on extended resource definitions.

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -344,38 +344,62 @@ func createResources(request requests.CreateFunctionRequest) (*apiv1.ResourceReq
 		Requests: apiv1.ResourceList{},
 	}
 
-	// Set Memory limits
-	if request.Limits != nil && len(request.Limits.Memory) > 0 {
-		qty, err := resource.ParseQuantity(request.Limits.Memory)
-		if err != nil {
-			return resources, err
+	if request.Limits != nil {
+		if len(request.Limits.Memory) > 0 {
+			// Set Memory limits
+			qty, err := resource.ParseQuantity(request.Limits.Memory)
+			if err != nil {
+				return resources, err
+			}
+			resources.Limits[apiv1.ResourceMemory] = qty
 		}
-		resources.Limits[apiv1.ResourceMemory] = qty
+		if len(request.Limits.CPU) > 0 {
+			// Set CPU limits
+			qty, err := resource.ParseQuantity(request.Limits.CPU)
+			if err != nil {
+				return resources, err
+			}
+			resources.Limits[apiv1.ResourceCPU] = qty
+		}
+		if len(request.Limits.Others) > 0 {
+			// Set other extended resources
+			for extresource, value := range request.Limits.Others {
+				qty, err := resource.ParseQuantity(value)
+				if err != nil {
+					return resources, err
+				}
+				resources.Limits[apiv1.ResourceName(extresource)] = qty
+			}
+		}
 	}
 
-	if request.Requests != nil && len(request.Requests.Memory) > 0 {
-		qty, err := resource.ParseQuantity(request.Requests.Memory)
-		if err != nil {
-			return resources, err
+	if request.Requests != nil {
+		if len(request.Requests.Memory) > 0 {
+			// Set Memory limits
+			qty, err := resource.ParseQuantity(request.Requests.Memory)
+			if err != nil {
+				return resources, err
+			}
+			resources.Requests[apiv1.ResourceMemory] = qty
 		}
-		resources.Requests[apiv1.ResourceMemory] = qty
-	}
-
-	// Set CPU limits
-	if request.Limits != nil && len(request.Limits.CPU) > 0 {
-		qty, err := resource.ParseQuantity(request.Limits.CPU)
-		if err != nil {
-			return resources, err
+		if len(request.Requests.CPU) > 0 {
+			// Set CPU limits
+			qty, err := resource.ParseQuantity(request.Requests.CPU)
+			if err != nil {
+				return resources, err
+			}
+			resources.Requests[apiv1.ResourceCPU] = qty
 		}
-		resources.Limits[apiv1.ResourceCPU] = qty
-	}
-
-	if request.Requests != nil && len(request.Requests.CPU) > 0 {
-		qty, err := resource.ParseQuantity(request.Requests.CPU)
-		if err != nil {
-			return resources, err
+		if len(request.Requests.Others) > 0 {
+			// Set other extended resources
+			for extresource, value := range request.Requests.Others {
+				qty, err := resource.ParseQuantity(value)
+				if err != nil {
+					return resources, err
+				}
+				resources.Requests[apiv1.ResourceName(extresource)] = qty
+			}
 		}
-		resources.Requests[apiv1.ResourceCPU] = qty
 	}
 
 	return resources, nil

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -47,10 +47,11 @@ type CreateFunctionRequest struct {
 	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
 }
 
-// FunctionResources Memory and CPU
+// FunctionResources Memory, CPU and other extended resources
 type FunctionResources struct {
 	Memory string `json:"memory"`
 	CPU    string `json:"cpu"`
+	Others  map[string]string
 }
 
 // Function exported for system/functions endpoint


### PR DESCRIPTION
## Description
The FunctionResources struct was extended with a new field: Others. This field stores extended resource definitions. Others is a map of strings, where the keys and values are pure strings. When the command line client (faas-cli) sends a deploy request then the deploy handler of faas-netes will process the "Others" field and populates the Limits and Requests part of the resources map respectively. These values will be then "translated" into the POD spec of the function, so that Kubernetes can schedule to nodes where those resources are available.

## Motivation and Context
The motivation behind the patch is to enable function scheduling in Kubernetes based on extended resources, such as GPUs or FPGAs. This will hopefully contribute for the fix of issue 639 in faas.
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
The changes -together with the patched faas-cli- were tested in a Kubernetes (v1.11.0) cluster including 4 nodes. One of the nodes is running the Intel Device Plugin and exposes the integrated Intel GPU of that computer.
During the tests I was checking if scheduling is handled properly, ie. loads (functions) requesting "intel.com/gpu" are properly directed to the node mentioned before, or they were skipped if the node "ran out" of the specified resource, or was taken away from the cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
