### PR TITLE
Add k8s cluster domain name to values and fix nats address and functions-suffix

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -138,6 +138,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `gateway.scaleFromZero` | Enables an intercepting proxy which will scale any function from 0 replicas to the desired amount | `false` |
 | `queueWorker.ackWait` | Max duration of any async task/request | `30s` |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
+| `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 See values.yaml for detailed configuration.

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -62,13 +62,13 @@ spec:
           value: "http://127.0.0.1:8081/"
         {{- if .Values.async }}
         - name: faas_nats_address
-          value: "nats.{{ .Release.Namespace }}.svc.cluster.local."
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}."
         - name: faas_nats_port
           value: "4222"
         - name: direct_functions
           value: "true"
         - name: direct_functions_suffix
-          value: "{{ $functionNs }}.svc.cluster.local."
+          value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}."
         {{- end }}
         {{- if .Values.basic_auth }}
         - name: basic_auth

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -24,7 +24,7 @@ spec:
         {{- if .Values.functionNamespace }}
         env:
         - name: faas_function_suffix
-          value: .{{ .Values.functionNamespace }}.{{ .Values.kubernetesDNSDomain }}.
+          value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}."
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
         {{- end }}

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -24,7 +24,7 @@ spec:
         {{- if .Values.functionNamespace }}
         env:
         - name: faas_function_suffix
-          value: .{{ .Values.functionNamespace }}
+          value: .{{ .Values.functionNamespace }}.{{ .Values.kubernetesDNSDomain }}
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
         {{- end }}

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -24,7 +24,7 @@ spec:
         {{- if .Values.functionNamespace }}
         env:
         - name: faas_function_suffix
-          value: .{{ .Values.functionNamespace }}.{{ .Values.kubernetesDNSDomain }}
+          value: .{{ .Values.functionNamespace }}.{{ .Values.kubernetesDNSDomain }}.
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
         {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -90,3 +90,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+kubernetesDNSDomain: cluster.local


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add helm value for kubernetes domain name with `cluster.local` default value. Value is used to correctly configure nats connection address and functions suffix .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
closes https://github.com/openfaas/faas-netes/issues/266

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed faas-netes to kubernetes cluster with custom domain name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
