### PR TITLE
Helm chart: Istio compatibility and CRD validation

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -78,12 +78,6 @@ Now log in:
 echo -n $PASSWORD | faas-cli login -g http://$OPENFAAS_URL -u admin --password-stdin
 ```
 
-Save your credentials in faas-cli store:
-
-```bash
-echo $password | faas-cli login -g http://GATEWAY-URL -u admin --password-stdin
-```
-
 ## OpenFaaS Operator / CRD controller
 
 If you would like to work with CRDs there is an alternative controller to faas-netes named [OpenFaaS Operator](https://github.com/openfaas-incubator/openfaas-operator) which can be swapped in at deployment time.

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -33,6 +33,7 @@ $ helm repo add openfaas https://openfaas.github.io/faas-netes/
 "openfaas" has been added to your repositories
 ```
 
+<<<<<<< HEAD
 Generate secrets so that we can enable basic authentication for the gateway:
 
 ```bash
@@ -52,14 +53,32 @@ Now decide how you want to expose the services and edit the `helm upgrade` comma
 
 > Note: even without a LoadBalancer or IngressController you can access your gateway at any time via `kubectl port-forward`.
 
+=======
+In order to secure the Gateway administrative API and UI you have to create a secret named `basic-auth` in the openfaas namespace:
+
+```bash
+# generate a random password
+password=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+
+kubectl -n openfaas create secret generic basic-auth \
+--from-literal=basic-auth-user=admin \
+--from-literal=basic-auth-password=$password 
+```
+
+>>>>>>> Move basic auth setup in the main install section
 Now deploy OpenFaaS from the helm chart repo:
 
 ```
 $ helm repo update \
  && helm upgrade openfaas --install openfaas/openfaas \
     --namespace openfaas  \
+<<<<<<< HEAD
     --set basic_auth=true \
     --set functionNamespace=openfaas-fn
+=======
+    --set functionNamespace=openfaas-fn \
+    --set basic_auth=true
+>>>>>>> Move basic auth setup in the main install section
 ```
 
 > The above command will also update your helm repo to pull in any new releases.
@@ -76,6 +95,12 @@ Now log in:
 
 ``` bash
 echo -n $PASSWORD | faas-cli login -g http://$OPENFAAS_URL -u admin --password-stdin
+```
+
+Save your credentials in faas-cli store:
+
+```bash
+echo $password | faas-cli login -g http://GATEWAY-URL -u admin --password-stdin
 ```
 
 ## OpenFaaS Operator / CRD controller
@@ -120,10 +145,15 @@ Add `--set ingress.enabled` to enable ingress pass `--set ingress.enabled=true` 
 By default services will be exposed with following hostnames (can be changed, see values.yaml for details):
 
 * `gateway.openfaas.local`
+<<<<<<< HEAD
 
 ### SSL / TLS
 
 If you require TLS/SSL then please make use of an IngressController. A full guide is provided to [enable TLS for the OpenFaaS Gateway using cert-manager and Let's Encrypt](https://docs.openfaas.com/reference/ssl/kubernetes-with-cert-manager/).
+=======
+* `prometheus.openfaas.local`
+* `alertmanager.openfaas.local`
+>>>>>>> Move basic auth setup in the main install section
 
 ## Configuration
 

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -33,7 +33,6 @@ $ helm repo add openfaas https://openfaas.github.io/faas-netes/
 "openfaas" has been added to your repositories
 ```
 
-<<<<<<< HEAD
 Generate secrets so that we can enable basic authentication for the gateway:
 
 ```bash
@@ -53,32 +52,14 @@ Now decide how you want to expose the services and edit the `helm upgrade` comma
 
 > Note: even without a LoadBalancer or IngressController you can access your gateway at any time via `kubectl port-forward`.
 
-=======
-In order to secure the Gateway administrative API and UI you have to create a secret named `basic-auth` in the openfaas namespace:
-
-```bash
-# generate a random password
-password=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
-
-kubectl -n openfaas create secret generic basic-auth \
---from-literal=basic-auth-user=admin \
---from-literal=basic-auth-password=$password 
-```
-
->>>>>>> Move basic auth setup in the main install section
 Now deploy OpenFaaS from the helm chart repo:
 
 ```
 $ helm repo update \
  && helm upgrade openfaas --install openfaas/openfaas \
     --namespace openfaas  \
-<<<<<<< HEAD
     --set basic_auth=true \
     --set functionNamespace=openfaas-fn
-=======
-    --set functionNamespace=openfaas-fn \
-    --set basic_auth=true
->>>>>>> Move basic auth setup in the main install section
 ```
 
 > The above command will also update your helm repo to pull in any new releases.
@@ -145,15 +126,10 @@ Add `--set ingress.enabled` to enable ingress pass `--set ingress.enabled=true` 
 By default services will be exposed with following hostnames (can be changed, see values.yaml for details):
 
 * `gateway.openfaas.local`
-<<<<<<< HEAD
 
 ### SSL / TLS
 
 If you require TLS/SSL then please make use of an IngressController. A full guide is provided to [enable TLS for the OpenFaaS Gateway using cert-manager and Let's Encrypt](https://docs.openfaas.com/reference/ssl/kubernetes-with-cert-manager/).
-=======
-* `prometheus.openfaas.local`
-* `alertmanager.openfaas.local`
->>>>>>> Move basic auth setup in the main install section
 
 ## Configuration
 

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -11,6 +11,7 @@
 * Portable - runs on existing hardware or public/private cloud - [Kubernetes](https://github.com/openfaas/faas-netes) and Docker Swarm native
 * [CLI](http://github.com/openfaas/faas-cli) available with YAML format for templating and defining functions
 * Auto-scales as demand increases
+* Compatible with Istio mTLS (all health checks are done with exec wget)
 
 ## Deploy OpenFaaS
 

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -27,15 +27,17 @@ spec:
           - "--config.file=/alertmanager.yml"
           - "--storage.path=/alertmanager"
         livenessProbe:
-          httpGet:
-            path: /#/status
-            port: 9093
-          timeoutSeconds: 30
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - wget --quiet --tries=1 --spider http://localhost:9093/-/ready || exit 1
         readinessProbe:
-          httpGet:
-            path: /#/status
-            port: 9093
-          timeoutSeconds: 30
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - wget --quiet --tries=1 --spider http://localhost:9093/-/ready || exit 1
         ports:
         - containerPort: 9093
           protocol: TCP

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -29,15 +29,23 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - wget --quiet --tries=1 --spider http://localhost:9093/-/ready || exit 1
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          timeoutSeconds: 30
         readinessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - wget --quiet --tries=1 --spider http://localhost:9093/-/ready || exit 1
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          timeoutSeconds: 30
         ports:
         - containerPort: 9093
           protocol: TCP

--- a/chart/openfaas/templates/crd.yaml
+++ b/chart/openfaas/templates/crd.yaml
@@ -48,19 +48,5 @@ spec:
                 memory:
                   type: string
                   pattern: "^[0-9]+(Mi|Gi)"
-            secrets:
-              type: array
-              items:
-                type: string
-            constraints:
-              type: array
-              items:
-                type: string
-            environment:
-              type: object
-            labels:
-              type: object
-            annotations:
-              type: object
 {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/crd.yaml
+++ b/chart/openfaas/templates/crd.yaml
@@ -8,9 +8,59 @@ metadata:
 spec:
   group: openfaas.com
   version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
   names:
-    kind: Function
     plural: functions
+    singular: function
+    kind: Function
+    shortNames:
+    - fn
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - name
+            - image
+          properties:
+            name:
+              type: string
+              pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            image:
+              type: string
+            limits:
+              properties:
+                cpu:
+                  type: string
+                  pattern: "^[0-9]+(m)"
+                memory:
+                  type: string
+                  pattern: "^[0-9]+(Mi|Gi)"
+            requests:
+              properties:
+                cpu:
+                  type: string
+                  pattern: "^[0-9]+(m)"
+                memory:
+                  type: string
+                  pattern: "^[0-9]+(Mi|Gi)"
+            secrets:
+              type: array
+              items:
+                type: string
+            constraints:
+              type: array
+              items:
+                type: string
+            environment:
+              type: object
+            labels:
+              type: object
+            annotations:
+              type: object
 {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -38,19 +38,17 @@ spec:
           runAsUser: 10001
         {{- end }}
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          timeoutSeconds: 2
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
         readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 2
-          periodSeconds: 10
-          timeoutSeconds: 2
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
         env:
         - name: read_timeout
           value: "{{ .Values.gateway.readTimeout }}"

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -22,11 +22,6 @@ spec:
       {{- else }}
       serviceAccountName: {{ .Release.Name }}-controller
       {{- end }}
-      {{- if .Values.securityContext }}
-      securityContext:
-        readOnlyRootFilesystem: true
-        runAsUser: 10001
-      {{- end }}
       {{- if .Values.basic_auth }}
       volumes:
       - name: auth
@@ -37,6 +32,11 @@ spec:
       - name: gateway
         image: {{ .Values.gateway.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -91,6 +91,11 @@ spec:
       - name: operator
         image: {{ .Values.operator.image }}
         imagePullPolicy: Always
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
         command:
           - ./openfaas-operator
           - -logtostderr

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -40,15 +40,23 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
         readinessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
         env:
         - name: read_timeout
           value: "{{ .Values.gateway.readTimeout }}"

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -62,13 +62,13 @@ spec:
           value: "http://127.0.0.1:8081/"
         {{- if .Values.async }}
         - name: faas_nats_address
-          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}."
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: faas_nats_port
           value: "4222"
         - name: direct_functions
           value: "true"
         - name: direct_functions_suffix
-          value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}."
+          value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}"
         {{- end }}
         {{- if .Values.basic_auth }}
         - name: basic_auth
@@ -85,17 +85,13 @@ spec:
           mountPath: "/var/secrets"
         {{- end }}
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
           protocol: TCP
       {{- if .Values.operator.create }}
       - name: operator
         image: {{ .Values.operator.image }}
         imagePullPolicy: Always
-        {{- if .Values.securityContext }}
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 10001
-        {{- end }}
         command:
           - ./openfaas-operator
           - -logtostderr

--- a/chart/openfaas/templates/gateway-svc.yaml
+++ b/chart/openfaas/templates/gateway-svc.yaml
@@ -13,6 +13,8 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
+      targetPort: http
       protocol: TCP
+      name: http
   selector:
     app: gateway

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -28,15 +28,23 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - wget --quiet --tries=1 --spider http://localhost:9090/-/healthy || exit 1
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          timeoutSeconds: 30
         readinessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - wget --quiet --tries=1 --spider http://localhost:9090/-/ready || exit 1
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          timeoutSeconds: 30
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -26,15 +26,17 @@ spec:
           - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         livenessProbe:
-          httpGet:
-            path: /-/healthy
-            port: 9090
-          timeoutSeconds: 30
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - wget --quiet --tries=1 --spider http://localhost:9090/-/healthy || exit 1
         readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 9090
-          timeoutSeconds: 30
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - wget --quiet --tries=1 --spider http://localhost:9090/-/ready || exit 1
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -24,7 +24,7 @@ spec:
         {{- if .Values.functionNamespace }}
         env:
         - name: faas_function_suffix
-          value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}."
+          value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
         {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -34,7 +34,7 @@ gateway:
   nodePort: 31112
 
 queueWorker:
-  image: openfaas/queue-worker:0.4.9
+  image: openfaas/queue-worker:0.5.2
   ackWait : "30s"
   replicas: 1
 

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -13,7 +13,7 @@ faasnetesd:
   readTimeout : "20s"
   writeTimeout : "20s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
-  httpProbe: false              # Setting to true will use a lock file for readiness and liveness
+  httpProbe: false              # Setting to true will use a lock file for readiness and liveness (incompatible with Istio)
   readinessProbe:
     initialDelaySeconds: 0
     timeoutSeconds: 1

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -9,7 +9,7 @@ securityContext: true
 basic_auth: false
 
 faasnetesd:
-  image: openfaas/faas-netes:0.6.0
+  image: openfaas/faas-netes:0.6.1
   readTimeout : "20s"
   writeTimeout : "20s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
@@ -43,7 +43,7 @@ openfaasImagePullPolicy: "Always"
 
 # replaces faas-netes with openfaas-operator
 operator:
-  image: openfaas/openfaas-operator:0.8.5
+  image: openfaas/openfaas-operator:0.8.6
   create: false
   # set this to false when creating multiple releases in the same cluster
   # must be true for the first one only


### PR DESCRIPTION
## Description

This PR does the following:

* add openAPIV3Schema validation to CRD, port from https://github.com/openfaas-incubator/openfaas-operator/pull/40 
* move basic auth setup in the main install section to encourage users to secure the Gateway when using the Helm chart

Istio compatibility:

* move the Gateway security context from pod to container level
* remove the last dot from the domain name so that Envoy can resolve the destination
* use a named port for the Gateway service to enable Istio L7 HTTP/S routing and tracing
* use wget for health checks (mTLS)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
The  security context change and the CRD validation have been tested on GKE 1.10 and Istio 1.0.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
