### PR TITLE
Add named ports to function service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4
+FROM golang:1.9.7
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-netes/
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.9.4 as build
+FROM golang:1.9.7 as build
 ENV GOPATH=/go/
 RUN mkdir -p /go/src/github.com/openfaas/faas-netes/
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM golang:1.9.4 as build
+FROM golang:1.9.7 as build
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-netes/
 

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -203,7 +203,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 			APIVersion: "extensions/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: request.Service,
+			Name:        request.Service,
 			Annotations: annotations,
 		},
 		Spec: v1beta1.DeploymentSpec{
@@ -286,6 +286,7 @@ func makeServiceSpec(request requests.CreateFunctionRequest) *v1.Service {
 			},
 			Ports: []v1.ServicePort{
 				{
+					Name:     "http",
 					Protocol: v1.ProtocolTCP,
 					Port:     watchdogPort,
 					TargetPort: intstr.IntOrString{
@@ -296,6 +297,7 @@ func makeServiceSpec(request requests.CreateFunctionRequest) *v1.Service {
 			},
 		},
 	}
+
 	return serviceSpec
 }
 


### PR DESCRIPTION
This allows the function to be queried for metadata about which
port provides a HTTP interface.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>
