### PR TITLE
WIP: Added faas-idler to the helm chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -49,7 +49,7 @@ Now decide how you want to expose the services and edit the `helm upgrade` comma
 
 * To use NodePorts (default) pass no additional flags
 * To use a LoadBalancer add `--set serviceType=LoadBalancer`
-* To use an IngressController add `--set ingress.enabled=true` 
+* To use an IngressController add `--set ingress.enabled=true`
 
 > Note: even without a LoadBalancer or IngressController you can access your gateway at any time via `kubectl port-forward`.
 
@@ -147,11 +147,15 @@ Additional OpenFaaS options in `values.yaml`.
 | `gateway.readTimeout` | Queue worker read timeout | `20s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `20s` |
 | `gateway.upstreamTimeout` | Maximum duration of upstream function call | `20s` |
-| `gateway.scaleFromZero` | Enables an intercepting proxy which will scale any function from 0 replicas to the desired amount | `false` |
+| `gateway.scaleFromZero` | Enables an intercepting proxy which will scale any function from 0 replicas to the desired amount | `true` |
 | `queueWorker.replicas` | Replicas of the queue-worker, pick more than `1` for HA | `1` |
 | `queueWorker.ackWait` | Max duration of any async task/request | `30s` |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
 | `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |
+| `faasIdler.inactivityDuration` | Duration after which faas-idler will scale function down to 0 | `5m` |
+| `faasIdler.reconcileInterval` | The time between each of reconciliation | `30s` |
+| `faasIdler.dryRun` | When set to false the OpenFaaS API will be called to scale down idle functions, by default this is set to only print in the logs. | `true` |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 See values.yaml for detailed configuration.

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: faas-idler
+  app: {{ template "openfaas.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.faasIdler.replicas }}
+  template:
+    metadata:
+      labels:
+        app: faas-idler
+    spec:
+      containers:
+        - name: faas-idler
+          image: {{ .Values.faasIdler.image }}
+          imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+          env:
+            - name: gateway_url
+              value: "http://gateway.{{ .Release.Namespace }}:8080/"
+            - name: prometheus_host
+              value: "prometheus.{{ .Release.Namespace }}"
+            - name: prometheus_port
+              value: "9090"
+            - name: inactivity_duration
+              value: {{ .Values.faasIdler.inactivityDuration }}
+            - name: reconcile_interval
+              value: {{ .Values.faasIdler.reconcileInterval }}
+          command:
+            - /home/app/faas-idler
+            - -dry-run={{ .Values.faasIdler.dryRun }}
+
+{{- if .Values.basic_auth }}
+          volumeMounts:
+            - name: auth
+              readOnly: true
+              mountPath: "/var/secrets/"
+      volumes:
+        - name: auth
+          secret:
+            secretName: basic-auth
+
+{{- end }}
+{{- with .Values.nodeSelector }}
+    nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+        tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -29,7 +29,7 @@ gateway:
   writeTimeout : "20s"
   upstreamTimeout : "15s"  # Must be smaller than read/write_timeout
   replicas: 1
-  scaleFromZero: false
+  scaleFromZero: true
   # change the port when creating multiple releases in the same baremetal cluster
   nodePort: 31112
 
@@ -72,6 +72,14 @@ ingress:
     kubernetes.io/ingress.class: nginx
   tls:
     # Secrets must be manually created in the namespace.
+
+# faas-idler configuration
+faasIdler:
+  replicas: 1
+  image: openfaas/faas-idler:0.1.7
+  inactivityDuration: 5m
+  reconcileInterval: 30s
+  dryRun: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
It's WIP because I need to test it again.

Closes: https://github.com/openfaas/faas-netes/issues/281

I have added faas-idler-dep.yaml file to helm chart, which will
deploy it by default when anyone will install OpenFaaS via Helm
By default faas-idler works in dryRun mode, but you can change it
by setting `faasIdler.dryRun` to `true`

Gateway setting `gateway.scaleFromZero` is turned on by default from
now on.

I have added description of new possible values inside helm chart
README file.

Signed-off-by: Bart Smykla (VMware) <bartek@smykla.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
