### PR TITLE
Add basic auth for queue worker

### DIFF
--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -17,16 +17,34 @@ spec:
       labels:
         app: queue-worker
     spec:
+      {{- if .Values.basic_auth }}
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      {{- end }}
       containers:
       - name:  queue-worker
         image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
-        {{- if .Values.functionNamespace }}
         env:
+        {{- if .Values.functionNamespace }}
         - name: faas_function_suffix
           value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        {{- end }}
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
+        {{- if .Values.basic_auth }}
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "true"
+        {{- end }}
+        {{- if .Values.basic_auth }}
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
         {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -39,8 +39,6 @@ spec:
           value: "/var/secrets"
         - name: basic_auth
           value: "true"
-        {{- end }}
-        {{- if .Values.basic_auth }}
         volumeMounts:
         - name: auth
           readOnly: true

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -4,7 +4,7 @@ These instructions are for OpenFaaS when you don't want to use `helm`.
 
 ## 1.0 Enable basic auth on gateway
 
-To enable built-in basic auth: create secrets, configure the gateway and mount the secrets to the gateway.
+To enable built-in basic auth: create secrets, configure and mount the secrets to the gateway and queue worker.
 
 ### 1.1 Create secrets:
 
@@ -26,14 +26,14 @@ kubectl create secret generic basic-auth-password -n openfaas-fn \
 
 Record the line from "Password: c66ec59d880e66fb02c043ef910eefba020f2a3a" for later use with `faas-cli login`
 
-### 1.2 Set env-vars on gateway
+### 1.2 Set env-vars on gateway and queue worker
 
 ```
         - name: basic_auth
           value: "true"
 ```
 
-### 1.3 Add volume mount to gateway
+### 1.3 Add volume mount to gateway and queue worker
 
 ```
         volumeMounts:
@@ -42,7 +42,7 @@ Record the line from "Password: c66ec59d880e66fb02c043ef910eefba020f2a3a" for la
           mountPath: "/etc/openfaas"
 ```
 
-### 1.4 Add secrets as volumes within gateway
+### 1.4 Add secrets as volumes within gateway and queue worker
 ```
       volumes:
       - name: gateway-basic-auth
@@ -50,10 +50,11 @@ Record the line from "Password: c66ec59d880e66fb02c043ef910eefba020f2a3a" for la
           secretName: gateway-basic-auth
 ```
 
-Apply the changes to the gateway (deployment only):
+Apply the changes to the gateway and queue worker(deployment only):
 
 ```
 $ kubectl apply -f ./yaml/gateway-dep.yml
+$ kubectl apply -f ./yaml/queueworker-dep.yml
 ```
 
 ### 1.5 Login in

--- a/yaml/queueworker-dep.yml
+++ b/yaml/queueworker-dep.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name:  queue-worker
-        image: openfaas/queue-worker:0.4.9
+        image: openfaas/queue-worker:0.5.2
         imagePullPolicy: Always
         env:
         - name: max_inflight      # Max number of items in-flight
@@ -21,3 +21,7 @@ spec:
           value: "30s"
         - name: faas_function_suffix
           value: ".openfaas-fn.svc.cluster.local."  # absolute DNS will suppress search domains
+        - name: basic_auth
+          value: "false"
+        - name: secret_mount_path
+          value: "/etc/openfaas"


### PR DESCRIPTION
This changes add basic authetication credentials to queue worker to use
for `/system/async-report` call.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
