### PR TITLE
Add external svc for prometheus helm chart

### DIFF
--- a/chart/openfaas/templates/prometheus-external-svc.yaml
+++ b/chart/openfaas/templates/prometheus-external-svc.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.exposeServices }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: prometheus-external
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: {{ .Values.serviceType }}
+  ports:
+    - port: 9090
+      protocol: TCP
+      {{- if contains "NodePort" .Values.serviceType }}
+      nodePort: {{ .Values.prometheus.nodePort }}
+      {{- end }}
+  selector:
+    app: prometheus
+{{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -52,6 +52,8 @@ operator:
 # monitoring and auto-scaling components
 prometheus:
   image: prom/prometheus:v2.3.1
+  # change the port when creating multiple releases in the same cluster
+  nodePort: 31119
 alertmanager:
   image: prom/alertmanager:v0.15.0
 


### PR DESCRIPTION
## Description
- Add external srv to expose prometheus as a node port 31119 so that the
installation matches the README description.  This also matches the static
yaml manifest installs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #316


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by installing on a local Docker-for-Mac and seeing the new `prometheus-external` svc is created

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
