### PR TITLE
Update note on helm chart nodeports

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -135,7 +135,7 @@ $ helm upgrade --install openfaas openfaas/ \
 
 ### NodePorts
 
-By default NodePorts will be created for the API Gateway and Prometheus.
+By default a NodePort will be created for the API Gateway.
 
 ### LB
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Update the chart readme to reflect that only the Gateway has a NodePort by default.
- The prometheus component should not be exposed because it is an internal implementation detail used to control scaling etc.  Changing the docs better reflects this role and behavior
- This ensures that the docs are correct

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Addresses #316 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Previewed the docs using VSCode's markdown preview

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
