### PR TITLE
Simplify handlers

### DIFF
--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -17,8 +17,6 @@ import (
 // MakeDeleteHandler delete a function
 func MakeDeleteHandler(functionNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-
 		request := requests.DeleteFunctionRequest{}
 		err := json.NewDecoder(r.Body).Decode(&request)
 		if err != nil {

--- a/handlers/delete.go
+++ b/handlers/delete.go
@@ -5,7 +5,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/openfaas/faas/gateway/requests"
@@ -20,10 +19,8 @@ func MakeDeleteHandler(functionNamespace string, clientset *kubernetes.Clientset
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
-		body, _ := ioutil.ReadAll(r.Body)
-
 		request := requests.DeleteFunctionRequest{}
-		err := json.Unmarshal(body, &request)
+		err := json.NewDecoder(r.Body).Decode(&request)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -62,8 +62,6 @@ type DeployHandlerConfig struct {
 // MakeDeployHandler creates a handler to create new functions in the cluster
 func MakeDeployHandler(functionNamespace string, clientset *kubernetes.Clientset, config *DeployHandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-
 		request := requests.CreateFunctionRequest{}
 		err := json.NewDecoder(r.Body).Decode(&request)
 		if err != nil {
@@ -116,6 +114,7 @@ func MakeDeployHandler(functionNamespace string, clientset *kubernetes.Clientset
 		}
 
 		log.Println("Created service - " + request.Service)
+		body, _ := json.Marshal(request)
 		log.Println(string(body))
 
 		w.WriteHeader(http.StatusAccepted)

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -6,7 +6,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -65,10 +64,8 @@ func MakeDeployHandler(functionNamespace string, clientset *kubernetes.Clientset
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
-		body, _ := ioutil.ReadAll(r.Body)
-
 		request := requests.CreateFunctionRequest{}
-		err := json.Unmarshal(body, &request)
+		err := json.NewDecoder(r.Body).Decode(&request)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -5,8 +5,6 @@ import "net/http"
 // MakeHealthHandler returns 200/OK when healthy
 func MakeHealthHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/handlers/info.go
+++ b/handlers/info.go
@@ -17,10 +17,6 @@ const (
 //MakeInfoHandler creates handler for /system/info endpoint
 func MakeInfoHandler(version, sha string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Body != nil {
-			defer r.Body.Close()
-		}
-
 		infoRequest := types.InfoRequest{
 			Orchestration: OrchestrationIdentifier,
 			Provider:      ProviderName,

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -4,7 +4,6 @@
 package handlers
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -34,11 +33,6 @@ func MakeProxy(functionNamespace string, timeout time.Duration) http.HandlerFunc
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-
-		if r.Body != nil {
-			defer r.Body.Close()
-		}
-
 		switch r.Method {
 		case http.MethodPost,
 			http.MethodPut,
@@ -71,8 +65,7 @@ func MakeProxy(functionNamespace string, timeout time.Duration) http.HandlerFunc
 			if err != nil {
 				log.Println(err.Error())
 				writeHead(service, http.StatusInternalServerError, w)
-				buf := bytes.NewBufferString("Can't reach service: " + service)
-				w.Write(buf.Bytes())
+				fmt.Fprintln(w, "Can't reach service: ", service)
 				return
 			}
 

--- a/handlers/replicas.go
+++ b/handlers/replicas.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -23,16 +24,14 @@ func MakeReplicaUpdater(functionNamespace string, clientset *kubernetes.Clientse
 		functionName := vars["name"]
 
 		req := types.ScaleServiceRequest{}
-		if r.Body != nil {
-			defer r.Body.Close()
-			err := json.NewDecoder(r.Body).Decode(&req)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				msg := "Cannot parse request. Please pass valid JSON."
-				w.Write([]byte(msg))
-				log.Println(msg, err)
-				return
-			}
+
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			msg := "Cannot parse request. Please pass valid JSON."
+			fmt.Fprintln(w, msg)
+			log.Println(msg, err)
+			return
 		}
 
 		options := metav1.GetOptions{

--- a/handlers/replicas.go
+++ b/handlers/replicas.go
@@ -5,7 +5,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -26,13 +25,12 @@ func MakeReplicaUpdater(functionNamespace string, clientset *kubernetes.Clientse
 		req := types.ScaleServiceRequest{}
 		if r.Body != nil {
 			defer r.Body.Close()
-			bytesIn, _ := ioutil.ReadAll(r.Body)
-			marshalErr := json.Unmarshal(bytesIn, &req)
-			if marshalErr != nil {
+			err := json.NewDecoder(r.Body).Decode(&req)
+			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				msg := "Cannot parse request. Please pass valid JSON."
 				w.Write([]byte(msg))
-				log.Println(msg, marshalErr)
+				log.Println(msg, err)
 				return
 			}
 		}

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -15,9 +15,6 @@ import (
 // MakeUpdateHandler update specified function
 func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
-		defer r.Body.Close()
-
 		request := requests.CreateFunctionRequest{}
 		err := json.NewDecoder(r.Body).Decode(&request)
 		if err != nil {

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -19,10 +18,8 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 
 		defer r.Body.Close()
 
-		body, _ := ioutil.ReadAll(r.Body)
-
 		request := requests.CreateFunctionRequest{}
-		err := json.Unmarshal(body, &request)
+		err := json.NewDecoder(r.Body).Decode(&request)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return


### PR DESCRIPTION
Two smalls tips to simplify handlers
- Remove Body.Close() call from handlers
- Use json.Decoder instead of JSON.Unmarshall 