### PR TITLE
Helm chart: fix offline install and bump operator version

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -97,7 +97,7 @@ spec:
       {{- if .Values.operator.create }}
       - name: operator
         image: {{ .Values.operator.image }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - ./openfaas-operator
           - -logtostderr

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -43,7 +43,7 @@ openfaasImagePullPolicy: "Always"
 
 # replaces faas-netes with openfaas-operator
 operator:
-  image: openfaas/openfaas-operator:0.8.9
+  image: openfaas/openfaas-operator:0.8.10
   create: false
   # set this to false when creating multiple releases in the same cluster
   # must be true for the first one only


### PR DESCRIPTION
## Description

* Update operator to v0.8.10 fix #326
* Set operator image pull policy using values.yaml fix #322 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

Tested on Docker for Mac by installing the chart with internet, going offline, uninstalling and then installing again with IfNotPresent

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.