### PR TITLE
Bumpe golang to 1.10.x and alpine to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.7
+FROM golang:1.10
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-netes/
 
@@ -18,7 +18,7 @@ RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") \
         -X github.com/openfaas/faas-netes/version.Version=${VERSION}" \
         -a -installsuffix cgo -o faas-netes .
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 LABEL org.label-schema.license="MIT" \
       org.label-schema.vcs-url="https://github.com/openfaas/faas-netes" \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.9.7 as build
+FROM golang:1.10 as build
 ENV GOPATH=/go/
 RUN mkdir -p /go/src/github.com/openfaas/faas-netes/
 
@@ -15,7 +15,7 @@ RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") \
     -a -installsuffix cgo -o faas-netes .
 
 
-FROM alpine:3.7
+FROM alpine:3.8
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM golang:1.9.7 as build
+FROM golang:1.10 as build
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-netes/
 
@@ -13,7 +13,7 @@ RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags 
         -X github.com/openfaas/faas-netes/version.Version=${VERSION}" \
         -a -installsuffix cgo -o faas-netes .
 
-FROM alpine:3.7 as ship
+FROM alpine:3.8 as ship
 
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Bump the base docker image to golang:1.10
- Bump the alpine version to 3.8

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

I opened #329 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested the change using the `docker-for-desktop` Kubernetes

In the faas-netes repo

```sh
make build
kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
cd chart/openfaas
helm upgrade openfaas --install . \
    --namespace openfaas  \
    --set faasnetesd.image=openfaas/faas-netes:latest \
    --set faasnetesd.imagePullPolicy=IfNotPresent \
    --set basic_auth=false \
    --set openfaasImagePullPolicy=IfNotPresent \
    --set functionNamespace=openfaas-fn
```

Then, in the browser go to http://localhost:31112/ui/ and see the `nodeinfo` function is running and test it

Finally, delete the function in the UI and then check that the related k8s resources were deteled using 

```sh
kubectl -n openfaas-fn get all
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
