### PR TITLE
Remove double http:// in README

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -80,7 +80,7 @@ export OPENFAAS_URL=http://...
 Now log in:
 
 ``` bash
-echo -n $PASSWORD | faas-cli login -g http://$OPENFAAS_URL -u admin --password-stdin
+echo -n $PASSWORD | faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 ```
 
 ## OpenFaaS Operator / CRD controller

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -80,7 +80,7 @@ export OPENFAAS_URL=http://...
 Now log in:
 
 ``` bash
-echo -n $PASSWORD | faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
+echo -n $PASSWORD | faas-cli login -g $OPENFAAS_URL:8080 -u admin --password-stdin
 ```
 
 ## OpenFaaS Operator / CRD controller


### PR DESCRIPTION
Remove double http:// in README

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 

Resolves #337

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
