### PR TITLE
Disable Prometheus scraping for components without /metrics

### DIFF
--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -45,7 +45,7 @@ spec:
 
 {{- end }}
 {{- with .Values.nodeSelector }}
-    nodeSelector:
+      nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.affinity }}
@@ -53,6 +53,6 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
-        tolerations:
+      tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -9,6 +9,8 @@ spec:
   replicas: {{ .Values.faasIdler.replicas }}
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "false"
       labels:
         app: faas-idler
     spec:

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "false"
       labels:
         app: nats
     spec:

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: {{ .Values.queueWorker.replicas }}
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "false"
       labels:
         app: queue-worker
     spec:

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -41,6 +41,8 @@ spec:
           value: "/var/secrets"
         - name: basic_auth
           value: "{{ .Values.basic_auth }}"
+        - name: faas_nats_address
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         volumeMounts:
         - name: auth
           readOnly: true

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -40,7 +40,7 @@ spec:
         - name: secret_mount_path
           value: "/var/secrets"
         - name: basic_auth
-          value: "true"
+          value: "{{ .Values.basic_auth }}"
         volumeMounts:
         - name: auth
           readOnly: true


### PR DESCRIPTION
## Description

- disable Prometheus scraping for NATS, worker and  faas-idler
- fix faas-idler node selector and toleration indentation
- set worker env vars for basic auth and NATS address

Fix #325 

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested on GKE with Weave Cloud

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
