### PR TITLE
Fix add basic auth to alert manager config

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 1.6.2
+version: 1.6.3
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/templates/alertmanager-cfg.yaml
+++ b/chart/openfaas/templates/alertmanager-cfg.yaml
@@ -35,3 +35,9 @@ data:
       webhook_configs:
         - url: http://gateway.{{ .Release.Namespace }}:8080/system/alert
           send_resolved: true
+          {{- if .Values.basic_auth }}
+          http_config:
+            basic_auth:
+              username: admin
+              password_file: /var/secrets/basic-auth-password
+          {{- end -}}

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -53,6 +53,11 @@ spec:
         - mountPath: /alertmanager.yml
           name: alertmanager-config
           subPath: alertmanager.yml
+        {{- if .Values.basic_auth }}
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        {{- end }}
       volumes:
         - name: alertmanager-config
           configMap:
@@ -61,6 +66,11 @@ spec:
               - key: alertmanager.yml
                 path: alertmanager.yml
                 mode: 0644
+        {{- if .Values.basic_auth }}
+        - name: auth
+          secret:
+            secretName: basic-auth
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
**What**
- Update the alert manager config to send the basic auth credentials
when basic auth is enabled.
- This is required to support openfaas/faas#1049
- bump the gateway tag
- bump the chart version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This issue was raised by @alexellis on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually in Docker-for-mac

Pull the gateway image from openfaas/faas#1049
```sh
docker pull theaxer/gateway:0.10.0
```

Create `spammer.sh`
```sh
#! /bin/bash
gateway=localhost:31112
fnc=cows
sleepSec=0
while true; do
    echo "" | faas-cli invoke "$fnc" --gateway "$gateway"
    sleep $sleepSec
done
```


Deploy and test in k8s
```sh
kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml && \
kubectl -n openfaas create secret generic basic-auth \
    --from-literal=basic-auth-user=admin \
    --from-literal=basic-auth-password='testpass'
helm upgrade openfaas --install ./openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set gateway.image='theaxer/gateway:0.10.0' \
    --set faasnetesd.imagePullPolicy='IfNotPresent' \
    --set openfaasImagePullPolicy='IfNotPresent' \
    --set functionNamespace=openfaas-fn

export gateway=localhost:31112

# test that basic auth is required on the alert endpoint
curl -X POST http://$gateway/system/alert -d '{}'
# invalid credentials%

faas-cli -g $gateway login -u admin --password testpass
faas-cli -g $gateway store deploy cows

# in a new shell, run the spammer to test scaling
./spammer.sh

# watch the gateway logs for `Alert received.` message
kubectl -n openfaas logs $(kubectl -n openfaas get po -l "app=gateway" -o name) gateway -f
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
