### PR TITLE
 Use Kubernetes discovery for Gateway Prometheus scrapping 

### DIFF
--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: alertmanager
       annotations:
+        sidecar.istio.io/inject: "false"
         checksum/alertmanager-config: {{ include (print $.Template.BasePath "/alertmanager-cfg.yaml") . | sha256sum | quote  }}
     spec:
       containers:

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -10,6 +10,7 @@ spec:
   template:
     metadata:
       annotations:
+        sidecar.istio.io/inject: "false"
         prometheus.io.scrape: "false"
       labels:
         app: faas-idler

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -10,7 +10,6 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "false"
         prometheus.io.scrape: "false"
       labels:
         app: faas-idler

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -14,6 +14,9 @@ spec:
   replicas: {{ .Values.gateway.replicas }}
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+        prometheus.io.port: "8080"
       labels:
         app: gateway
     spec:

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        sidecar.istio.io/inject: "false"
         prometheus.io.scrape: "false"
       labels:
         app: nats

--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -26,13 +26,31 @@ data:
         static_configs:
           - targets: ['localhost:9090']
 
-      - job_name: "gateway"
+      - job_name: 'kubernetes-pods'
         scrape_interval: 5s
-        dns_sd_configs:
-          - names: ['gateway.{{ .Release.Namespace }}']
-            port: 8080
-            type: A
-            refresh_interval: 5s
+        honor_labels: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
 
     alerting:
       alertmanagers:

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: prometheus
       annotations:
+        sidecar.istio.io/inject: "false"
         checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-cfg.yaml") . | sha256sum | quote }}
     spec:
       serviceAccountName: {{ .Release.Name }}-prometheus

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-cfg.yaml") . | sha256sum | quote }}
     spec:
+      serviceAccountName: {{ .Release.Name }}-prometheus
       containers:
       - name: prometheus
         image: {{ .Values.prometheus.image }}

--- a/chart/openfaas/templates/prometheus-rbac.yaml
+++ b/chart/openfaas/templates/prometheus-rbac.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-prometheus
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -51,7 +51,7 @@ operator:
 
 # monitoring and auto-scaling components
 prometheus:
-  image: prom/prometheus:v2.6.1
+  image: prom/prometheus:v2.7.1
 alertmanager:
   image: prom/alertmanager:v0.15.0
 

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -51,7 +51,7 @@ operator:
 
 # monitoring and auto-scaling components
 prometheus:
-  image: prom/prometheus:v2.3.1
+  image: prom/prometheus:v2.6.1
 alertmanager:
   image: prom/alertmanager:v0.15.0
 

--- a/yaml/gateway-dep.yml
+++ b/yaml/gateway-dep.yml
@@ -7,6 +7,9 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+        prometheus.io.port: "8080"
       labels:
         app: gateway
     spec:

--- a/yaml/prometheus-cfg.yml
+++ b/yaml/prometheus-cfg.yml
@@ -19,13 +19,31 @@ data:
         scrape_interval: 5s
         static_configs:
           - targets: ['localhost:9090']
-      - job_name: "gateway"
+      - job_name: 'kubernetes-pods'
         scrape_interval: 5s
-        dns_sd_configs:
-          - names: ['gateway.openfaas']
-            port: 8080
-            type: A
-            refresh_interval: 5s
+        honor_labels: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - openfaas
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
     alerting:
       alertmanagers:
       - static_configs:

--- a/yaml/prometheus-dep.yml
+++ b/yaml/prometheus-dep.yml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: openfaas-prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.3.1
+        image: prom/prometheus:v2.6.1
         command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"

--- a/yaml/prometheus-dep.yml
+++ b/yaml/prometheus-dep.yml
@@ -10,6 +10,7 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccountName: openfaas-prometheus
       containers:
       - name: prometheus
         image: prom/prometheus:v2.3.1

--- a/yaml/prometheus-dep.yml
+++ b/yaml/prometheus-dep.yml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: openfaas-prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.6.1
+        image: prom/prometheus:v2.7.1
         command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"

--- a/yaml/prometheus-rbac.yml
+++ b/yaml/prometheus-rbac.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openfaas-prometheus
+  namespace: openfaas
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openfaas-prometheus
+  namespace: openfaas
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openfaas-prometheus
+  namespace: openfaas
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openfaas-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: openfaas-prometheus
+    namespace: openfaas


### PR DESCRIPTION
This PR does the following:
- upgrade Prometheus to v2.6.1
- add Prometheus Kubernetes service account, role and RBAC
- enable pod scraping for OpenFaaS Gateway on port 8080
- disable Istio sidecar injection except for Gateway and QueueWorker

Fix: #354

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Helm install tested on GKE with Istio 1.0.3 and two Gateway pods

Prometheus:

<img width="1032" alt="screenshot 2019-01-27 at 12 02 22" src="https://user-images.githubusercontent.com/3797675/51799733-bcec8280-222d-11e9-9fe7-6b48e5e73417.png">

Gateway promql:

<img width="893" alt="screenshot 2019-02-03 at 12 19 37" src="https://user-images.githubusercontent.com/3797675/52175553-3c3e0100-27ae-11e9-9fbf-c6d00e4071f3.png">

Grafana:

<img width="1431" alt="screenshot 2019-02-03 at 12 20 38" src="https://user-images.githubusercontent.com/3797675/52175556-452ed280-27ae-11e9-9dde-63a93c2a0b12.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
