### PR TITLE
Fix remove value from scaling alert definition

### DIFF
--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -70,7 +70,6 @@ data:
           labels:
             service: gateway
             severity: major
-            value: '{{ "{{" }}$value{{ "}}" }}'
           annotations:
-            description: High invocation total on "{{ "{{" }}$labels.instance{{ "}}" }}"
-            summary: High invocation total on "{{ "{{" }}$labels.instance{{ "}}" }}"
+            description: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
+            summary: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -55,7 +55,7 @@ operator:
 prometheus:
   image: prom/prometheus:v2.7.1
 alertmanager:
-  image: prom/alertmanager:v0.15.0
+  image: prom/alertmanager:v0.16.1
 
 # async provider
 nats:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates the alert configuration and updates alert manager to the latest version.

## Description
<!--- Describe your changes in detail -->
- upgrade alert manager to the latest release to match prometheus and to
get the expected alert behavior
- Removes the `alert` label in the scale-up alert
- Updates the annotaitons to use the `function_name` label instead of
the `instance` label that was removed.
- Per prometheus/prometheus#4836 and the related mailing list discussion
https://groups.google.com/d/msg/prometheus-users/7Ul6ngc7Ogs/j_YDszV5BwAJ
the alert value should not be included in the alert labels otherwise
each calculation of the alert is treated like a new alert and then the
use of `for 5s` will not behave as expected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #372 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested locally, 

1. deploy the helm chart 
```sh
helm upgrade openfaas --install ./openfaas \
    --namespace openfaas  \
    --set basic_auth=false \
    --set functionNamespace=openfaas-fn
```
2. deploy the go-echo function https://github.com/alexellis/echo-fn
3. create constant load using `hey`
```sh
hey -c 2 -q 10 -n 100000 http://127.0.0.1:31112/function/go-echo
```
4. observe that the function scales in steps relatively quickly after the alert stops and that the function then scales quickly to 1 replica when the alert stops, this is shown in the below graphs

![image](https://user-images.githubusercontent.com/891889/52916956-e6a54080-32e5-11e9-895f-74dd2f29159b.png)

Note: you should be able to reproduce those graphs by 
1. forwarding the prometheus pod to 9090
2. opening  http://localhost:9090/graph?g0.range_input=15m&g0.expr=rate(gateway_function_invocation_total%5B10s%5D)&g0.tab=0&g1.range_input=15m&g1.expr=ALERTS%7Balertname%3D%22APIHighInvocationRate%22%7D&g1.tab=0&g2.range_input=15m&g2.expr=gateway_service_count&g2.tab=0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
