### PR TITLE
disable istio injection for nats and alertmanager in yaml files

### DIFF
--- a/yaml/alertmanager-dep.yml
+++ b/yaml/alertmanager-dep.yml
@@ -7,6 +7,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: alertmanager
     spec:

--- a/yaml/nats-dep.yml
+++ b/yaml/nats-dep.yml
@@ -7,6 +7,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: nats
     spec:

--- a/yaml_arm64/alertmanager-dep.yml
+++ b/yaml_arm64/alertmanager-dep.yml
@@ -7,6 +7,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: alertmanager
     spec:

--- a/yaml_arm64/nats-dep.yml
+++ b/yaml_arm64/nats-dep.yml
@@ -7,6 +7,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: nats
     spec:

--- a/yaml_armhf/alertmanager-dep.yml
+++ b/yaml_armhf/alertmanager-dep.yml
@@ -7,6 +7,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: alertmanager
     spec:

--- a/yaml_armhf/nats-dep.yml
+++ b/yaml_armhf/nats-dep.yml
@@ -7,6 +7,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: nats
     spec:


### PR DESCRIPTION
## Description
I have disabled istio injection in the yaml files in the same way it was done in the helm charts 

## Motivation and Context
To solve issue #369 

## How Has This Been Tested?
Tested on Kubernetes 1.11.7

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
