### PR TITLE
Enable non-repudiation for function callbacks

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -25,11 +25,16 @@ spec:
       {{- else }}
       serviceAccountName: {{ .Release.Name }}-controller
       {{- end }}
-      {{- if .Values.basic_auth }}
       volumes:
+      {{- if .Values.basic_auth }}
       - name: auth
         secret:
           secretName: basic-auth
+      {{- end }}
+      {{- if .Values.http_signatures }}
+      - name: http-signing-public-key
+        secret:
+          secretName: http-signing-public-key
       {{- end }}
       containers:
       - name: gateway
@@ -73,6 +78,8 @@ spec:
           value: "true"
         - name: direct_functions_suffix
           value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        - name: secret_mount_path
+          value: "/var/secrets"
         {{- if .Values.async }}
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
@@ -82,8 +89,6 @@ spec:
         {{- if .Values.basic_auth }}
         - name: basic_auth
           value: "true"
-        - name: secret_mount_path
-          value: "/var/secrets"
         {{- end }}
         - name: scale_from_zero
           value: "{{ .Values.gateway.scaleFromZero }}"
@@ -91,9 +96,14 @@ spec:
           value: "{{ .Values.gateway.maxIdleConns }}"
         - name: max_idle_conns_per_host
           value: "{{ .Values.gateway.maxIdleConnsPerHost }}"
-        {{- if .Values.basic_auth }}
         volumeMounts:
+        {{- if .Values.basic_auth }}
         - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        {{- end }}
+        {{- if .Values.http_signatures }}
+        - name: http-signing-public-key
           readOnly: true
           mountPath: "/var/secrets"
         {{- end }}

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -19,32 +19,46 @@ spec:
       labels:
         app: queue-worker
     spec:
-      {{- if .Values.basic_auth }}
       volumes:
+      {{- if .Values.basic_auth }}
       - name: auth
         secret:
           secretName: basic-auth
+      {{- end }}
+      {{- if .Values.http_signatures }}
+      - name: http-signing-private-key
+        secret:
+          secretName: http-signing-private-key
       {{- end }}
       containers:
       - name:  queue-worker
         image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         env:
+        - name : write_debug
+          value : "true"
         {{- if .Values.functionNamespace }}
         - name: faas_function_suffix
           value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         {{- end }}
         - name: ack_wait    # Max duration of any async task / request
           value: {{ .Values.queueWorker.ackWait }}
-        {{- if .Values.basic_auth }}
         - name: secret_mount_path
           value: "/var/secrets"
+        {{- if .Values.basic_auth }}
         - name: basic_auth
           value: "{{ .Values.basic_auth }}"
+        {{- end }}
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         volumeMounts:
+        {{- if .Values.basic_auth }}
         - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        {{- end }}
+        {{- if .Values.http_signatures }}
+        - name: http-signing-private-key
           readOnly: true
           mountPath: "/var/secrets"
         {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -7,6 +7,7 @@ serviceType: NodePort
 rbac: true
 securityContext: true
 basic_auth: false
+http_signatures: false
 
 faasnetes:
   image: openfaas/faas-netes:0.7.1

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -64,3 +64,68 @@ Now attempt to login with:
 ```
 echo -n $GW_PASS | faas-cli login --username=admin --password-stdin
 ```
+
+## 2.0 Enable Non-repudiation for asynchronous function callbacks
+
+To enable built-in Non-repudiation for asynchronous function callbacks: create secrets, 
+configure and mount the secrets to the gateway and queue worker.
+
+### 2.1 Create secrets:
+
+```
+rm signing.key > /dev/null 2>&1 || true && rm signing.key.pub > /dev/null 2>&1 || true
+ssh-keygen -t rsa -b 2048 -N "" -m PEM -f signing.key > /dev/null 2>&1
+openssl rsa -in ./signing.key -pubout -outform PEM -out signing.key.pub > /dev/null 2>&1
+
+kubectl create secret generic http-signing-private-key -n openfaas \
+    --from-file=http-signing-private-key=./signing.key
+
+kubectl create secret generic http-signing-public-key -n openfaas \
+    --from-file=http-signing-public-key=./signing.key.pub
+ 
+rm signing.key || true && rm signing.key.pub || true
+```
+
+### 2.2 Add volume mount to gateway
+
+```
+        volumeMounts:
+        - name: http-signing-public-key
+          readOnly: true
+          mountPath: "/etc/openfaas"
+```
+
+### 2.3 Add secrets as volumes to gateway
+
+```
+      volumes:
+      - name: http-signing-public-key
+        secret:
+          secretName: http-signing-public-key
+```
+
+
+### 2.4 Add volume mount to queue worker
+
+```
+        volumeMounts:
+        - name: http-signing-private-key
+          readOnly: true
+          mountPath: "/etc/openfaas"
+```
+
+### 2.5 Add secrets as volumes to queue worker
+
+```
+      volumes:
+      - name: http-signing-private-key
+        secret:
+          secretName: http-signing-private-key
+```
+
+Apply the changes to the gateway and queue worker(deployment only):
+
+```
+$ kubectl apply -f ./yaml/gateway-dep.yml
+$ kubectl apply -f ./yaml/queueworker-dep.yml
+```


### PR DESCRIPTION
## PRs that should be merged first: 
- [ ] https://github.com/openfaas/nats-queue-worker/pull/56
- [ ] https://github.com/openfaas/faas/pull/1101

## Description 
- Update helm charts to include option for enabling http signatures

- Updates kubernetes YAML manifest README.md to explain the steps
required to create and enable the secrets for the feature

- Updates helm charts README.md and templates with required steps to
enable the feature

### Tasks
- [x] Update README.md for kubernetes YAML manifests
- [x] Test README.md instructions for feature using kubernetes YAML manifests

- [x] Update README.md & templates for helm charts
- [x] Test README.md instructions for feature using helm charts



## How Has This Been Tested?
Detailed instructions on how this has been tested are in the sister PR https://github.com/openfaas/nats-queue-worker/pull/56

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
