### PR TITLE
Parameterize connector deployment name

### DIFF
--- a/chart/kafka-connector/README.md
+++ b/chart/kafka-connector/README.md
@@ -44,15 +44,15 @@ TBD
 
 Additional kafka-connector options in `values.yaml`.
 
-| Parameter          | Description                                                                            | Default                        |
-| ------------------ | -------------------------------------------------------------------------------------- | ------------------------------ |
-| `upstream_timeout` | Maximum timeout for upstream function call, must be a Go formatted duration string.    | `30s`                          |
-| `rebuild_interval` | Interval for rebuilding function to topic map, must be a Go formatted duration string. | `3s`                           |
-| `topics`           | Topics to which the connector will bind, provide as a comma-separated list.            | `faas-request`                 |
-| `gateway_url`      | The URL for the API gateway.                                                           | `http://gateway.openfaas:8080` |
-| `broker_host`      | location of the Kafka brokers.                                                         | `kafka`                        |
-| `print_response`   | Output the response of calling a function in the logs.                                 | `true`                         |
-| `fullnameOverride` | Override the name value used for the Connector Deployment object.                      | ``                             |
+| Parameter                | Description                                                                            | Default                        |
+| ------------------------ | -------------------------------------------------------------------------------------- | ------------------------------ |
+| `upstream_timeout`       | Maximum timeout for upstream function call, must be a Go formatted duration string.    | `30s`                          |
+| `rebuild_interval`       | Interval for rebuilding function to topic map, must be a Go formatted duration string. | `3s`                           |
+| `topics`                 | Topics to which the connector will bind, provide as a comma-separated list.            | `faas-request`                 |
+| `gateway_url`            | The URL for the API gateway.                                                           | `http://gateway.openfaas:8080` |
+| `broker_host`            | location of the Kafka brokers.                                                         | `kafka`                        |
+| `print_response`         | Output the response of calling a function in the logs.                                 | `true`                         |
+| `deploymentNameOverride` | Override the name value used for the Connector Deployment object.                      | ``                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 See values.yaml for detailed configuration.

--- a/chart/kafka-connector/README.md
+++ b/chart/kafka-connector/README.md
@@ -10,14 +10,14 @@ The [Kafka connector](https://github.com/openfaas-incubator/kafka-connector) bri
 
 - Install Kafka (dev/testing)
 
-    You can install [Apache Kafka](https://kafka.apache.org/) with the [wurstmeister Docker images](https://github.com/wurstmeister/kafka-docker) from the [kafka-connector repo](https://github.com/openfaas-incubator/kafka-connector).
+  You can install [Apache Kafka](https://kafka.apache.org/) with the [wurstmeister Docker images](https://github.com/wurstmeister/kafka-docker) from the [kafka-connector repo](https://github.com/openfaas-incubator/kafka-connector).
 
-    ```sh
-    $ git clone https://github.com/openfaas-incubator/kafka-connector
-    $ cd kafka-connector/yaml/kubernetes
-    $ kubectl apply -f \
-     kafka-broker-dep.yml,kafka-broker-svc.yml,zookeeper-dep.yaml,zookeeper-svc.yaml
-    ```
+  ```sh
+  $ git clone https://github.com/openfaas-incubator/kafka-connector
+  $ cd kafka-connector/yaml/kubernetes
+  $ kubectl apply -f \
+   kafka-broker-dep.yml,kafka-broker-svc.yml,zookeeper-dep.yaml,zookeeper-svc.yaml
+  ```
 
 - Install Kafka (production)
 
@@ -52,6 +52,7 @@ Additional kafka-connector options in `values.yaml`.
 | `gateway_url`      | The URL for the API gateway.                                                           | `http://gateway.openfaas:8080` |
 | `broker_host`      | location of the Kafka brokers.                                                         | `kafka`                        |
 | `print_response`   | Output the response of calling a function in the logs.                                 | `true`                         |
+| `fullnameOverride` | Override the name value used for the Connector Deployment object.                      | ``                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 See values.yaml for detailed configuration.

--- a/chart/kafka-connector/templates/_helpers.tpl
+++ b/chart/kafka-connector/templates/_helpers.tpl
@@ -12,8 +12,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "connector.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.deploymentNameOverride -}}
+{{- .Values.deploymentNameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}

--- a/chart/kafka-connector/templates/deployment.yml
+++ b/chart/kafka-connector/templates/deployment.yml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/part-of: openfaas
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: kafka-connector
+  name: {{ template "connector.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.replicas }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- use the fullname template helper instead of a constant.  This allows
the chart to be installed multiply times and the user can override the
value via the "fullnameOverride"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #400


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Observed the deployment name value changes to match the override when using `--dry-run` and `--debug` to deploy it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
