### PR TITLE
Add print_response_body

### DIFF
--- a/chart/kafka-connector/templates/deployment.yml
+++ b/chart/kafka-connector/templates/deployment.yml
@@ -43,9 +43,11 @@ spec:
             - name: gateway_url
               value: {{ .Values.gateway_url | quote }}
             - name: topics
-              value: {{ .Values.topics | quote}}
+              value: {{ .Values.topics | quote }}
             - name: print_response
-              value: {{ .Values.print_response |quote }}
+              value: {{ .Values.print_response | quote }}
+            - name: print_response_body
+              value: {{ .Values.print_response_body | quote }}
             {{- if .Values.basic_auth }}
             - name: basic_auth
               value: "true"

--- a/chart/kafka-connector/values.yaml
+++ b/chart/kafka-connector/values.yaml
@@ -3,6 +3,7 @@ replicas: 1
 gateway_url: http://gateway.openfaas:8080
 topics: faas-request
 print_response: true
+print_response_body: false
 broker_host: kafka
 basic_auth: true
 


### PR DESCRIPTION
Adding print_response_body to the values.yml
and updaing the deployment.yml file to read
the value set to true by default. Also
bumping the charts

Signed-off-by: Martin Dekov <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Deploying with charts would not give option to set output while reading
the kafka connector logs, this adds print_response_body value to values.yml
to enable the feature

## Description
<!--- Describe your changes in detail -->

Adding `print_response_body` to `values.yml` along with the field in `deployment.yml` to be red from the file. Bumping the charts in the process with `make charts`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Writing blog post which describes this and actually it is not feasible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Not sure if it is breaking?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
