### PR TITLE
Implement serviceAccount for functions

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -198,6 +198,16 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 	}
 
 	annotations := buildAnnotations(request)
+
+	var serviceAccount string
+
+	if request.Annotations != nil {
+		annotations := *request.Annotations
+		if val, ok := annotations["com.openfaas.serviceaccount"]; ok && len(val) > 0 {
+			serviceAccount = val
+		}
+	}
+
 	deploymentSpec := &v1beta1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -253,8 +263,9 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 							},
 						},
 					},
-					RestartPolicy: corev1.RestartPolicyAlways,
-					DNSPolicy:     corev1.DNSClusterFirst,
+					ServiceAccountName: serviceAccount,
+					RestartPolicy:      corev1.RestartPolicyAlways,
+					DNSPolicy:          corev1.DNSClusterFirst,
 				},
 			},
 		},

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -101,6 +101,17 @@ func updateDeploymentSpec(
 
 		deployment.Spec.Template.Spec.Containers[0].Resources = *resources
 
+		var serviceAccount string
+
+		if request.Annotations != nil {
+			annotations := *request.Annotations
+			if val, ok := annotations["com.openfaas.serviceaccount"]; ok && len(val) > 0 {
+				serviceAccount = val
+			}
+		}
+
+		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccount
+
 		existingSecrets, err := getSecrets(clientset, functionNamespace, request.Secrets)
 		if err != nil {
 			return err, http.StatusBadRequest


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change adds custom serviceAccount support for faas-netes
as per the equivalent change in the Operator:

https://github.com/openfaas-incubator/openfaas-operator/pull/77

The deploy and update handlers are updated to read and
set the serviceAccountName from the annotation:
"com.openfaas.serviceaccount". When the annotation is empty
then the default service account is set when the podSpec
is updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes: #409 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The same code is tested in the operator here: https://github.com/openfaas-incubator/openfaas-operator/pull/77

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
