### PR TITLE
Prepare for httpProbes

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -70,6 +70,8 @@ helm repo update \
 
 > The above command will also update your helm repo to pull in any new releases.
 
+If you want to switch from "exec" liveness and readiness probes to httpProbes then use `--set faasnetes.httpProbe=true`, this can only be used with `--set operator.create=false`.
+
 ### Verify the installation
 
 Once all the services are up and running, log into your gateway using the OpenFaaS CLI. This will cache your credentials into your `~/.openfaas/config.yml` file.
@@ -206,6 +208,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `operator.create` | Use the OpenFaaS operator CRD controller, default uses faas-netes as the Kubernetes controller | `false` |
 | `operator.createCRD` | Create the CRD for OpenFaaS Function definition | `true` |
 | `ingress.enabled` | Create ingress resources | `false` |
+| `faasnetes.httpProbe` | Use a httpProbe instead of exec | `false` |
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -71,7 +71,7 @@ ingress:
   enabled: false
   # Used to create Ingress record (should be used with exposeServices: false).
   hosts:
-    - host: gateway.openfaas.local
+    - host: gateway.openfaas.local  # Replace with gateway.example.com if public-facing
       serviceName: gateway
       servicePort: 8080
       path: /

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -225,3 +225,41 @@ func readOnlyRootEnabled(t *testing.T, deployment *v1beta1.Deployment) {
 		t.Error("should set ReadOnlyRootFilesystem to true on the container SecurityContext")
 	}
 }
+
+func Test_makeProbes_useExec(t *testing.T) {
+	cfg := DeployHandlerConfig{
+		HTTPProbe:                    false,
+		FunctionLivenessProbeConfig:  &FunctionProbeConfig{},
+		FunctionReadinessProbeConfig: &FunctionProbeConfig{},
+	}
+
+	probes := makeProbes(&cfg)
+
+	if probes.Readiness.Exec == nil {
+		t.Errorf("Readiness probe should have had exec handler")
+		t.Fail()
+	}
+	if probes.Liveness.Exec == nil {
+		t.Errorf("Liveness probe should have had exec handler")
+		t.Fail()
+	}
+}
+
+func Test_makeProbes_useHTTPProbe(t *testing.T) {
+	cfg := DeployHandlerConfig{
+		HTTPProbe:                    true,
+		FunctionLivenessProbeConfig:  &FunctionProbeConfig{},
+		FunctionReadinessProbeConfig: &FunctionProbeConfig{},
+	}
+
+	probes := makeProbes(&cfg)
+
+	if probes.Readiness.HTTPGet == nil {
+		t.Errorf("Readiness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Liveness.HTTPGet == nil {
+		t.Errorf("Liveness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+}

--- a/server.go
+++ b/server.go
@@ -41,6 +41,7 @@ func main() {
 
 	log.Printf("HTTP Read Timeout: %s\n", cfg.ReadTimeout)
 	log.Printf("HTTP Write Timeout: %s\n", cfg.WriteTimeout)
+	log.Printf("HTTPProbe: %v\n", cfg.HTTPProbe)
 
 	deployConfig := &handlers.DeployHandlerConfig{
 		HTTPProbe: cfg.HTTPProbe,
@@ -64,7 +65,7 @@ func main() {
 		FunctionReader: handlers.MakeFunctionReader(functionNamespace, clientset),
 		ReplicaReader:  handlers.MakeReplicaReader(functionNamespace, clientset),
 		ReplicaUpdater: handlers.MakeReplicaUpdater(functionNamespace, clientset),
-		UpdateHandler:  handlers.MakeUpdateHandler(functionNamespace, clientset),
+		UpdateHandler:  handlers.MakeUpdateHandler(functionNamespace, clientset, deployConfig),
 		Health:         handlers.MakeHealthHandler(),
 		InfoHandler:    handlers.MakeInfoHandler(version.BuildVersion(), version.GitCommit),
 		SecretHandler:  handlers.MakeSecretHandler(functionNamespace, clientset),


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prepare to switch to httpProbes and fix issues.

- httpProbe as an option is documented in the README

- In testing the update handler would not update the probe values
for deployments even if the controller was reloaded with new
config. This has been updated in the update handler.

- New method broken out for makeProbes to be used from
deploy/update.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes: #413

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Updated unit tests

* Scenario 1 - not updating the probes

Deployed faas-netes with current image and httpProbe=false, deployed cows. Then I updated the faas-netes deployment for httpProbe=true and redeployed cows, but the probes were not changed. With a new image from this PR this scenario was resolved.

* Scenario 2 - exec / http probes both work

In this example I tried toggling httpProbe on/off and was able to see it reflect in the function and the function was healthy. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
