### PR TITLE
Enable auth for YAML files

### DIFF
--- a/yaml/README.md
+++ b/yaml/README.md
@@ -9,7 +9,7 @@ One size doesn't fit all and for that reason it's strongly encouraged that you u
 ### 1.0 Create namespaces
 
 ```sh
-kubectl apply ./namespaces.yaml
+kubectl apply -f namespaces.yml
 ```
 
 ### 2.0 Create password
@@ -47,7 +47,8 @@ kubectl port-forward svc/gateway -n openfaas 31112:8080 &
 
 Now log-in:
 ```sh
-echo -n $PASSWORD faas-cli login --password-stdin
+echo -n $PASSWORD | faas-cli login --password-stdin
+
 faas-cli list
 
 Function                        Invocations     Replicas

--- a/yaml/alertmanager-cfg.yml
+++ b/yaml/alertmanager-cfg.yml
@@ -29,4 +29,7 @@ data:
       webhook_configs:
         - url: http://gateway.openfaas:8080/system/alert
           send_resolved: true
-
+          http_config:
+            basic_auth:
+              username: admin
+              password_file: /var/secrets/basic-auth-password

--- a/yaml/alertmanager-cfg.yml
+++ b/yaml/alertmanager-cfg.yml
@@ -18,12 +18,14 @@ data:
           service: gateway
           receiver: scale-up
           severity: major
+
     inhibit_rules:
     - source_match:
         severity: 'critical'
       target_match:
         severity: 'warning'
       equal: ['alertname', 'cluster', 'service']
+
     receivers:
     - name: 'scale-up'
       webhook_configs:

--- a/yaml/alertmanager-dep.yml
+++ b/yaml/alertmanager-dep.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: prom/alertmanager:v0.15.0
+        image: prom/alertmanager:v0.16.1
         imagePullPolicy: Always
         command: 
           - "alertmanager"
@@ -32,6 +32,9 @@ spec:
         - mountPath: /alertmanager.yml
           name: alertmanager-config
           subPath: alertmanager.yml
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
       volumes:
         - name: alertmanager-config
           configMap:
@@ -40,3 +43,6 @@ spec:
               - key: alertmanager.yml
                 path: alertmanager.yml
                 mode: 0644
+        - name: auth
+          secret:
+            secretName: basic-auth

--- a/yaml/gateway-dep.yml
+++ b/yaml/gateway-dep.yml
@@ -14,6 +14,10 @@ spec:
         app: gateway
     spec:
       serviceAccountName: faas-controller
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
       containers:
       - name: gateway
         image: openfaas/gateway:0.13.0
@@ -44,15 +48,19 @@ spec:
         - name: upstream_timeout  # Must be smaller than read/write_timeout
           value: "60s"
         - name: basic_auth
-          value: "false"
+          value: "true"
         - name: secret_mount_path
-          value: "/etc/openfaas"
+          value: "/var/secrets"
         - name: scale_from_zero
-          value: "false"
+          value: "true"
         - name: max_idle_conns
           value: "1024"
         - name: max_idle_conns_per_host
           value: "1024"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/yaml/prometheus-cfg.yml
+++ b/yaml/prometheus-cfg.yml
@@ -12,13 +12,16 @@ data:
       evaluation_interval: 15s
       external_labels:
           monitor: 'faas-monitor'
+
     rule_files:
         - 'alert.rules.yml'
+
     scrape_configs:
       - job_name: 'prometheus'
         scrape_interval: 5s
         static_configs:
           - targets: ['localhost:9090']
+
       - job_name: 'kubernetes-pods'
         scrape_interval: 5s
         honor_labels: false
@@ -44,26 +47,26 @@ data:
           regex: ([^:]+)(?::\d+)?;(\d+)
           replacement: $1:$2
           target_label: __address__
+
     alerting:
       alertmanagers:
       - static_configs:
         - targets:
-          - alertmanager.openfaas:9093
+          - alertmanager:9093
+
   alert.rules.yml: |
     groups:
-    - name: openfaas
-      rules:
-      - alert: service_down
-        expr: up == 0
-      - alert: APIHighInvocationRate
-        expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name)
-          > 5
-        for: 5s
-        labels:
-          service: gateway
-          severity: major
-          value: '{{$value}}'
-        annotations:
-          description: High invocation total on {{ $labels.instance }}
-          summary: High invocation total on {{ $labels.instance }}
+      - name: openfaas
+        rules:
+        - alert: service_down
+          expr: up == 0
+        - alert: APIHighInvocationRate
+          expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+          for: 5s
+          labels:
+            service: gateway
+            severity: major
+          annotations:
+            description: High invocation total on "{{$labels.function_name}}"
+            summary: High invocation total on "{{$labels.function_name}}"
 ---

--- a/yaml/prometheus-dep.yml
+++ b/yaml/prometheus-dep.yml
@@ -9,6 +9,8 @@ spec:
     metadata:
       labels:
         app: prometheus
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: openfaas-prometheus
       containers:

--- a/yaml/queueworker-dep.yml
+++ b/yaml/queueworker-dep.yml
@@ -28,7 +28,7 @@ spec:
         - name: secret_mount_path
           value: "/var/secrets"
         - name: basic_auth
-          value: "{{ .Values.basic_auth }}"
+          value: "true"
         volumeMounts:
         - name: auth
           readOnly: true

--- a/yaml/queueworker-dep.yml
+++ b/yaml/queueworker-dep.yml
@@ -10,6 +10,10 @@ spec:
       labels:
         app: queue-worker
     spec:
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
       containers:
       - name:  queue-worker
         image: openfaas/queue-worker:0.7.1
@@ -21,7 +25,12 @@ spec:
           value: "30s"
         - name: faas_function_suffix
           value: ".openfaas-fn.svc.cluster.local."  # absolute DNS will suppress search domains
-        - name: basic_auth
-          value: "false"
         - name: secret_mount_path
-          value: "/etc/openfaas"
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "{{ .Values.basic_auth }}"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+


### PR DESCRIPTION
This commit enables authentication for the plain, YAML development
files. The change is being made in response to people publishing
guides without reading the documentation and potentially
deploying OpenFaaS to a public-facing endpoint without
authentication enabled.

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
