### PR TITLE
Add support for setting the functions container user id

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 3.2.2
+version: 3.2.3
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 3.2.3
+version: 3.2.2
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -212,6 +212,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
+| `faasnetes.forceNonRootUser` | Force all function containers to run with user id `2000` | `false` |
 | `gateway.replicas` | Replicas of the gateway, pick more than `1` for HA | `1` |
 | `gateway.readTimeout` | Queue worker read timeout | `65s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `65s` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -212,7 +212,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
-| `faasnetes.setNonRooUser` | Force all function containers to run with user id `12000` | `false` |
+| `faasnetes.setNonRootUser` | Force all function containers to run with user id `12000` | `false` |
 | `gateway.replicas` | Replicas of the gateway, pick more than `1` for HA | `1` |
 | `gateway.readTimeout` | Queue worker read timeout | `65s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `65s` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -212,7 +212,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
-| `faasnetes.forceNonRootUser` | Force all function containers to run with user id `2000` | `false` |
+| `faasnetes.setNonRooUser` | Force all function containers to run with user id `2000` | `false` |
 | `gateway.replicas` | Replicas of the gateway, pick more than `1` for HA | `1` |
 | `gateway.readTimeout` | Queue worker read timeout | `65s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `65s` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -212,7 +212,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
-| `faasnetes.setNonRooUser` | Force all function containers to run with user id `2000` | `false` |
+| `faasnetes.setNonRooUser` | Force all function containers to run with user id `12000` | `false` |
 | `gateway.replicas` | Replicas of the gateway, pick more than `1` for HA | `1` |
 | `gateway.readTimeout` | Queue worker read timeout | `65s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `65s` |

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -138,8 +138,8 @@ spec:
           value: {{ .Values.faasnetes.imagePullPolicy | quote }}
         - name: http_probe
           value: "{{ .Values.faasnetes.httpProbe }}"
-        - name: force_nonroot_user
-          value: "{{ .Values.faasnetes.forceNonRootuser }}"
+        - name: set_nonroot_user
+          value: "{{ .Values.faasnetes.setNonRootuser }}"
         - name: readiness_probe_initial_delay_seconds
           value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
         - name: readiness_probe_timeout_seconds

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -138,6 +138,8 @@ spec:
           value: {{ .Values.faasnetes.imagePullPolicy | quote }}
         - name: http_probe
           value: "{{ .Values.faasnetes.httpProbe }}"
+        - name: force_nonroot_user
+          value: "{{ .Values.faasnetes.forceNonRootuser }}"
         - name: readiness_probe_initial_delay_seconds
           value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
         - name: readiness_probe_timeout_seconds

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -139,7 +139,7 @@ spec:
         - name: http_probe
           value: "{{ .Values.faasnetes.httpProbe }}"
         - name: set_nonroot_user
-          value: "{{ .Values.faasnetes.setNonRootuser }}"
+          value: "{{ .Values.faasnetes.setNonRootUser }}"
         - name: readiness_probe_initial_delay_seconds
           value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
         - name: readiness_probe_timeout_seconds

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -14,6 +14,7 @@ faasnetes:
   writeTimeout : "60s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
   httpProbe: false              # Setting to true will use a lock file for readiness and liveness (incompatible with Istio)
+  forceNonRootuser: false
   readinessProbe:
     initialDelaySeconds: 0
     timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -14,7 +14,7 @@ faasnetes:
   writeTimeout : "60s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
   httpProbe: false              # Setting to true will use a lock file for readiness and liveness (incompatible with Istio)
-  setNonRootuser: false
+  setNonRootUser: false
   readinessProbe:
     initialDelaySeconds: 0
     timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -14,7 +14,7 @@ faasnetes:
   writeTimeout : "60s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
   httpProbe: false              # Setting to true will use a lock file for readiness and liveness (incompatible with Istio)
-  forceNonRootuser: false
+  setNonRootuser: false
   readinessProbe:
     initialDelaySeconds: 0
     timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -62,9 +62,9 @@ type DeployHandlerConfig struct {
 	FunctionReadinessProbeConfig *FunctionProbeConfig
 	FunctionLivenessProbeConfig  *FunctionProbeConfig
 	ImagePullPolicy              string
-	// ForceNonRootUser will override the function image user to ensure that it is not root. When
+	// SetNonRootUser will override the function image user to ensure that it is not root. When
 	// true, the user will set to 2000 for all functions.
-	ForceNonRootUser bool
+	SetNonRootUser bool
 }
 
 // MakeDeployHandler creates a handler to create new functions in the cluster
@@ -491,11 +491,11 @@ func configureReadOnlyRootFilesystem(request requests.CreateFunctionRequest, dep
 }
 
 // configureContainerUserID set the UID for all containers in the function Container.  Defaults to user
-// specified in image metadata if `forceNonRoot` is `false`. Root == 0.
+// specified in image metadata if `SetNonRootUser` is `false`. Root == 0.
 func configureContainerUserID(deployment *v1beta1.Deployment, userID int64, config *DeployHandlerConfig) {
 	var functionUser *int64
 
-	if config.ForceNonRootUser {
+	if config.SetNonRootUser {
 		functionUser = &userID
 	}
 

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -31,8 +31,9 @@ const watchdogPort = 8080
 // initialReplicasCount how many replicas to start of creating for a function
 const initialReplicasCount = 1
 
-// nonRootFunctionuserID is the user id that is set when DeployHandlerConfig.ForceNonRootUser is true
-const nonRootFunctionuserID = 2000
+// nonRootFunctionuserID is the user id that is set when DeployHandlerConfig.SetNonRootUser is true.
+// value >10000 per the suggestion from https://kubesec.io/basics/containers-securitycontext-runasuser/
+const nonRootFunctionuserID = 12000
 
 // Regex for RFC-1123 validation:
 // 	k8s.io/kubernetes/pkg/util/validation/validation.go

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -63,7 +63,7 @@ type DeployHandlerConfig struct {
 	FunctionLivenessProbeConfig  *FunctionProbeConfig
 	ImagePullPolicy              string
 	// SetNonRootUser will override the function image user to ensure that it is not root. When
-	// true, the user will set to 2000 for all functions.
+	// true, the user will set to 12000 for all functions.
 	SetNonRootUser bool
 }
 

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -264,14 +264,14 @@ func Test_makeProbes_useHTTPProbe(t *testing.T) {
 	}
 }
 
-func Test_ForceNonRootUser(t *testing.T) {
+func Test_SetNonRootUser(t *testing.T) {
 
 	scenarios := []struct {
-		name         string
-		forceNonRoot bool
+		name       string
+		setNonRoot bool
 	}{
-		{"does not set userid value when ForceNonRootUser is false", false},
-		{"does set userid to constant value when ForceNonRootUser is true", true},
+		{"does not set userid value when SetNonRootUser is false", false},
+		{"does set userid to constant value when SetNonRootUser is true", true},
 	}
 
 	for _, s := range scenarios {
@@ -280,7 +280,7 @@ func Test_ForceNonRootUser(t *testing.T) {
 			cfg := &DeployHandlerConfig{
 				FunctionLivenessProbeConfig:  &FunctionProbeConfig{},
 				FunctionReadinessProbeConfig: &FunctionProbeConfig{},
-				ForceNonRootUser:             s.forceNonRoot,
+				SetNonRootUser:               s.setNonRoot,
 			}
 			deployment, err := makeDeploymentSpec(request, map[string]*apiv1.Secret{}, cfg)
 			if err != nil {
@@ -292,11 +292,11 @@ func Test_ForceNonRootUser(t *testing.T) {
 				t.Errorf("expected container %s to have a non-nil security context", functionContainer.Name)
 			}
 
-			if !s.forceNonRoot && functionContainer.SecurityContext.RunAsUser != nil {
+			if !s.setNonRoot && functionContainer.SecurityContext.RunAsUser != nil {
 				t.Errorf("expected RunAsUser to be nil, got %d", functionContainer.SecurityContext.RunAsUser)
 			}
 
-			if s.forceNonRoot && *functionContainer.SecurityContext.RunAsUser != nonRootFunctionuserID {
+			if s.setNonRoot && *functionContainer.SecurityContext.RunAsUser != nonRootFunctionuserID {
 				t.Errorf("expected RunAsUser to be %d, got %d", nonRootFunctionuserID, functionContainer.SecurityContext.RunAsUser)
 			}
 		})

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -263,3 +263,43 @@ func Test_makeProbes_useHTTPProbe(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func Test_ForceNonRootUser(t *testing.T) {
+
+	scenarios := []struct {
+		name         string
+		forceNonRoot bool
+	}{
+		{"does not set userid value when ForceNonRootUser is false", false},
+		{"does set userid to constant value when ForceNonRootUser is true", true},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			request := requests.CreateFunctionRequest{Service: "testfunc", Image: "alpine:latest"}
+			cfg := &DeployHandlerConfig{
+				FunctionLivenessProbeConfig:  &FunctionProbeConfig{},
+				FunctionReadinessProbeConfig: &FunctionProbeConfig{},
+				ForceNonRootUser:             s.forceNonRoot,
+			}
+			deployment, err := makeDeploymentSpec(request, map[string]*apiv1.Secret{}, cfg)
+			if err != nil {
+				t.Errorf("unexpected makeDeploymentSpec error: %s", err.Error())
+			}
+
+			functionContainer := deployment.Spec.Template.Spec.Containers[0]
+			if functionContainer.SecurityContext == nil {
+				t.Errorf("expected container %s to have a non-nil security context", functionContainer.Name)
+			}
+
+			if !s.forceNonRoot && functionContainer.SecurityContext.RunAsUser != nil {
+				t.Errorf("expected RunAsUser to be nil, got %d", functionContainer.SecurityContext.RunAsUser)
+			}
+
+			if s.forceNonRoot && *functionContainer.SecurityContext.RunAsUser != nonRootFunctionuserID {
+				t.Errorf("expected RunAsUser to be %d, got %d", nonRootFunctionuserID, functionContainer.SecurityContext.RunAsUser)
+			}
+		})
+	}
+
+}

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -71,6 +71,7 @@ func updateDeploymentSpec(
 		deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
 
 		configureReadOnlyRootFilesystem(request, deployment)
+		configureContainerUserID(deployment, nonRootFunctionuserID, config)
 
 		deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
 

--- a/server.go
+++ b/server.go
@@ -42,9 +42,11 @@ func main() {
 	log.Printf("HTTP Read Timeout: %s\n", cfg.ReadTimeout)
 	log.Printf("HTTP Write Timeout: %s\n", cfg.WriteTimeout)
 	log.Printf("HTTPProbe: %v\n", cfg.HTTPProbe)
+	log.Printf("ForceNonRootUser: %v\n", cfg.ForceNonRootUser)
 
 	deployConfig := &handlers.DeployHandlerConfig{
-		HTTPProbe: cfg.HTTPProbe,
+		HTTPProbe:        cfg.HTTPProbe,
+		ForceNonRootUser: cfg.ForceNonRootUser,
 		FunctionReadinessProbeConfig: &handlers.FunctionProbeConfig{
 			InitialDelaySeconds: int32(cfg.ReadinessProbeInitialDelaySeconds),
 			TimeoutSeconds:      int32(cfg.ReadinessProbeTimeoutSeconds),

--- a/server.go
+++ b/server.go
@@ -42,11 +42,11 @@ func main() {
 	log.Printf("HTTP Read Timeout: %s\n", cfg.ReadTimeout)
 	log.Printf("HTTP Write Timeout: %s\n", cfg.WriteTimeout)
 	log.Printf("HTTPProbe: %v\n", cfg.HTTPProbe)
-	log.Printf("ForceNonRootUser: %v\n", cfg.ForceNonRootUser)
+	log.Printf("SetNonRootUser: %v\n", cfg.SetNonRootUser)
 
 	deployConfig := &handlers.DeployHandlerConfig{
-		HTTPProbe:        cfg.HTTPProbe,
-		ForceNonRootUser: cfg.ForceNonRootUser,
+		HTTPProbe:      cfg.HTTPProbe,
+		SetNonRootUser: cfg.SetNonRootUser,
 		FunctionReadinessProbeConfig: &handlers.FunctionProbeConfig{
 			InitialDelaySeconds: int32(cfg.ReadinessProbeInitialDelaySeconds),
 			TimeoutSeconds:      int32(cfg.ReadinessProbeTimeoutSeconds),

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -71,7 +71,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg := BootstrapConfig{}
 
 	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
-	forceNonRootUser := parseBoolValue(hasEnv.Getenv("force_nonroot_user"), false)
+	setNonRootUser := parseBoolValue(hasEnv.Getenv("set_nonroot_user"), false)
 
 	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
 	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
@@ -90,7 +90,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg.WriteTimeout = writeTimeout
 
 	cfg.HTTPProbe = httpProbe
-	cfg.ForceNonRootUser = forceNonRootUser
+	cfg.SetNonRootUser = setNonRootUser
 
 	cfg.ReadinessProbeInitialDelaySeconds = readinessProbeInitialDelaySeconds
 	cfg.ReadinessProbeTimeoutSeconds = readinessProbeTimeoutSeconds
@@ -113,7 +113,7 @@ type BootstrapConfig struct {
 	// HTTPProbe when set to true switches readiness and liveness probe to
 	// access /_/health over HTTP instead of accessing /tmp/.lock.
 	HTTPProbe                         bool
-	ForceNonRootUser                  bool
+	SetNonRootUser                    bool
 	ReadinessProbeInitialDelaySeconds int
 	ReadinessProbeTimeoutSeconds      int
 	ReadinessProbePeriodSeconds       int

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -71,6 +71,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg := BootstrapConfig{}
 
 	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
+	forceNonRootUser := parseBoolValue(hasEnv.Getenv("force_nonroot_user"), false)
 
 	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
 	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
@@ -89,6 +90,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg.WriteTimeout = writeTimeout
 
 	cfg.HTTPProbe = httpProbe
+	cfg.ForceNonRootUser = forceNonRootUser
 
 	cfg.ReadinessProbeInitialDelaySeconds = readinessProbeInitialDelaySeconds
 	cfg.ReadinessProbeTimeoutSeconds = readinessProbeTimeoutSeconds
@@ -111,6 +113,7 @@ type BootstrapConfig struct {
 	// HTTPProbe when set to true switches readiness and liveness probe to
 	// access /_/health over HTTP instead of accessing /tmp/.lock.
 	HTTPProbe                         bool
+	ForceNonRootUser                  bool
 	ReadinessProbeInitialDelaySeconds int
 	ReadinessProbeTimeoutSeconds      int
 	ReadinessProbePeriodSeconds       int


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This allows the cluster admin to enforce that user containers do not run as the root user by setting the `RunAsUser` in the container's `SecurityContext`.

- Add new boolean configuration and parsing to enable the feature within
the faas-netes provider
- Update the helm chart to allow toggling the feature
- Add utility method for setting the `RunAsUser` value in the functions
container
- Check and set the user during deployment and update, add test for the
deployment method

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Partially supports #371

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test has been added and I have started testing it manually with various functions.

I have pushed a public docker image so that others can also test it

1. I used https://gist.github.com/LucasRoesler/c029f7b7446f7c051522b8edb456b703 to create an OpenFaaS installation in KinD.  
2. I then update the installation to use my dev image
```sh
export KUBECONFIG="$(kind get kubeconfig-path --name="devopenfaas")"
helm upgrade openfaas --install ./chart/openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set openfaasImagePullPolicy=IfNotPresent \
    --set faasnetes.imagePullPolicy=IfNotPresent \
    --set faasnetes.image=theaxer/faas-netes:forceRootUser \
    --set faasnetes.forceNonRootuser=true \
    --set functionNamespace=openfaas-fn
```
3. I then deployed the `nodeinfo` function via the CLI 
```sh
export GATEWAY=http://localhost:31112
faas-cli login --gateway=$GATEWAY -u admin -p tester
faas-cli store deploy nodeinfo --gateway=$GATEWAY
```
4. I verified that the web UI was working and showed the `nodeinfo` function as deployed
5. I verified that the function was working via the UI and via the CLI 
```sh
echo "" | faas-cli invoke nodeinfo --gateway=$GATEWAY
```
6. and, finally that the function deployment had the expected `runAsUser` value

```sh
export KUBECONFIG="$(kind get kubeconfig-path --name="devopenfaas")"
kubectl -n openfaas-fn get deploy nodeinfo -o yaml | grep runAsUser
```


I then ran the same sequence of steps but with the default `false` value for `forceNonRootUser`

```sh
export KUBECONFIG="$(kind get kubeconfig-path --name="devopenfaas")"
helm upgrade openfaas --install ./chart/openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set openfaasImagePullPolicy=IfNotPresent \
    --set faasnetes.imagePullPolicy=IfNotPresent \
    --set faasnetes.image=theaxer/faas-netes:forceRootUser \
    --set functionNamespace=openfaas-fn
```
This time, in the last step I check that the `securityContext` does not contain `runAsUser`.

ToDO:
1. verify secret support is not broken
2. verify the behavior of the function's temp directory when `ReadOnlyRootFilesystem` is enabled 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
