### PR TITLE
 Add support for setting the functions container user id

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -212,6 +212,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
+| `faasnetes.setNonRootUser` | Force all function containers to run with user id `12000` | `false` |
 | `gateway.replicas` | Replicas of the gateway, pick more than `1` for HA | `1` |
 | `gateway.readTimeout` | Queue worker read timeout | `65s` |
 | `gateway.writeTimeout` | Queue worker write timeout | `65s` |

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -138,6 +138,8 @@ spec:
           value: {{ .Values.faasnetes.imagePullPolicy | quote }}
         - name: http_probe
           value: "{{ .Values.faasnetes.httpProbe }}"
+        - name: set_nonroot_user
+          value: "{{ .Values.faasnetes.setNonRootUser }}"
         - name: readiness_probe_initial_delay_seconds
           value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
         - name: readiness_probe_timeout_seconds

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -14,6 +14,7 @@ faasnetes:
   writeTimeout : "60s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
   httpProbe: false              # Setting to true will use a lock file for readiness and liveness (incompatible with Istio)
+  setNonRootUser: false
   readinessProbe:
     initialDelaySeconds: 0
     timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -31,6 +31,10 @@ const watchdogPort = 8080
 // initialReplicasCount how many replicas to start of creating for a function
 const initialReplicasCount = 1
 
+// nonRootFunctionuserID is the user id that is set when DeployHandlerConfig.SetNonRootUser is true.
+// value >10000 per the suggestion from https://kubesec.io/basics/containers-securitycontext-runasuser/
+const nonRootFunctionuserID = 12000
+
 // Regex for RFC-1123 validation:
 // 	k8s.io/kubernetes/pkg/util/validation/validation.go
 var validDNS = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
@@ -58,6 +62,9 @@ type DeployHandlerConfig struct {
 	FunctionReadinessProbeConfig *FunctionProbeConfig
 	FunctionLivenessProbeConfig  *FunctionProbeConfig
 	ImagePullPolicy              string
+	// SetNonRootUser will override the function image user to ensure that it is not root. When
+	// true, the user will set to 12000 for all functions.
+	SetNonRootUser bool
 }
 
 // MakeDeployHandler creates a handler to create new functions in the cluster
@@ -287,6 +294,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 	}
 
 	configureReadOnlyRootFilesystem(request, deploymentSpec)
+	configureContainerUserID(deploymentSpec, nonRootFunctionuserID, config)
 
 	if err := UpdateSecrets(request, deploymentSpec, existingSecrets); err != nil {
 		return nil, err
@@ -480,4 +488,20 @@ func configureReadOnlyRootFilesystem(request requests.CreateFunctionRequest, dep
 				ReadOnly:  false},
 		)
 	}
+}
+
+// configureContainerUserID set the UID for all containers in the function Container.  Defaults to user
+// specified in image metadata if `SetNonRootUser` is `false`. Root == 0.
+func configureContainerUserID(deployment *v1beta1.Deployment, userID int64, config *DeployHandlerConfig) {
+	var functionUser *int64
+
+	if config.SetNonRootUser {
+		functionUser = &userID
+	}
+
+	if deployment.Spec.Template.Spec.Containers[0].SecurityContext == nil {
+		deployment.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
+	}
+
+	deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = functionUser
 }

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -71,6 +71,7 @@ func updateDeploymentSpec(
 		deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
 
 		configureReadOnlyRootFilesystem(request, deployment)
+		configureContainerUserID(deployment, nonRootFunctionuserID, config)
 
 		deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
 

--- a/server.go
+++ b/server.go
@@ -42,9 +42,11 @@ func main() {
 	log.Printf("HTTP Read Timeout: %s\n", cfg.ReadTimeout)
 	log.Printf("HTTP Write Timeout: %s\n", cfg.WriteTimeout)
 	log.Printf("HTTPProbe: %v\n", cfg.HTTPProbe)
+	log.Printf("SetNonRootUser: %v\n", cfg.SetNonRootUser)
 
 	deployConfig := &handlers.DeployHandlerConfig{
-		HTTPProbe: cfg.HTTPProbe,
+		HTTPProbe:      cfg.HTTPProbe,
+		SetNonRootUser: cfg.SetNonRootUser,
 		FunctionReadinessProbeConfig: &handlers.FunctionProbeConfig{
 			InitialDelaySeconds: int32(cfg.ReadinessProbeInitialDelaySeconds),
 			TimeoutSeconds:      int32(cfg.ReadinessProbeTimeoutSeconds),

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -71,6 +71,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg := BootstrapConfig{}
 
 	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
+	setNonRootUser := parseBoolValue(hasEnv.Getenv("set_nonroot_user"), false)
 
 	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
 	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
@@ -89,6 +90,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 	cfg.WriteTimeout = writeTimeout
 
 	cfg.HTTPProbe = httpProbe
+	cfg.SetNonRootUser = setNonRootUser
 
 	cfg.ReadinessProbeInitialDelaySeconds = readinessProbeInitialDelaySeconds
 	cfg.ReadinessProbeTimeoutSeconds = readinessProbeTimeoutSeconds
@@ -111,6 +113,7 @@ type BootstrapConfig struct {
 	// HTTPProbe when set to true switches readiness and liveness probe to
 	// access /_/health over HTTP instead of accessing /tmp/.lock.
 	HTTPProbe                         bool
+	SetNonRootUser                    bool
 	ReadinessProbeInitialDelaySeconds int
 	ReadinessProbeTimeoutSeconds      int
 	ReadinessProbePeriodSeconds       int


### PR DESCRIPTION
**What**
- Add new boolean configuration and parsing to enable the feature within
the faas-netes provider
- Update the helm chart to allow toggling the feature
- Add utility method for setting the `RunAsUser` value in the functions
container
- Check and set the user during deployment and update, add test for the
deployment method

**Why**
- This allows the cluster admin to enforce that user containers do not
run as the root user

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
