### PR TITLE
fix: a typo caused function would be create in namespace "openfaas"

### DIFF
--- a/yaml/gateway-dep.yml
+++ b/yaml/gateway-dep.yml
@@ -99,7 +99,7 @@ spec:
         - name: port
           value: "8081"
         - name: function_namespace
-          value: "openfaas"
+          value: "openfaas-fn"
         - name: read_timeout
           value: "60s"
         - name: write_timeout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the new function will be created in namespace "openfaas" but not in "oepnfaas-fn"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I rewrite the yaml file so that it can be created in "oepnfaas-fn"


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

not yet =w=

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
