### PR TITLE
Use go 1.11 in travis ci and fix kind install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-  - 1.10.x
+  - 1.11.x
 
 install:
   - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
@@ -33,7 +33,7 @@ after_success:
         export DOCKER_NS=openfaas;
         fi
 
-    - if [ ! -z "$TRAVIS_TAG" ] ; then 
+    - if [ ! -z "$TRAVIS_TAG" ] ; then
         docker tag $DOCKER_NS/faas-netes:latest $DOCKER_NS/faas-netes:$TRAVIS_TAG;
         echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
         docker push $DOCKER_NS/faas-netes:$TRAVIS_TAG;

--- a/contrib/get_kind.sh
+++ b/contrib/get_kind.sh
@@ -2,4 +2,5 @@
 
 echo "go get -u sigs.k8s.io/kind"
 
-go get -u sigs.k8s.io/kind
+export GO111MODULE="on"
+go get -u sigs.k8s.io/kind@0a6ceae


### PR DESCRIPTION
## Description
- Update the travis go version to 1.11.X so that we can use the module
support to install kind correctly.  It recently moved to modules and the
current install was breaking.  Additionally, we pin the kind install to
0a6ceae which matches the current HEAD on kind's master branch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
