### PR TITLE
Add security context to faas-netes container inside the gateway pod

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -137,6 +137,11 @@ spec:
             cpu: "50m"
         image: {{ .Values.faasnetes.image }}
         imagePullPolicy: {{ .Values.openFaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
         env:
         - name: port
           value: "8081"


### PR DESCRIPTION
Add security context to faas-netes container inside the gateway pod

## Description
In a production environment, all containers must be running as non root. At least one of the containers inside the gateway pod runs as root. So a change is required.

## Motivation and Context
Applying this pull request the `faas-netes` container will run as 10001 user id having a readonly filesystem.
Related issue can be found here: https://github.com/openfaas/faas-netes/issues/438

## How Has This Been Tested?
It has been tested on our platform, k8spin.cloud in a beta namespace. Detailed information could be found here: https://gitlab.com/k8spin-open/examples/openfaas

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
