### PR TITLE
Deploy basic-auth-plugin for faas-netes / operator

### DIFF
--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: basic-auth-plugin
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: basic-auth-plugin
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.basicAuthPlugin.replicas }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: basic-auth-plugin
+    spec:
+      {{- if .Values.basic_auth }}
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      {{- end }}
+      containers:
+      - name:  basic-auth-plugin
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "20m"
+        image: {{ .Values.basicAuthPlugin.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        env:
+        {{- if .Values.basic_auth }}
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "{{ .Values.basic_auth }}"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/chart/openfaas/templates/basic-auth-plugin-svc.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: basic-auth-plugin
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: basic-auth-plugin
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: basic-auth-plugin

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -88,6 +88,10 @@ spec:
           value: "true"
         - name: secret_mount_path
           value: "/var/secrets"
+        - name: auth_proxy_url
+          value: "http://basic-auth-plugin.{{ .Release.Namespace }}:8080/validate"
+        - name: auth_pass_body
+          value: "false"
         {{- end }}
         - name: scale_from_zero
           value: "{{ .Values.gateway.scaleFromZero }}"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -25,7 +25,7 @@ faasnetes:
     periodSeconds: 10
 
 gateway:
-  image: openfaas/gateway:0.13.0
+  image: openfaas/gateway:0.13.6
   readTimeout : "65s"
   writeTimeout : "65s"
   upstreamTimeout : "60s"  # Must be smaller than read/write_timeout
@@ -90,6 +90,10 @@ faasIdler:
   inactivityDuration: 15m               # If a function is inactive for 15 minutes, it may be scaled to zero
   reconcileInterval: 1m                 # The interval between each attempt to scale functions to zero
   dryRun: true                          # Set to true to enable the idler to apply changes and scale to zero
+
+basicAuthPlugin:
+  replicas: 1
+  image: openfaas/basic-auth-plugin:0.1.0
 
 nodeSelector: {}
 

--- a/yaml/basic-auth-plugin-dep.yml
+++ b/yaml/basic-auth-plugin-dep.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    component: basic-auth-plugin
+  name: basic-auth-plugin
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: basic-auth-plugin
+    spec:
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      containers:
+      - name:  basic-auth-plugin
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "20m"
+        image: openfaas/basic-auth-plugin:0.1.0
+        imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        env:
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "true"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP

--- a/yaml/basic-auth-plugin-svc.yml
+++ b/yaml/basic-auth-plugin-svc.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    component: basic-auth-plugin
+  name: basic-auth-plugin
+  namespace: "openfaas"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: basic-auth-plugin

--- a/yaml/gateway-dep.yml
+++ b/yaml/gateway-dep.yml
@@ -74,6 +74,10 @@ spec:
           value: "true"
         - name: secret_mount_path
           value: "/var/secrets"
+        - name: auth_proxy_url
+          value: "http://basic-auth-plugin.openfaas:8080/validate"
+        - name: auth_pass_body
+          value: "false"
         - name: scale_from_zero
           value: "true"
         - name: max_idle_conns


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit adds the basic-auth-plugin dependency, but does not
make use of it as of yet. When the new version is available of
the gateway, we will simply need to bump the gateway version
to enable it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/openfaas/faas/issues/1209

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make charts` and applying to a fresh cluster.

The auth service started and I could port-forward it and receive a 200 / 401.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide