### PR TITLE
Refactor health-check probes and allow custom path and duration

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -199,7 +199,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 							Name:  request.Service,
 							Image: request.Image,
 							Ports: []apiv1.ContainerPort{
-								{ContainerPort: factory.Config.WatchdogPort, Protocol: corev1.ProtocolTCP},
+								{ContainerPort: factory.Config.RuntimeHTTPPort, Protocol: corev1.ProtocolTCP},
 							},
 							Env:             envVars,
 							Resources:       *resources,
@@ -249,10 +249,10 @@ func makeServiceSpec(request requests.CreateFunctionRequest, factory k8s.Functio
 				{
 					Name:     "http",
 					Protocol: corev1.ProtocolTCP,
-					Port:     factory.Config.WatchdogPort,
+					Port:     factory.Config.RuntimeHTTPPort,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
-						IntVal: factory.Config.WatchdogPort,
+						IntVal: factory.Config.RuntimeHTTPPort,
 					},
 				},
 			},

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -41,7 +41,7 @@ func ValidateDeployRequest(request *requests.CreateFunctionRequest) error {
 }
 
 // MakeDeployHandler creates a handler to create new functions in the cluster
-func MakeDeployHandler(functionNamespace string, factory k8s.Factory) http.HandlerFunc {
+func MakeDeployHandler(functionNamespace string, factory k8s.FunctionFactory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
@@ -106,7 +106,7 @@ func MakeDeployHandler(functionNamespace string, factory k8s.Factory) http.Handl
 	}
 }
 
-func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets map[string]*apiv1.Secret, factory k8s.Factory) (*appsv1.Deployment, error) {
+func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets map[string]*apiv1.Secret, factory k8s.FunctionFactory) (*appsv1.Deployment, error) {
 	envVars := buildEnvVars(&request)
 
 	initialReplicas := int32p(initialReplicasCount)
@@ -229,7 +229,7 @@ func makeDeploymentSpec(request requests.CreateFunctionRequest, existingSecrets 
 	return deploymentSpec, nil
 }
 
-func makeServiceSpec(request requests.CreateFunctionRequest, factory k8s.Factory) *corev1.Service {
+func makeServiceSpec(request requests.CreateFunctionRequest, factory k8s.FunctionFactory) *corev1.Service {
 
 	serviceSpec := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -6,131 +6,8 @@ import (
 	"testing"
 
 	"github.com/openfaas/faas/gateway/requests"
-	appsv1 "k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
 )
-
-func Test_configureReadOnlyRootFilesystem_Disabled_To_Disabled(t *testing.T) {
-	deployment := &appsv1.Deployment{
-		Spec: appsv1.DeploymentSpec{
-			Template: apiv1.PodTemplateSpec{
-				Spec: apiv1.PodSpec{
-					Containers: []apiv1.Container{
-						{Name: "testfunc", Image: "alpine:latest"},
-					},
-				},
-			},
-		},
-	}
-
-	request := requests.CreateFunctionRequest{
-		Service:                "testfunc",
-		ReadOnlyRootFilesystem: false,
-	}
-
-	configureReadOnlyRootFilesystem(request, deployment)
-	readOnlyRootDisabled(t, deployment)
-}
-
-func Test_configureReadOnlyRootFilesystem_Disabled_To_Enabled(t *testing.T) {
-	deployment := &appsv1.Deployment{
-		Spec: appsv1.DeploymentSpec{
-			Template: apiv1.PodTemplateSpec{
-				Spec: apiv1.PodSpec{
-					Containers: []apiv1.Container{
-						{Name: "testfunc", Image: "alpine:latest"},
-					},
-				},
-			},
-		},
-	}
-
-	request := requests.CreateFunctionRequest{
-		Service:                "testfunc",
-		ReadOnlyRootFilesystem: true,
-	}
-
-	configureReadOnlyRootFilesystem(request, deployment)
-	readOnlyRootEnabled(t, deployment)
-}
-
-func Test_configureReadOnlyRootFilesystem_Enabled_To_Disabled(t *testing.T) {
-	trueValue := true
-	deployment := &appsv1.Deployment{
-		Spec: appsv1.DeploymentSpec{
-			Template: apiv1.PodTemplateSpec{
-				Spec: apiv1.PodSpec{
-					Containers: []apiv1.Container{
-						{
-							Name:  "testfunc",
-							Image: "alpine:latest",
-							SecurityContext: &apiv1.SecurityContext{
-								ReadOnlyRootFilesystem: &trueValue,
-							},
-							VolumeMounts: []apiv1.VolumeMount{
-								{Name: "temp", MountPath: "/tmp", ReadOnly: false},
-							},
-						},
-					},
-					Volumes: []apiv1.Volume{
-						{
-							Name: "temp",
-							VolumeSource: apiv1.VolumeSource{
-								EmptyDir: &apiv1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	request := requests.CreateFunctionRequest{
-		Service:                "testfunc",
-		ReadOnlyRootFilesystem: false,
-	}
-	configureReadOnlyRootFilesystem(request, deployment)
-	readOnlyRootDisabled(t, deployment)
-}
-
-func Test_configureReadOnlyRootFilesystem_Enabled_To_Enabled(t *testing.T) {
-	trueValue := true
-	deployment := &appsv1.Deployment{
-		Spec: appsv1.DeploymentSpec{
-			Template: apiv1.PodTemplateSpec{
-				Spec: apiv1.PodSpec{
-					Containers: []apiv1.Container{
-						{
-							Name:  "testfunc",
-							Image: "alpine:latest",
-							SecurityContext: &apiv1.SecurityContext{
-								ReadOnlyRootFilesystem: &trueValue,
-							},
-							VolumeMounts: []apiv1.VolumeMount{
-								{Name: "temp", MountPath: "/tmp", ReadOnly: false},
-							},
-						},
-					},
-					Volumes: []apiv1.Volume{
-						{
-							Name: "temp",
-							VolumeSource: apiv1.VolumeSource{
-								EmptyDir: &apiv1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	request := requests.CreateFunctionRequest{
-		Service:                "testfunc",
-		ReadOnlyRootFilesystem: true,
-	}
-	configureReadOnlyRootFilesystem(request, deployment)
-	readOnlyRootEnabled(t, deployment)
-}
 
 func Test_buildAnnotations_Empty_In_CreateRequest(t *testing.T) {
 	request := requests.CreateFunctionRequest{}
@@ -175,59 +52,6 @@ func Test_buildAnnotations_From_CreateRequest(t *testing.T) {
 	}
 }
 
-func readOnlyRootDisabled(t *testing.T, deployment *appsv1.Deployment) {
-	if len(deployment.Spec.Template.Spec.Volumes) != 0 {
-		t.Error("Volumes should be empty if ReadOnlyRootFilesystem is false")
-	}
-
-	if len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts) != 0 {
-		t.Error("VolumeMounts should be empty if ReadOnlyRootFilesystem is false")
-	}
-	functionContatiner := deployment.Spec.Template.Spec.Containers[0]
-
-	if functionContatiner.SecurityContext != nil {
-		if *functionContatiner.SecurityContext.ReadOnlyRootFilesystem != false {
-			t.Error("ReadOnlyRootFilesystem should be false on the container SecurityContext")
-		}
-	}
-}
-
-func readOnlyRootEnabled(t *testing.T, deployment *appsv1.Deployment) {
-	if len(deployment.Spec.Template.Spec.Volumes) != 1 {
-		t.Error("should create a single tmp Volume")
-	}
-
-	if len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts) != 1 {
-		t.Error("should create a single tmp VolumeMount")
-	}
-
-	volume := deployment.Spec.Template.Spec.Volumes[0]
-	if volume.Name != "temp" {
-		t.Error("volume should be named temp")
-	}
-
-	mount := deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0]
-	if mount.Name != "temp" {
-		t.Error("volume mount should be named temp")
-	}
-
-	if mount.MountPath != "/tmp" {
-		t.Error("temp volume should be mounted to /tmp")
-	}
-
-	if mount.ReadOnly {
-		t.Errorf("temp mount should not read only")
-	}
-
-	if deployment.Spec.Template.Spec.Containers[0].SecurityContext == nil {
-		t.Error("container security context should not be nil")
-	}
-
-	if *deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem != true {
-		t.Error("should set ReadOnlyRootFilesystem to true on the container SecurityContext")
-	}
-}
-
 func Test_SetNonRootUser(t *testing.T) {
 
 	scenarios := []struct {
@@ -260,8 +84,8 @@ func Test_SetNonRootUser(t *testing.T) {
 				t.Errorf("expected RunAsUser to be nil, got %d", functionContainer.SecurityContext.RunAsUser)
 			}
 
-			if s.setNonRoot && *functionContainer.SecurityContext.RunAsUser != nonRootFunctionuserID {
-				t.Errorf("expected RunAsUser to be %d, got %d", nonRootFunctionuserID, functionContainer.SecurityContext.RunAsUser)
+			if s.setNonRoot && *functionContainer.SecurityContext.RunAsUser != k8s.SecurityContextUserID {
+				t.Errorf("expected RunAsUser to be %d, got %d", k8s.SecurityContextUserID, functionContainer.SecurityContext.RunAsUser)
 			}
 		})
 	}

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -65,7 +65,7 @@ func Test_SetNonRootUser(t *testing.T) {
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
 			request := requests.CreateFunctionRequest{Service: "testfunc", Image: "alpine:latest"}
-			factory := k8s.NewFactory(fake.NewSimpleClientset(), k8s.DeploymentConfig{
+			factory := k8s.NewFunctionFactory(fake.NewSimpleClientset(), k8s.DeploymentConfig{
 				LivenessProbe:  &k8s.ProbeConfig{},
 				ReadinessProbe: &k8s.ProbeConfig{},
 				SetNonRootUser: s.setNonRoot,

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -17,6 +17,9 @@ import (
 	"github.com/openfaas/faas/gateway/requests"
 )
 
+// watchdogPort for the OpenFaaS function watchdog
+const watchdogPort = 8080
+
 // MakeProxy creates a proxy for HTTP web requests which can be routed to a function.
 func MakeProxy(functionNamespace string, timeout time.Duration) http.HandlerFunc {
 	proxyClient := http.Client{

--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -173,7 +173,7 @@ func parseSecret(namespace string, r io.Reader) (*apiv1.Secret, error) {
 }
 
 // getSecrets queries Kubernetes for a list of secrets by name in the given k8s namespace.
-func getSecrets(clientset *kubernetes.Clientset, namespace string, secretNames []string) (map[string]*apiv1.Secret, error) {
+func getSecrets(clientset kubernetes.Interface, namespace string, secretNames []string) (map[string]*apiv1.Secret, error) {
 	secrets := map[string]*apiv1.Secret{}
 
 	for _, secretName := range secretNames {

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openfaas/faas-netes/k8s"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -10,11 +11,10 @@ import (
 
 	"github.com/openfaas/faas/gateway/requests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // MakeUpdateHandler update specified function
-func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset, config *DeployHandlerConfig) http.HandlerFunc {
+func MakeUpdateHandler(functionNamespace string, factory k8s.Factory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		defer r.Body.Close()
@@ -29,12 +29,12 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 		}
 
 		annotations := buildAnnotations(request)
-		if err, status := updateDeploymentSpec(functionNamespace, clientset, request, annotations, config); err != nil {
+		if err, status := updateDeploymentSpec(functionNamespace, factory, request, annotations); err != nil {
 			w.WriteHeader(status)
 			w.Write([]byte(err.Error()))
 		}
 
-		if err, status := updateService(functionNamespace, clientset, request, annotations); err != nil {
+		if err, status := updateService(functionNamespace, factory, request, annotations); err != nil {
 			w.WriteHeader(status)
 			w.Write([]byte(err.Error()))
 		}
@@ -45,14 +45,13 @@ func MakeUpdateHandler(functionNamespace string, clientset *kubernetes.Clientset
 
 func updateDeploymentSpec(
 	functionNamespace string,
-	clientset *kubernetes.Clientset,
+	factory k8s.Factory,
 	request requests.CreateFunctionRequest,
-	annotations map[string]string,
-	config *DeployHandlerConfig) (err error, httpStatus int) {
+	annotations map[string]string) (err error, httpStatus int) {
 
 	getOpts := metav1.GetOptions{}
 
-	deployment, findDeployErr := clientset.AppsV1beta2().
+	deployment, findDeployErr := factory.Client.AppsV1beta2().
 		Deployments(functionNamespace).
 		Get(request.Service, getOpts)
 
@@ -71,7 +70,7 @@ func updateDeploymentSpec(
 		deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
 
 		configureReadOnlyRootFilesystem(request, deployment)
-		configureContainerUserID(deployment, nonRootFunctionuserID, config)
+		configureContainerUserID(deployment, nonRootFunctionuserID, factory.Config)
 
 		deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
 
@@ -115,7 +114,7 @@ func updateDeploymentSpec(
 
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccount
 
-		existingSecrets, err := getSecrets(clientset, functionNamespace, request.Secrets)
+		existingSecrets, err := getSecrets(factory.Client, functionNamespace, request.Secrets)
 		if err != nil {
 			return err, http.StatusBadRequest
 		}
@@ -126,12 +125,16 @@ func updateDeploymentSpec(
 			return err, http.StatusBadRequest
 		}
 
-		probes := makeProbes(config)
+		probes, err := factory.MakeProbes(request)
+		if err != nil {
+			return err, http.StatusBadRequest
+		}
+
 		deployment.Spec.Template.Spec.Containers[0].LivenessProbe = probes.Liveness
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = probes.Readiness
 	}
 
-	if _, updateErr := clientset.AppsV1beta2().
+	if _, updateErr := factory.Client.AppsV1beta2().
 		Deployments(functionNamespace).
 		Update(deployment); updateErr != nil {
 
@@ -143,13 +146,13 @@ func updateDeploymentSpec(
 
 func updateService(
 	functionNamespace string,
-	clientset *kubernetes.Clientset,
+	factory k8s.Factory,
 	request requests.CreateFunctionRequest,
 	annotations map[string]string) (err error, httpStatus int) {
 
 	getOpts := metav1.GetOptions{}
 
-	service, findServiceErr := clientset.CoreV1().
+	service, findServiceErr := factory.Client.CoreV1().
 		Services(functionNamespace).
 		Get(request.Service, getOpts)
 
@@ -159,7 +162,7 @@ func updateService(
 
 	service.Annotations = annotations
 
-	if _, updateErr := clientset.CoreV1().
+	if _, updateErr := factory.Client.CoreV1().
 		Services(functionNamespace).
 		Update(service); updateErr != nil {
 

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MakeUpdateHandler update specified function
-func MakeUpdateHandler(functionNamespace string, factory k8s.Factory) http.HandlerFunc {
+func MakeUpdateHandler(functionNamespace string, factory k8s.FunctionFactory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		defer r.Body.Close()
@@ -45,7 +45,7 @@ func MakeUpdateHandler(functionNamespace string, factory k8s.Factory) http.Handl
 
 func updateDeploymentSpec(
 	functionNamespace string,
-	factory k8s.Factory,
+	factory k8s.FunctionFactory,
 	request requests.CreateFunctionRequest,
 	annotations map[string]string) (err error, httpStatus int) {
 
@@ -146,7 +146,7 @@ func updateDeploymentSpec(
 
 func updateService(
 	functionNamespace string,
-	factory k8s.Factory,
+	factory k8s.FunctionFactory,
 	request requests.CreateFunctionRequest,
 	annotations map[string]string) (err error, httpStatus int) {
 

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -69,8 +69,8 @@ func updateDeploymentSpec(
 
 		deployment.Spec.Template.Spec.Containers[0].Env = buildEnvVars(&request)
 
-		configureReadOnlyRootFilesystem(request, deployment)
-		configureContainerUserID(deployment, nonRootFunctionuserID, factory.Config)
+		factory.ConfigureReadOnlyRootFilesystem(request, deployment)
+		factory.ConfigureContainerUserID(deployment)
 
 		deployment.Spec.Template.Spec.NodeSelector = createSelector(request.Constraints)
 

--- a/k8s/config.go
+++ b/k8s/config.go
@@ -1,0 +1,20 @@
+package k8s
+
+// ProbeConfig holds the deployment liveness and readiness options
+type ProbeConfig struct {
+	InitialDelaySeconds int32
+	TimeoutSeconds      int32
+	PeriodSeconds       int32
+}
+
+// DeploymentConfig holds the global deployment options
+type DeploymentConfig struct {
+	Port            int
+	HTTPProbe       bool
+	ReadinessProbe  *ProbeConfig
+	LivenessProbe   *ProbeConfig
+	ImagePullPolicy string
+	// SetNonRootUser will override the function image user to ensure that it is not root. When
+	// true, the user will set to 12000 for all functions.
+	SetNonRootUser bool
+}

--- a/k8s/config.go
+++ b/k8s/config.go
@@ -12,7 +12,7 @@ type ProbeConfig struct {
 
 // DeploymentConfig holds the global deployment options
 type DeploymentConfig struct {
-	WatchdogPort    int32
+	RuntimeHTTPPort int32
 	HTTPProbe       bool
 	ReadinessProbe  *ProbeConfig
 	LivenessProbe   *ProbeConfig

--- a/k8s/config.go
+++ b/k8s/config.go
@@ -9,7 +9,7 @@ type ProbeConfig struct {
 
 // DeploymentConfig holds the global deployment options
 type DeploymentConfig struct {
-	Port            int
+	WatchdogPort    int32
 	HTTPProbe       bool
 	ReadinessProbe  *ProbeConfig
 	LivenessProbe   *ProbeConfig

--- a/k8s/config.go
+++ b/k8s/config.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 // ProbeConfig holds the deployment liveness and readiness options

--- a/k8s/factory.go
+++ b/k8s/factory.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import (

--- a/k8s/factory.go
+++ b/k8s/factory.go
@@ -7,14 +7,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// Factory is handling Kubernetes operations to materialise functions into deployments and services
-type Factory struct {
+// FunctionFactory is handling Kubernetes operations to materialise functions into deployments and services
+type FunctionFactory struct {
 	Client kubernetes.Interface
 	Config DeploymentConfig
 }
 
-func NewFactory(clientset kubernetes.Interface, config DeploymentConfig) Factory {
-	return Factory{
+func NewFunctionFactory(clientset kubernetes.Interface, config DeploymentConfig) FunctionFactory {
+	return FunctionFactory{
 		Client: clientset,
 		Config: config,
 	}

--- a/k8s/factory.go
+++ b/k8s/factory.go
@@ -1,0 +1,18 @@
+package k8s
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+// Factory is handling Kubernetes operations to materialise functions into deployments and services
+type Factory struct {
+	Client kubernetes.Interface
+	Config DeploymentConfig
+}
+
+func NewFactory(clientset kubernetes.Interface, config DeploymentConfig) Factory {
+	return Factory{
+		Client: clientset,
+		Config: config,
+	}
+}

--- a/k8s/factory_test.go
+++ b/k8s/factory_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import "k8s.io/client-go/kubernetes/fake"

--- a/k8s/factory_test.go
+++ b/k8s/factory_test.go
@@ -5,8 +5,8 @@ package k8s
 
 import "k8s.io/client-go/kubernetes/fake"
 
-func mockFactory() Factory {
-	return NewFactory(fake.NewSimpleClientset(),
+func mockFactory() FunctionFactory {
+	return NewFunctionFactory(fake.NewSimpleClientset(),
 		DeploymentConfig{
 			HTTPProbe: false,
 			LivenessProbe: &ProbeConfig{

--- a/k8s/factory_test.go
+++ b/k8s/factory_test.go
@@ -1,0 +1,20 @@
+package k8s
+
+import "k8s.io/client-go/kubernetes/fake"
+
+func mockFactory() Factory {
+	return NewFactory(fake.NewSimpleClientset(),
+		DeploymentConfig{
+			HTTPProbe: false,
+			LivenessProbe: &ProbeConfig{
+				PeriodSeconds:       1,
+				TimeoutSeconds:      3,
+				InitialDelaySeconds: 0,
+			},
+			ReadinessProbe: &ProbeConfig{
+				PeriodSeconds:       1,
+				TimeoutSeconds:      3,
+				InitialDelaySeconds: 0,
+			},
+		})
+}

--- a/k8s/probes.go
+++ b/k8s/probes.go
@@ -50,7 +50,7 @@ func (f *FunctionFactory) MakeProbes(r requests.CreateFunctionRequest) (*Functio
 				Path: httpPath,
 				Port: intstr.IntOrString{
 					Type:   intstr.Int,
-					IntVal: int32(f.Config.WatchdogPort),
+					IntVal: int32(f.Config.RuntimeHTTPPort),
 				},
 			},
 		}

--- a/k8s/probes.go
+++ b/k8s/probes.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	"fmt"
+	"github.com/openfaas/faas/gateway/requests"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"path/filepath"
+	"time"
+)
+
+const (
+	ProbePath         = "com.openfaas.health.http.path"
+	ProbeInitialDelay = "com.openfaas.health.http.initialDelay"
+)
+
+type FunctionProbes struct {
+	Liveness  *corev1.Probe
+	Readiness *corev1.Probe
+}
+
+func (f *Factory) MakeProbes(r requests.CreateFunctionRequest) (*FunctionProbes, error) {
+	var handler corev1.Handler
+	httpPath := "/_/health"
+	initialDelaySeconds := int32(f.Config.LivenessProbe.InitialDelaySeconds)
+
+	if r.Annotations != nil {
+		annotations := *r.Annotations
+		if path, ok := annotations[ProbePath]; ok {
+			httpPath = path
+		}
+		if delay, ok := annotations[ProbeInitialDelay]; ok {
+			d, err := time.ParseDuration(delay)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s duration format: %v", ProbeInitialDelay, err)
+			}
+			initialDelaySeconds = int32(d.Seconds())
+		}
+	}
+
+	if f.Config.HTTPProbe {
+		handler = corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: httpPath,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: int32(f.Config.Port),
+				},
+			},
+		}
+	} else {
+		path := filepath.Join("/tmp/", ".lock")
+		handler = corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"cat", path},
+			},
+		}
+	}
+
+	probes := FunctionProbes{}
+	probes.Readiness = &corev1.Probe{
+		Handler:             handler,
+		InitialDelaySeconds: initialDelaySeconds,
+		TimeoutSeconds:      int32(f.Config.ReadinessProbe.TimeoutSeconds),
+		PeriodSeconds:       int32(f.Config.ReadinessProbe.PeriodSeconds),
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+
+	probes.Liveness = &corev1.Probe{
+		Handler:             handler,
+		InitialDelaySeconds: initialDelaySeconds,
+		TimeoutSeconds:      int32(f.Config.LivenessProbe.TimeoutSeconds),
+		PeriodSeconds:       int32(f.Config.LivenessProbe.PeriodSeconds),
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+
+	return &probes, nil
+}

--- a/k8s/probes.go
+++ b/k8s/probes.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import (

--- a/k8s/probes.go
+++ b/k8s/probes.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	ProbePath         = "com.openfaas.health.http.path"
+	ProbePathValue    = "/_/health"
 	ProbeInitialDelay = "com.openfaas.health.http.initialDelay"
 )
 
@@ -19,9 +20,11 @@ type FunctionProbes struct {
 	Readiness *corev1.Probe
 }
 
+// MakeProbes returns the liveness and readiness probes
+// by default the health check runs `cat /tmp/.lock` every ten seconds
 func (f *Factory) MakeProbes(r requests.CreateFunctionRequest) (*FunctionProbes, error) {
 	var handler corev1.Handler
-	httpPath := "/_/health"
+	httpPath := ProbePathValue
 	initialDelaySeconds := int32(f.Config.LivenessProbe.InitialDelaySeconds)
 
 	if r.Annotations != nil {
@@ -38,7 +41,7 @@ func (f *Factory) MakeProbes(r requests.CreateFunctionRequest) (*FunctionProbes,
 		}
 	}
 
-	if f.Config.HTTPProbe {
+	if f.Config.HTTPProbe || httpPath != ProbePathValue {
 		handler = corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: httpPath,

--- a/k8s/probes.go
+++ b/k8s/probes.go
@@ -25,7 +25,7 @@ type FunctionProbes struct {
 
 // MakeProbes returns the liveness and readiness probes
 // by default the health check runs `cat /tmp/.lock` every ten seconds
-func (f *Factory) MakeProbes(r requests.CreateFunctionRequest) (*FunctionProbes, error) {
+func (f *FunctionFactory) MakeProbes(r requests.CreateFunctionRequest) (*FunctionProbes, error) {
 	var handler corev1.Handler
 	httpPath := ProbePathValue
 	initialDelaySeconds := int32(f.Config.LivenessProbe.InitialDelaySeconds)

--- a/k8s/probes.go
+++ b/k8s/probes.go
@@ -44,7 +44,7 @@ func (f *Factory) MakeProbes(r requests.CreateFunctionRequest) (*FunctionProbes,
 				Path: httpPath,
 				Port: intstr.IntOrString{
 					Type:   intstr.Int,
-					IntVal: int32(f.Config.Port),
+					IntVal: int32(f.Config.WatchdogPort),
 				},
 			},
 		}

--- a/k8s/probes_test.go
+++ b/k8s/probes_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import (

--- a/k8s/probes_test.go
+++ b/k8s/probes_test.go
@@ -54,7 +54,6 @@ func Test_makeProbes_useHTTPProbe(t *testing.T) {
 
 func Test_makeProbes_useCustomHTTPProbe(t *testing.T) {
 	f := mockFactory()
-	f.Config.HTTPProbe = true
 	customPath := "/healthz"
 	request := requests.CreateFunctionRequest{
 		Service:                "testfunc",

--- a/k8s/probes_test.go
+++ b/k8s/probes_test.go
@@ -1,0 +1,126 @@
+package k8s
+
+import (
+	"github.com/openfaas/faas/gateway/requests"
+	"testing"
+)
+
+func Test_makeProbes_useExec(t *testing.T) {
+	f := mockFactory()
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: false,
+	}
+
+	probes, err := f.MakeProbes(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if probes.Readiness.Exec == nil {
+		t.Errorf("Readiness probe should have had exec handler")
+		t.Fail()
+	}
+	if probes.Liveness.Exec == nil {
+		t.Errorf("Liveness probe should have had exec handler")
+		t.Fail()
+	}
+}
+
+func Test_makeProbes_useHTTPProbe(t *testing.T) {
+	f := mockFactory()
+	f.Config.HTTPProbe = true
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: false,
+	}
+
+	probes, err := f.MakeProbes(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if probes.Readiness.HTTPGet == nil {
+		t.Errorf("Readiness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Liveness.HTTPGet == nil {
+		t.Errorf("Liveness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+}
+
+func Test_makeProbes_useCustomHTTPProbe(t *testing.T) {
+	f := mockFactory()
+	f.Config.HTTPProbe = true
+	customPath := "/healthz"
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: false,
+		Annotations: &map[string]string{
+			ProbePath: customPath,
+		},
+	}
+
+	probes, err := f.MakeProbes(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if probes.Readiness.HTTPGet == nil {
+		t.Errorf("Readiness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Readiness.HTTPGet.Path != customPath {
+		t.Errorf("Readiness probe should have had HTTPGet handler set to %s", customPath)
+		t.Fail()
+	}
+
+	if probes.Liveness.HTTPGet == nil {
+		t.Errorf("Liveness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Liveness.HTTPGet.Path != customPath {
+		t.Errorf("Readiness probe should have had HTTPGet handler set to %s", customPath)
+		t.Fail()
+	}
+}
+
+func Test_makeProbes_useCustomDurationHTTPProbe(t *testing.T) {
+	f := mockFactory()
+	f.Config.HTTPProbe = true
+	customDelay := "2m"
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: false,
+		Annotations: &map[string]string{
+			ProbeInitialDelay: customDelay,
+		},
+	}
+
+	probes, err := f.MakeProbes(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if probes.Readiness.HTTPGet == nil {
+		t.Errorf("Readiness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Readiness.InitialDelaySeconds != 120 {
+		t.Errorf("Readiness probe should have initial delay seconds set to %s", customDelay)
+		t.Fail()
+	}
+
+	if probes.Liveness.HTTPGet == nil {
+		t.Errorf("Liveness probe should have had HTTPGet handler")
+		t.Fail()
+	}
+	if probes.Liveness.InitialDelaySeconds != 120 {
+		t.Errorf("Readiness probe should have had HTTPGet handler set to %s", customDelay)
+		t.Fail()
+	}
+}

--- a/k8s/securityContext.go
+++ b/k8s/securityContext.go
@@ -1,0 +1,72 @@
+package k8s
+
+import (
+	"github.com/openfaas/faas/gateway/requests"
+	appsv1 "k8s.io/api/apps/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// nonRootFunctionuserID is the user id that is set when DeployHandlerConfig.SetNonRootUser is true.
+// value >10000 per the suggestion from https://kubesec.io/basics/containers-securitycontext-runasuser/
+const SecurityContextUserID = int64(12000)
+
+// ConfigureContainerUserID sets the UID to 12000 for the function Container.  Defaults to user
+// specified in image metadata if `SetNonRootUser` is `false`. Root == 0.
+func (f *Factory) ConfigureContainerUserID(deployment *appsv1.Deployment) {
+	userID := SecurityContextUserID
+	var functionUser *int64
+
+	if f.Config.SetNonRootUser {
+		functionUser = &userID
+	}
+
+	if deployment.Spec.Template.Spec.Containers[0].SecurityContext == nil {
+		deployment.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
+	}
+
+	deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = functionUser
+}
+
+// ConfigureReadOnlyRootFilesystem will create or update the required settings and mounts to ensure
+// that the ReadOnlyRootFilesystem setting works as expected, meaning:
+// 1. when ReadOnlyRootFilesystem is true, the security context of the container will have ReadOnlyRootFilesystem also
+//    marked as true and a new `/tmp` folder mount will be added to the deployment spec
+// 2. when ReadOnlyRootFilesystem is false, the security context of the container will also have ReadOnlyRootFilesystem set
+//    to false and there will be no mount for the `/tmp` folder
+//
+// This method is safe for both create and update operations.
+func (f *Factory) ConfigureReadOnlyRootFilesystem(request requests.CreateFunctionRequest, deployment *appsv1.Deployment) {
+	if deployment.Spec.Template.Spec.Containers[0].SecurityContext != nil {
+		deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &request.ReadOnlyRootFilesystem
+	} else {
+		deployment.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: &request.ReadOnlyRootFilesystem,
+		}
+	}
+
+	existingVolumes := removeVolume("temp", deployment.Spec.Template.Spec.Volumes)
+	deployment.Spec.Template.Spec.Volumes = existingVolumes
+
+	existingMounts := removeVolumeMount("temp", deployment.Spec.Template.Spec.Containers[0].VolumeMounts)
+	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = existingMounts
+
+	if request.ReadOnlyRootFilesystem {
+		deployment.Spec.Template.Spec.Volumes = append(
+			existingVolumes,
+			corev1.Volume{
+				Name: "temp",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		)
+
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+			existingMounts,
+			corev1.VolumeMount{
+				Name:      "temp",
+				MountPath: "/tmp",
+				ReadOnly:  false},
+		)
+	}
+}

--- a/k8s/securityContext.go
+++ b/k8s/securityContext.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import (

--- a/k8s/securityContext.go
+++ b/k8s/securityContext.go
@@ -15,7 +15,7 @@ const SecurityContextUserID = int64(12000)
 
 // ConfigureContainerUserID sets the UID to 12000 for the function Container.  Defaults to user
 // specified in image metadata if `SetNonRootUser` is `false`. Root == 0.
-func (f *Factory) ConfigureContainerUserID(deployment *appsv1.Deployment) {
+func (f *FunctionFactory) ConfigureContainerUserID(deployment *appsv1.Deployment) {
 	userID := SecurityContextUserID
 	var functionUser *int64
 
@@ -38,7 +38,7 @@ func (f *Factory) ConfigureContainerUserID(deployment *appsv1.Deployment) {
 //    to false and there will be no mount for the `/tmp` folder
 //
 // This method is safe for both create and update operations.
-func (f *Factory) ConfigureReadOnlyRootFilesystem(request requests.CreateFunctionRequest, deployment *appsv1.Deployment) {
+func (f *FunctionFactory) ConfigureReadOnlyRootFilesystem(request requests.CreateFunctionRequest, deployment *appsv1.Deployment) {
 	if deployment.Spec.Template.Spec.Containers[0].SecurityContext != nil {
 		deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &request.ReadOnlyRootFilesystem
 	} else {

--- a/k8s/securityContext_test.go
+++ b/k8s/securityContext_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import (

--- a/k8s/securityContext_test.go
+++ b/k8s/securityContext_test.go
@@ -1,0 +1,187 @@
+package k8s
+
+import (
+	"github.com/openfaas/faas/gateway/requests"
+	appsv1 "k8s.io/api/apps/v1beta2"
+	apiv1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func readOnlyRootDisabled(t *testing.T, deployment *appsv1.Deployment) {
+	if len(deployment.Spec.Template.Spec.Volumes) != 0 {
+		t.Error("Volumes should be empty if ReadOnlyRootFilesystem is false")
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts) != 0 {
+		t.Error("VolumeMounts should be empty if ReadOnlyRootFilesystem is false")
+	}
+	functionContatiner := deployment.Spec.Template.Spec.Containers[0]
+
+	if functionContatiner.SecurityContext != nil {
+		if *functionContatiner.SecurityContext.ReadOnlyRootFilesystem != false {
+			t.Error("ReadOnlyRootFilesystem should be false on the container SecurityContext")
+		}
+	}
+}
+
+func readOnlyRootEnabled(t *testing.T, deployment *appsv1.Deployment) {
+	if len(deployment.Spec.Template.Spec.Volumes) != 1 {
+		t.Error("should create a single tmp Volume")
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts) != 1 {
+		t.Error("should create a single tmp VolumeMount")
+	}
+
+	volume := deployment.Spec.Template.Spec.Volumes[0]
+	if volume.Name != "temp" {
+		t.Error("volume should be named temp")
+	}
+
+	mount := deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0]
+	if mount.Name != "temp" {
+		t.Error("volume mount should be named temp")
+	}
+
+	if mount.MountPath != "/tmp" {
+		t.Error("temp volume should be mounted to /tmp")
+	}
+
+	if mount.ReadOnly {
+		t.Errorf("temp mount should not read only")
+	}
+
+	if deployment.Spec.Template.Spec.Containers[0].SecurityContext == nil {
+		t.Error("container security context should not be nil")
+	}
+
+	if *deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem != true {
+		t.Error("should set ReadOnlyRootFilesystem to true on the container SecurityContext")
+	}
+}
+
+func Test_configureReadOnlyRootFilesystem_Disabled_To_Disabled(t *testing.T) {
+	f := mockFactory()
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: false,
+	}
+
+	f.ConfigureReadOnlyRootFilesystem(request, deployment)
+	readOnlyRootDisabled(t, deployment)
+}
+
+func Test_configureReadOnlyRootFilesystem_Disabled_To_Enabled(t *testing.T) {
+	f := mockFactory()
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "testfunc", Image: "alpine:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: true,
+	}
+
+	f.ConfigureReadOnlyRootFilesystem(request, deployment)
+	readOnlyRootEnabled(t, deployment)
+}
+
+func Test_configureReadOnlyRootFilesystem_Enabled_To_Disabled(t *testing.T) {
+	f := mockFactory()
+	trueValue := true
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:  "testfunc",
+							Image: "alpine:latest",
+							SecurityContext: &apiv1.SecurityContext{
+								ReadOnlyRootFilesystem: &trueValue,
+							},
+							VolumeMounts: []apiv1.VolumeMount{
+								{Name: "temp", MountPath: "/tmp", ReadOnly: false},
+							},
+						},
+					},
+					Volumes: []apiv1.Volume{
+						{
+							Name: "temp",
+							VolumeSource: apiv1.VolumeSource{
+								EmptyDir: &apiv1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: false,
+	}
+	f.ConfigureReadOnlyRootFilesystem(request, deployment)
+	readOnlyRootDisabled(t, deployment)
+}
+
+func Test_configureReadOnlyRootFilesystem_Enabled_To_Enabled(t *testing.T) {
+	f := mockFactory()
+	trueValue := true
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:  "testfunc",
+							Image: "alpine:latest",
+							SecurityContext: &apiv1.SecurityContext{
+								ReadOnlyRootFilesystem: &trueValue,
+							},
+							VolumeMounts: []apiv1.VolumeMount{
+								{Name: "temp", MountPath: "/tmp", ReadOnly: false},
+							},
+						},
+					},
+					Volumes: []apiv1.Volume{
+						{
+							Name: "temp",
+							VolumeSource: apiv1.VolumeSource{
+								EmptyDir: &apiv1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	request := requests.CreateFunctionRequest{
+		Service:                "testfunc",
+		ReadOnlyRootFilesystem: true,
+	}
+	f.ConfigureReadOnlyRootFilesystem(request, deployment)
+	readOnlyRootEnabled(t, deployment)
+}

--- a/k8s/utils.go
+++ b/k8s/utils.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package k8s
 
 import (

--- a/k8s/utils.go
+++ b/k8s/utils.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// removeVolume returns a Volume slice with any volumes matching volumeName removed.
+// Uses the filter without allocation technique
+// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+func removeVolume(volumeName string, volumes []corev1.Volume) []corev1.Volume {
+	if volumes == nil {
+		return []corev1.Volume{}
+	}
+
+	newVolumes := volumes[:0]
+	for _, v := range volumes {
+		if v.Name != volumeName {
+			newVolumes = append(newVolumes, v)
+		}
+	}
+
+	return newVolumes
+}
+
+// removeVolumeMount returns a VolumeMount slice with any mounts matching volumeName removed
+// Uses the filter without allocation technique
+// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+func removeVolumeMount(volumeName string, mounts []corev1.VolumeMount) []corev1.VolumeMount {
+	if mounts == nil {
+		return []corev1.VolumeMount{}
+	}
+
+	newMounts := mounts[:0]
+	for _, v := range mounts {
+		if v.Name != volumeName {
+			newMounts = append(newMounts, v)
+		}
+	}
+
+	return newMounts
+}

--- a/server.go
+++ b/server.go
@@ -46,6 +46,7 @@ func main() {
 	log.Printf("SetNonRootUser: %v\n", cfg.SetNonRootUser)
 
 	deployConfig := k8s.DeploymentConfig{
+		WatchdogPort:   8080,
 		HTTPProbe:      cfg.HTTPProbe,
 		SetNonRootUser: cfg.SetNonRootUser,
 		ReadinessProbe: &k8s.ProbeConfig{

--- a/server.go
+++ b/server.go
@@ -62,7 +62,7 @@ func main() {
 		ImagePullPolicy: cfg.ImagePullPolicy,
 	}
 
-	factory := k8s.NewFactory(clientset, deployConfig)
+	factory := k8s.NewFunctionFactory(clientset, deployConfig)
 
 	bootstrapHandlers := bootTypes.FaaSHandlers{
 		FunctionProxy:  handlers.MakeProxy(functionNamespace, cfg.ReadTimeout),

--- a/server.go
+++ b/server.go
@@ -46,9 +46,9 @@ func main() {
 	log.Printf("SetNonRootUser: %v\n", cfg.SetNonRootUser)
 
 	deployConfig := k8s.DeploymentConfig{
-		WatchdogPort:   8080,
-		HTTPProbe:      cfg.HTTPProbe,
-		SetNonRootUser: cfg.SetNonRootUser,
+		RuntimeHTTPPort: 8080,
+		HTTPProbe:       cfg.HTTPProbe,
+		SetNonRootUser:  cfg.SetNonRootUser,
 		ReadinessProbe: &k8s.ProbeConfig{
 			InitialDelaySeconds: int32(cfg.ReadinessProbeInitialDelaySeconds),
 			TimeoutSeconds:      int32(cfg.ReadinessProbeTimeoutSeconds),

--- a/test/read_config_test.go
+++ b/test/read_config_test.go
@@ -47,7 +47,7 @@ func TestRead_EmptyTimeoutConfig(t *testing.T) {
 	wantPort := 8080
 
 	if config.Port != wantPort {
-		t.Logf("WatchdogPort want: %d, got %d", wantPort, config.Port)
+		t.Logf("Port want: %d, got %d", wantPort, config.Port)
 		t.Fail()
 	}
 }
@@ -62,7 +62,7 @@ func TestRead_ReadPortConfig(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if config.Port != wantPort {
-		t.Logf("WatchdogPort incorrect, want: %d, got: %d\n", wantPort, config.Port)
+		t.Logf("Port incorrect, want: %d, got: %d\n", wantPort, config.Port)
 		t.Fail()
 	}
 }

--- a/test/read_config_test.go
+++ b/test/read_config_test.go
@@ -47,7 +47,7 @@ func TestRead_EmptyTimeoutConfig(t *testing.T) {
 	wantPort := 8080
 
 	if config.Port != wantPort {
-		t.Logf("Port want: %d, got %d", wantPort, config.Port)
+		t.Logf("WatchdogPort want: %d, got %d", wantPort, config.Port)
 		t.Fail()
 	}
 }
@@ -62,7 +62,7 @@ func TestRead_ReadPortConfig(t *testing.T) {
 	config := readConfig.Read(defaults)
 
 	if config.Port != wantPort {
-		t.Logf("Port incorrect, want: %d, got: %d\n", wantPort, config.Port)
+		t.Logf("WatchdogPort incorrect, want: %d, got: %d\n", wantPort, config.Port)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
This PR adds two annotations that can be used to configure the liveness/readiness probes HTTP path and initial delay.

- `com.openfaas.health.http.path: "/healthz"` 
- `com.openfaas.health.http.initialDelay: "3m"`

Fix: #442 

## Description

- Add k8s package to be used for Kubernetes operations
- Extract liveness and readiness probes logic from handlers into k8s package
- Implement HTTP probe custom path and initial delay duration by overriding the defaults with annotations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested locally with Kubernetes Kind

Run faas-netes with http probe enabled:

```
helm  upgrade -i openfaas ./chart/openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set functionNamespace=openfaas-fn \
    --set faasnetes.httpProbe=true \
    --set faasnetes.image=stefanprodan/faas-netes:probes-v2 \
    --wait
```

Deploy kubesec:

```
functions:
  kubesec:
    image: docker.io/stefanprodan/kubesec:v2.1
    skip_build: true
    annotations:
      com.openfaas.health.http.path: "/healthz"
      com.openfaas.health.http.initialDelay: "10s"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
