### PR TITLE
Helm chart: Bump openfaas-operator to 0.9.7

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -75,7 +75,7 @@ A note on health-checking probes for functions:
 * httpProbe - most efficient, currently incompatible with Istio
 * execProbe - least efficient health-checking, but most compatible
 
-If you want to switch from "exec" liveness and readiness probes to httpProbes then use `--set faasnetes.httpProbe=true`, this can only be used with `--set operator.create=false`.
+If you want to switch from "exec" liveness and readiness probes to httpProbes then use `--set faasnetes.httpProbe=true`.
 
 ### Verify the installation
 

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -122,14 +122,32 @@ spec:
           - -logtostderr
           - -v=2
         env:
-        - name: function_namespace
-          value: {{ $functionNs | quote }}
-        - name: read_timeout
-          value: "{{ .Values.faasnetes.readTimeout }}"
-        - name: write_timeout
-          value: "{{ .Values.faasnetes.writeTimeout }}"
-        - name: image_pull_policy
-          value: {{ .Values.faasnetes.imagePullPolicy | quote }}
+          - name: port
+            value: "8081"
+          - name: function_namespace
+            value: {{ $functionNs | quote }}
+          - name: read_timeout
+            value: "{{ .Values.faasnetes.readTimeout }}"
+          - name: write_timeout
+            value: "{{ .Values.faasnetes.writeTimeout }}"
+          - name: image_pull_policy
+            value: {{ .Values.faasnetes.imagePullPolicy | quote }}
+          - name: http_probe
+            value: "{{ .Values.faasnetes.httpProbe }}"
+          - name: set_nonroot_user
+            value: "{{ .Values.faasnetes.setNonRootUser }}"
+          - name: readiness_probe_initial_delay_seconds
+            value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
+          - name: readiness_probe_timeout_seconds
+            value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
+          - name: readiness_probe_period_seconds
+            value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+          - name: liveness_probe_initial_delay_seconds
+            value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
+          - name: liveness_probe_timeout_seconds
+            value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
+          - name: liveness_probe_period_seconds
+            value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
         ports:
         - containerPort: 8081
           protocol: TCP

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -41,7 +41,7 @@ faasnetes:
 
 # replaces faas-netes with openfaas-operator
 operator:
-  image: openfaas/openfaas-operator:0.9.4
+  image: openfaas/openfaas-operator:0.9.7
   create: false
   # set this to false when creating multiple releases in the same cluster
   # must be true for the first one only


### PR DESCRIPTION
## Description

- update openfaas-operator image to 0.9.7
 - reuse faas-netes env vars for the operator
- remove comment about operator not supporting httpProbe ref: #455

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

Tested locally with Kubernetes Kind and kubesec as described [here](https://github.com/openfaas-incubator/openfaas-operator/pull/83)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
