### PR TITLE
Merge which closes: #457

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ charts:
 	mv chart/*.tgz docs/
 	helm repo index docs --url https://openfaas.github.io/faas-netes/ --merge ./docs/index.yaml
 	./contrib/create-static-manifest.sh
+	./contrib/create-static-manifest.sh ./chart/openfaas ./yaml_arm64 contrib/values-arm64.yaml
+	./contrib/create-static-manifest.sh ./chart/openfaas ./yaml_armhf contrib/values-armhf.yaml
 
 ci-armhf-build:
 	docker build -t openfaas/faas-netes:$(TAG)-armhf . -f Dockerfile.armhf

--- a/contrib/create-static-manifest.sh
+++ b/contrib/create-static-manifest.sh
@@ -16,7 +16,7 @@
 
 CHART_DIR=${1:-"./chart/openfaas"}
 OUTPUT_DIR=${2:-"./yaml"}
-VALUESNAME=${3:-"values.yaml"}
+VALUESNAME=${3:-"$CHART_DIR/values.yaml"}
 NAMEPSPACE=${4:-"openfaas"}
 FUNCTIONNAMESPACE=${5:-"openfaas-fn"}
 
@@ -25,7 +25,7 @@ for filepath in $TEMPLATE_FILE; do
     filename=$(basename $filepath)
     outputname="${filename%%.*}.yml"
     # Use helm to generate the yaml and then use sed to remove the helm specific lables/annotations.
-    helm template "$CHART_DIR" --name=faas --namespace="$NAMEPSPACE" --set "functionNamespace=$FUNCTIONNAMESPACE" -x templates/$filename --values="$CHART_DIR/$VALUESNAME" \
+    helm template "$CHART_DIR" --name=faas --namespace="$NAMEPSPACE" --set "functionNamespace=$FUNCTIONNAMESPACE" -x templates/$filename --values="$VALUESNAME" \
         | sed -E '/(chart:)|(release:)|(heritage:)/d' \
         | sed -E '/# Source:/d' \
         | sed -E '/^$/d' \

--- a/contrib/values-arm64.yaml
+++ b/contrib/values-arm64.yaml
@@ -1,0 +1,19 @@
+basic_auth: true
+
+faasnetes:
+  image: openfaas/faas-netes:0.8.0-arm64
+
+gateway:
+  image: openfaas/gateway:0.14.4-arm64
+
+queueWorker:
+  image: openfaas/queue-worker:0.7.1-arm64
+
+prometheus:
+  image: functions/prometheus:2.7.1-arm64
+
+alertmanager:
+  image: functions/alertmanager:0.16.1-arm64
+
+faasIdler:
+  image: openfaas/faas-idler:0.2.0-arm64

--- a/contrib/values-armhf.yaml
+++ b/contrib/values-armhf.yaml
@@ -1,0 +1,19 @@
+basic_auth: false
+
+faasnetes:
+  image: openfaas/faas-netes:0.8.0-armhf
+
+gateway:
+  image: openfaas/gateway:0.14.4-armhf
+
+queueWorker:
+  image: openfaas/queue-worker:0.4.9-armhf
+
+prometheus:
+  image: functions/prometheus:2.7.1-armhf
+
+alertmanager:
+  image: functions/alertmanager:0.16.1-armhf
+
+faasIdler:
+  image: openfaas/faas-idler:0.2.0-armhf

--- a/yaml_arm64/README.md
+++ b/yaml_arm64/README.md
@@ -1,0 +1,7 @@
+## 64-bit ARM YAML files
+
+Follow steps for the `yaml` files for `x86_64`: [YAML](../yaml/)
+
+When creating new functions from templates, make sure you use the ones ending in `-arm64`.
+
+If there are specific templates or languages you would like to see for 64-bit ARM, please reach [out on Slack](https://docs.openfaas.com/community) or raise an issue on the [templates repo](https://github.com/openfaas/templates/).

--- a/yaml_arm64/alertmanager-cfg.yml
+++ b/yaml_arm64/alertmanager-cfg.yml
@@ -1,10 +1,13 @@
+---
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    app: alertmanager
+    app: openfaas
+    component: alertmanager-config
   name: alertmanager-config
-  namespace: openfaas
+  namespace: "openfaas"
 data:
   alertmanager.yml: |
     route:
@@ -29,4 +32,7 @@ data:
       webhook_configs:
         - url: http://gateway.openfaas:8080/system/alert
           send_resolved: true
----
+          http_config:
+            basic_auth:
+              username: admin
+              password_file: /var/secrets/basic-auth-password

--- a/yaml_arm64/alertmanager-dep.yml
+++ b/yaml_arm64/alertmanager-dep.yml
@@ -1,25 +1,56 @@
+---
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: alertmanager
   name: alertmanager
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: alertmanager
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/alertmanager-config: "02cdd6da334612bb90668bbca0531b4ec41410464ae3d276b32e1f44067ae923"
     spec:
       containers:
       - name: alertmanager
-        image: functions/alertmanager:0.15.0-rc.0-arm64
+        resources:
+          requests:
+            memory: "32Mi"
+        image: functions/alertmanager:0.16.1-arm64
         imagePullPolicy: Always
-        command: 
+        command:
           - "alertmanager"
           - "--config.file=/alertmanager.yml"
           - "--storage.path=/alertmanager"
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          timeoutSeconds: 30
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          timeoutSeconds: 30
         ports:
-        - containerPort: 9003
+        - containerPort: 9093
           protocol: TCP
         resources:
           requests:
@@ -30,6 +61,9 @@ spec:
         - mountPath: /alertmanager.yml
           name: alertmanager-config
           subPath: alertmanager.yml
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
       volumes:
         - name: alertmanager-config
           configMap:
@@ -38,3 +72,6 @@ spec:
               - key: alertmanager.yml
                 path: alertmanager.yml
                 mode: 0644
+        - name: auth
+          secret:
+            secretName: basic-auth

--- a/yaml_arm64/alertmanager-svc.yml
+++ b/yaml_arm64/alertmanager-svc.yml
@@ -1,15 +1,17 @@
+---
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: alertmanager
-  namespace: openfaas
   labels:
-    app: alertmanager
+    app: openfaas
+    component: alertmanager
+  name: alertmanager
+  namespace: "openfaas"
 spec:
   type: ClusterIP
   ports:
     - port: 9093
       protocol: TCP
-      targetPort: 9093
   selector:
     app: alertmanager

--- a/yaml_arm64/basic-auth-plugin-dep.yml
+++ b/yaml_arm64/basic-auth-plugin-dep.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    component: basic-auth-plugin
+  name: basic-auth-plugin
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: basic-auth-plugin
+    spec:
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      containers:
+      - name:  basic-auth-plugin
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "20m"
+        image: openfaas/basic-auth-plugin:0.1.1
+        imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        env:
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "true"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP

--- a/yaml_arm64/basic-auth-plugin-svc.yml
+++ b/yaml_arm64/basic-auth-plugin-svc.yml
@@ -1,18 +1,18 @@
 ---
----
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: openfaas
-    component: nats
-  name: nats
+    component: basic-auth-plugin
+  name: basic-auth-plugin
   namespace: "openfaas"
 spec:
   type: ClusterIP
   ports:
-    - port: 4222
+    - port: 8080
+      targetPort: http
       protocol: TCP
-      name: clients
+      name: http
   selector:
-    app: nats
+    app: basic-auth-plugin

--- a/yaml_arm64/controller-rbac.yml
+++ b/yaml_arm64/controller-rbac.yml
@@ -1,0 +1,72 @@
+---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: openfaas
+    component: faas-controller
+  name: faas-controller
+  namespace: "openfaas"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: openfaas
+    component: faas-controller
+  name: faas-controller
+  namespace: "openfaas-fn"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: openfaas
+    component: faas-controller
+  name: faas-controller
+  namespace: "openfaas-fn"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: faas-controller
+subjects:
+  - kind: ServiceAccount
+    name: faas-controller
+    namespace: "openfaas"

--- a/yaml_arm64/faas-idler-dep.yml
+++ b/yaml_arm64/faas-idler-dep.yml
@@ -1,0 +1,48 @@
+---
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: faas-idler
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: faas-idler
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: faas-idler
+    spec:
+      containers:
+        - name: faas-idler
+          resources:
+            requests:
+              memory: "64Mi"
+          image: openfaas/faas-idler:0.2.0-arm64
+          imagePullPolicy: Always
+          env:
+            - name: gateway_url
+              value: "http://gateway.openfaas:8080/"
+            - name: prometheus_host
+              value: "prometheus.openfaas"
+            - name: prometheus_port
+              value: "9090"
+            - name: inactivity_duration
+              value: 15m
+            - name: reconcile_interval
+              value: 1m
+          command:
+            - /home/app/faas-idler
+            - -dry-run=true
+          volumeMounts:
+            - name: auth
+              readOnly: true
+              mountPath: "/var/secrets/"
+      volumes:
+        - name: auth
+          secret:
+            secretName: basic-auth

--- a/yaml_arm64/gateway-dep.yml
+++ b/yaml_arm64/gateway-dep.yml
@@ -1,62 +1,134 @@
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: gateway
   name: gateway
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+        prometheus.io.port: "8082"
       labels:
         app: gateway
     spec:
       serviceAccountName: faas-controller
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
       containers:
       - name: gateway
-        image: openfaas/gateway:0.13.0-arm64
+        resources:
+          requests:
+            memory: "120Mi"
+            cpu: "50m"
+        image: openfaas/gateway:0.14.4-arm64
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
         env:
+        - name: read_timeout
+          value: "65s"
+        - name: write_timeout
+          value: "65s"
+        - name: upstream_timeout
+          value: "60s"
         - name: functions_provider_url
           value: "http://127.0.0.1:8081/"
+        - name: direct_functions
+          value: "true"
+        - name: direct_functions_suffix
+          value: "openfaas-fn.svc.cluster.local"
         - name: faas_nats_address
-          value: "nats.openfaas"
+          value: "nats.openfaas.svc.cluster.local"
         - name: faas_nats_port
           value: "4222"
-        - name: direct_functions
-          value: "true"                             # Functions are invoked directly over the overlay network
-        - name: direct_functions_suffix
-          value: "openfaas-fn.svc.cluster.local."   # contains K8s namespace
-        - name: read_timeout
-          value: "60s"
-        - name: write_timeout
-          value: "60s"
         - name: basic_auth
+          value: "true"
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: auth_proxy_url
+          value: "http://basic-auth-plugin.openfaas:8080/validate"
+        - name: auth_pass_body
           value: "false"
+        - name: scale_from_zero
+          value: "true"
+        - name: max_idle_conns
+          value: "1024"
+        - name: max_idle_conns_per_host
+          value: "1024"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
           protocol: TCP
+      - name: faas-netes
         resources:
           requests:
-            memory: 100Mi
-          limits:
-            memory: 100Mi
-      - name: faas-netesd
-        image: openfaas/faas-netes:0.7.1-arm64
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8081
-          protocol: TCP
-        resources:
-          requests:
-            memory: 50Mi
-          limits:
-            memory: 50Mi
+            memory: "120Mi"
+            cpu: "50m"
+        image: openfaas/faas-netes:0.8.0-arm64
+        imagePullPolicy: 
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
         env:
         - name: port
           value: "8081"
         - name: function_namespace
-          value: openfaas-fn
+          value: "openfaas-fn"
         - name: read_timeout
-          value: "50s"
+          value: "60s"
         - name: write_timeout
           value: "60s"
+        - name: image_pull_policy
+          value: "Always"
+        - name: http_probe
+          value: "false"
+        - name: set_nonroot_user
+          value: "false"
+        - name: readiness_probe_initial_delay_seconds
+          value: "0"
+        - name: readiness_probe_timeout_seconds
+          value: "1"
+        - name: readiness_probe_period_seconds
+          value: "1"
+        - name: liveness_probe_initial_delay_seconds
+          value: "3"
+        - name: liveness_probe_timeout_seconds
+          value: "1"
+        - name: liveness_probe_period_seconds
+          value: "10"
+        ports:
+        - containerPort: 8081
+          protocol: TCP

--- a/yaml_arm64/gateway-external-svc.yml
+++ b/yaml_arm64/gateway-external-svc.yml
@@ -5,14 +5,15 @@ kind: Service
 metadata:
   labels:
     app: openfaas
-    component: nats
-  name: nats
+    component: gateway
+  name: gateway-external
   namespace: "openfaas"
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
-    - port: 4222
+    - port: 8080
       protocol: TCP
-      name: clients
+      targetPort: 8080
+      nodePort: 31112
   selector:
-    app: nats
+    app: gateway

--- a/yaml_arm64/gateway-svc.yml
+++ b/yaml_arm64/gateway-svc.yml
@@ -1,21 +1,18 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: gateway
-  namespace: openfaas
   labels:
-    app: gateway
+    app: openfaas
+    component: gateway
+  name: gateway
+  namespace: "openfaas"
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
+      targetPort: http
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31112
-      name: "gateway"
-    - port: 8082
-      protocol: TCP
-      targetPort: 8082
-      name: "prometheus"
+      name: http
   selector:
     app: gateway

--- a/yaml_arm64/nats-dep.yml
+++ b/yaml_arm64/nats-dep.yml
@@ -1,29 +1,35 @@
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: nats
   name: nats
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io.scrape: "false"
       labels:
         app: nats
     spec:
       containers:
       - name:  nats
+        resources:
+          requests:
+            memory: "120Mi"
         image: nats-streaming:0.11.2
         imagePullPolicy: Always
         ports:
         - containerPort: 4222
           protocol: TCP
-        # - containerPort: 8222
-        #   protocol: TCP
         command: ["/nats-streaming-server"]
         args:
           - --store
           - memory
           - --cluster_id
           - faas-cluster
-          # - -m
-          # - "8222"

--- a/yaml_arm64/prometheus-cfg.yml
+++ b/yaml_arm64/prometheus-cfg.yml
@@ -1,10 +1,13 @@
+---
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    app: prometheus
+    app: openfaas
+    component: prometheus-config
   name: prometheus-config
-  namespace: openfaas
+  namespace: "openfaas"
 data:
   prometheus.yml: |
     global:
@@ -19,33 +22,48 @@ data:
         scrape_interval: 5s
         static_configs:
           - targets: ['localhost:9090']
-      - job_name: "gateway"
+      - job_name: 'kubernetes-pods'
         scrape_interval: 5s
-        dns_sd_configs:
-          - names: ['gateway.openfaas']
-            port: 8082
-            type: A
-            refresh_interval: 5s
+        honor_labels: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - openfaas
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
     alerting:
       alertmanagers:
       - static_configs:
         - targets:
-          - alertmanager.openfaas:9093
+          - alertmanager:9093
   alert.rules.yml: |
     groups:
-    - name: openfaas
-      rules:
-      - alert: service_down
-        expr: up == 0
-      - alert: APIHighInvocationRate
-        expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name)
-          > 5
-        for: 5s
-        labels:
-          service: gateway
-          severity: major
-          value: '{{$value}}'
-        annotations:
-          description: High invocation total on {{ $labels.instance }}
-          summary: High invocation total on {{ $labels.instance }}
----
+      - name: openfaas
+        rules:
+        - alert: service_down
+          expr: up == 0
+        - alert: APIHighInvocationRate
+          expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+          for: 5s
+          labels:
+            service: gateway
+            severity: major
+          annotations:
+            description: High invocation total on "{{$labels.function_name}}"
+            summary: High invocation total on "{{$labels.function_name}}"

--- a/yaml_arm64/prometheus-dep.yml
+++ b/yaml_arm64/prometheus-dep.yml
@@ -1,30 +1,57 @@
+---
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: prometheus
   name: prometheus
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: prometheus
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/prometheus-config: "6c1e41fcc392e2bfcfc6ddfd512cf520a6458abf28692c9422f90120388c38f9"
     spec:
+      serviceAccountName: faas-prometheus
       containers:
       - name: prometheus
-        image: functions/prometheus:2.3.1-arm64
-        command: 
+        resources:
+          requests:
+            memory: "512Mi"
+        image: functions/prometheus:2.7.1-arm64
+        command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: Always
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          timeoutSeconds: 30
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          timeoutSeconds: 30
         ports:
         - containerPort: 9090
           protocol: TCP
-        resources:
-          requests:
-            memory: 250Mi
-          limits:
-            memory: 250Mi
         volumeMounts:
         - mountPath: /etc/prometheus/prometheus.yml
           name: prometheus-config
@@ -32,6 +59,8 @@ spec:
         - mountPath: /etc/prometheus/alert.rules.yml
           name: prometheus-config
           subPath: alert.rules.yml
+        - mountPath: /prometheus/data
+          name: prom-data
       volumes:
         - name: prometheus-config
           configMap:
@@ -43,3 +72,5 @@ spec:
               - key: alert.rules.yml
                 path: alert.rules.yml
                 mode: 0644
+        - name: prom-data
+          emptyDir: {}

--- a/yaml_arm64/prometheus-rbac.yml
+++ b/yaml_arm64/prometheus-rbac.yml
@@ -1,0 +1,43 @@
+---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: faas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: faas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: faas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: faas-prometheus
+subjects:
+- kind: ServiceAccount
+  name: faas-prometheus
+  namespace: "openfaas"

--- a/yaml_arm64/prometheus-svc.yml
+++ b/yaml_arm64/prometheus-svc.yml
@@ -1,16 +1,17 @@
+---
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus
-  namespace: openfaas
   labels:
-    app: prometheus
+    app: openfaas
+    component: prometheus
+  name: prometheus
+  namespace: "openfaas"
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 9090
       protocol: TCP
-      targetPort: 9090
-      nodePort: 31119
   selector:
     app: prometheus

--- a/yaml_arm64/queueworker-dep.yml
+++ b/yaml_arm64/queueworker-dep.yml
@@ -1,24 +1,49 @@
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: queue-worker
   name: queue-worker
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "false"
       labels:
         app: queue-worker
     spec:
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
       containers:
       - name:  queue-worker
+        resources:
+          requests:
+            memory: "120Mi"
+            cpu: "50m"
         image: openfaas/queue-worker:0.7.1-arm64
         imagePullPolicy: Always
         env:
-        - name: max_inflight
-          value: "1"
-        - name: ack_wait    # Max duration of any async task / request
-          value: "30s"
+        - name: faas_nats_address
+          value: "nats.openfaas.svc.cluster.local"
+        - name: faas_gateway_address
+          value: "gateway.openfaas.svc.cluster.local"
+        - name: "gateway_invoke"
+          value: "true"
         - name: faas_function_suffix
-          value: ".openfaas-fn"
- 
+          value: ".openfaas-fn.svc.cluster.local"
+        - name: ack_wait    # Max duration of any async task / request
+          value: 60s
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "true"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"

--- a/yaml_armhf/alertmanager-cfg.yml
+++ b/yaml_armhf/alertmanager-cfg.yml
@@ -1,10 +1,13 @@
+---
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    app: alertmanager
+    app: openfaas
+    component: alertmanager-config
   name: alertmanager-config
-  namespace: openfaas
+  namespace: "openfaas"
 data:
   alertmanager.yml: |
     route:
@@ -29,4 +32,3 @@ data:
       webhook_configs:
         - url: http://gateway.openfaas:8080/system/alert
           send_resolved: true
----

--- a/yaml_armhf/alertmanager-dep.yml
+++ b/yaml_armhf/alertmanager-dep.yml
@@ -1,25 +1,56 @@
+---
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: alertmanager
   name: alertmanager
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: alertmanager
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/alertmanager-config: "8124bfa9a88fc177c67769560917f99d20ae68a43d28a998affd1b424603e378"
     spec:
       containers:
       - name: alertmanager
-        image: functions/alertmanager:0.15.0-rc.0-armhf
+        resources:
+          requests:
+            memory: "32Mi"
+        image: functions/alertmanager:0.16.1-armhf
         imagePullPolicy: Always
-        command: 
+        command:
           - "alertmanager"
           - "--config.file=/alertmanager.yml"
           - "--storage.path=/alertmanager"
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          timeoutSeconds: 30
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          timeoutSeconds: 30
         ports:
-        - containerPort: 9003
+        - containerPort: 9093
           protocol: TCP
         resources:
           requests:

--- a/yaml_armhf/alertmanager-svc.yml
+++ b/yaml_armhf/alertmanager-svc.yml
@@ -1,15 +1,17 @@
+---
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: alertmanager
-  namespace: openfaas
   labels:
-    app: alertmanager
+    app: openfaas
+    component: alertmanager
+  name: alertmanager
+  namespace: "openfaas"
 spec:
   type: ClusterIP
   ports:
     - port: 9093
       protocol: TCP
-      targetPort: 9093
   selector:
     app: alertmanager

--- a/yaml_armhf/basic-auth-plugin-dep.yml
+++ b/yaml_armhf/basic-auth-plugin-dep.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    component: basic-auth-plugin
+  name: basic-auth-plugin
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: basic-auth-plugin
+    spec:
+      containers:
+      - name:  basic-auth-plugin
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "20m"
+        image: openfaas/basic-auth-plugin:0.1.1
+        imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          timeoutSeconds: 5
+        env:

--- a/yaml_armhf/basic-auth-plugin-svc.yml
+++ b/yaml_armhf/basic-auth-plugin-svc.yml
@@ -1,18 +1,18 @@
 ---
----
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: openfaas
-    component: nats
-  name: nats
+    component: basic-auth-plugin
+  name: basic-auth-plugin
   namespace: "openfaas"
 spec:
   type: ClusterIP
   ports:
-    - port: 4222
+    - port: 8080
+      targetPort: http
       protocol: TCP
-      name: clients
+      name: http
   selector:
-    app: nats
+    app: basic-auth-plugin

--- a/yaml_armhf/controller-rbac.yml
+++ b/yaml_armhf/controller-rbac.yml
@@ -1,0 +1,72 @@
+---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: openfaas
+    component: faas-controller
+  name: faas-controller
+  namespace: "openfaas"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: openfaas
+    component: faas-controller
+  name: faas-controller
+  namespace: "openfaas-fn"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: openfaas
+    component: faas-controller
+  name: faas-controller
+  namespace: "openfaas-fn"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: faas-controller
+subjects:
+  - kind: ServiceAccount
+    name: faas-controller
+    namespace: "openfaas"

--- a/yaml_armhf/faas-idler-dep.yml
+++ b/yaml_armhf/faas-idler-dep.yml
@@ -1,0 +1,40 @@
+---
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: faas-idler
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: faas-idler
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: faas-idler
+    spec:
+      containers:
+        - name: faas-idler
+          resources:
+            requests:
+              memory: "64Mi"
+          image: openfaas/faas-idler:0.2.0-armhf
+          imagePullPolicy: Always
+          env:
+            - name: gateway_url
+              value: "http://gateway.openfaas:8080/"
+            - name: prometheus_host
+              value: "prometheus.openfaas"
+            - name: prometheus_port
+              value: "9090"
+            - name: inactivity_duration
+              value: 15m
+            - name: reconcile_interval
+              value: 1m
+          command:
+            - /home/app/faas-idler
+            - -dry-run=true

--- a/yaml_armhf/gateway-dep.yml
+++ b/yaml_armhf/gateway-dep.yml
@@ -1,62 +1,118 @@
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: gateway
   name: gateway
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+        prometheus.io.port: "8082"
       labels:
         app: gateway
     spec:
       serviceAccountName: faas-controller
       containers:
       - name: gateway
-        image: openfaas/gateway:0.11.0-armhf
+        resources:
+          requests:
+            memory: "120Mi"
+            cpu: "50m"
+        image: openfaas/gateway:0.14.4-armhf
         imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
         env:
+        - name: read_timeout
+          value: "65s"
+        - name: write_timeout
+          value: "65s"
+        - name: upstream_timeout
+          value: "60s"
         - name: functions_provider_url
           value: "http://127.0.0.1:8081/"
+        - name: direct_functions
+          value: "true"
+        - name: direct_functions_suffix
+          value: "openfaas-fn.svc.cluster.local"
         - name: faas_nats_address
-          value: "nats.openfaas"
+          value: "nats.openfaas.svc.cluster.local"
         - name: faas_nats_port
           value: "4222"
-        - name: direct_functions
-          value: "true"                             # Functions are invoked directly over the overlay network
-        - name: direct_functions_suffix
-          value: "openfaas-fn.svc.cluster.local."   # contains K8s namespace
-        - name: read_timeout
-          value: "60s"
-        - name: write_timeout
-          value: "60s"
-        - name: basic_auth
-          value: "false"
+        - name: scale_from_zero
+          value: "true"
+        - name: max_idle_conns
+          value: "1024"
+        - name: max_idle_conns_per_host
+          value: "1024"
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
           protocol: TCP
+      - name: faas-netes
         resources:
           requests:
-            memory: 100Mi
-          limits:
-            memory: 100Mi
-      - name: faas-netesd
-        image: openfaas/faas-netes:0.6.3-armhf
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8081
-          protocol: TCP
-        resources:
-          requests:
-            memory: 50Mi
-          limits:
-            memory: 50Mi
+            memory: "120Mi"
+            cpu: "50m"
+        image: openfaas/faas-netes:0.8.0-armhf
+        imagePullPolicy: 
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
         env:
         - name: port
           value: "8081"
         - name: function_namespace
-          value: openfaas-fn
+          value: "openfaas-fn"
         - name: read_timeout
-          value: "50s"
+          value: "60s"
         - name: write_timeout
           value: "60s"
+        - name: image_pull_policy
+          value: "Always"
+        - name: http_probe
+          value: "false"
+        - name: set_nonroot_user
+          value: "false"
+        - name: readiness_probe_initial_delay_seconds
+          value: "0"
+        - name: readiness_probe_timeout_seconds
+          value: "1"
+        - name: readiness_probe_period_seconds
+          value: "1"
+        - name: liveness_probe_initial_delay_seconds
+          value: "3"
+        - name: liveness_probe_timeout_seconds
+          value: "1"
+        - name: liveness_probe_period_seconds
+          value: "10"
+        ports:
+        - containerPort: 8081
+          protocol: TCP

--- a/yaml_armhf/gateway-external-svc.yml
+++ b/yaml_armhf/gateway-external-svc.yml
@@ -5,14 +5,15 @@ kind: Service
 metadata:
   labels:
     app: openfaas
-    component: nats
-  name: nats
+    component: gateway
+  name: gateway-external
   namespace: "openfaas"
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
-    - port: 4222
+    - port: 8080
       protocol: TCP
-      name: clients
+      targetPort: 8080
+      nodePort: 31112
   selector:
-    app: nats
+    app: gateway

--- a/yaml_armhf/gateway-svc.yml
+++ b/yaml_armhf/gateway-svc.yml
@@ -1,16 +1,18 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: gateway
-  namespace: openfaas
   labels:
-    app: gateway
+    app: openfaas
+    component: gateway
+  name: gateway
+  namespace: "openfaas"
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
+      targetPort: http
       protocol: TCP
-      targetPort: 8080
-      nodePort: 31112
+      name: http
   selector:
     app: gateway

--- a/yaml_armhf/nats-dep.yml
+++ b/yaml_armhf/nats-dep.yml
@@ -1,29 +1,35 @@
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: nats
   name: nats
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io.scrape: "false"
       labels:
         app: nats
     spec:
       containers:
       - name:  nats
+        resources:
+          requests:
+            memory: "120Mi"
         image: nats-streaming:0.11.2
         imagePullPolicy: Always
         ports:
         - containerPort: 4222
           protocol: TCP
-        # - containerPort: 8222
-        #   protocol: TCP
         command: ["/nats-streaming-server"]
         args:
           - --store
           - memory
           - --cluster_id
           - faas-cluster
-          # - -m
-          # - "8222"

--- a/yaml_armhf/nats-svc.yml
+++ b/yaml_armhf/nats-svc.yml
@@ -1,20 +1,18 @@
+---
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: nats
-  namespace: openfaas
   labels:
-    app: nats
+    app: openfaas
+    component: nats
+  name: nats
+  namespace: "openfaas"
 spec:
   type: ClusterIP
   ports:
     - port: 4222
       protocol: TCP
-      targetPort: 4222
       name: clients
-    # - port: 8222
-    #   protocol: TCP
-    #   targetPort: 8222
-    #   name: monitoring
   selector:
     app: nats

--- a/yaml_armhf/prometheus-cfg.yml
+++ b/yaml_armhf/prometheus-cfg.yml
@@ -1,10 +1,13 @@
+---
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-    app: prometheus
+    app: openfaas
+    component: prometheus-config
   name: prometheus-config
-  namespace: openfaas
+  namespace: "openfaas"
 data:
   prometheus.yml: |
     global:
@@ -19,33 +22,48 @@ data:
         scrape_interval: 5s
         static_configs:
           - targets: ['localhost:9090']
-      - job_name: "gateway"
+      - job_name: 'kubernetes-pods'
         scrape_interval: 5s
-        dns_sd_configs:
-          - names: ['gateway.openfaas']
-            port: 8080
-            type: A
-            refresh_interval: 5s
+        honor_labels: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - openfaas
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
     alerting:
       alertmanagers:
       - static_configs:
         - targets:
-          - alertmanager.openfaas:9093
+          - alertmanager:9093
   alert.rules.yml: |
     groups:
-    - name: openfaas
-      rules:
-      - alert: service_down
-        expr: up == 0
-      - alert: APIHighInvocationRate
-        expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name)
-          > 5
-        for: 5s
-        labels:
-          service: gateway
-          severity: major
-          value: '{{$value}}'
-        annotations:
-          description: High invocation total on {{ $labels.instance }}
-          summary: High invocation total on {{ $labels.instance }}
----
+      - name: openfaas
+        rules:
+        - alert: service_down
+          expr: up == 0
+        - alert: APIHighInvocationRate
+          expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+          for: 5s
+          labels:
+            service: gateway
+            severity: major
+          annotations:
+            description: High invocation total on "{{$labels.function_name}}"
+            summary: High invocation total on "{{$labels.function_name}}"

--- a/yaml_armhf/prometheus-dep.yml
+++ b/yaml_armhf/prometheus-dep.yml
@@ -1,30 +1,57 @@
+---
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: prometheus
   name: prometheus
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: prometheus
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/prometheus-config: "6c1e41fcc392e2bfcfc6ddfd512cf520a6458abf28692c9422f90120388c38f9"
     spec:
+      serviceAccountName: faas-prometheus
       containers:
       - name: prometheus
-        image: functions/prometheus:2.2.0-armhf
-        command: 
+        resources:
+          requests:
+            memory: "512Mi"
+        image: functions/prometheus:2.7.1-armhf
+        command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: Always
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          timeoutSeconds: 30
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          timeoutSeconds: 30
         ports:
         - containerPort: 9090
           protocol: TCP
-        resources:
-          requests:
-            memory: 250Mi
-          limits:
-            memory: 250Mi
         volumeMounts:
         - mountPath: /etc/prometheus/prometheus.yml
           name: prometheus-config
@@ -32,6 +59,8 @@ spec:
         - mountPath: /etc/prometheus/alert.rules.yml
           name: prometheus-config
           subPath: alert.rules.yml
+        - mountPath: /prometheus/data
+          name: prom-data
       volumes:
         - name: prometheus-config
           configMap:
@@ -43,3 +72,5 @@ spec:
               - key: alert.rules.yml
                 path: alert.rules.yml
                 mode: 0644
+        - name: prom-data
+          emptyDir: {}

--- a/yaml_armhf/prometheus-rbac.yml
+++ b/yaml_armhf/prometheus-rbac.yml
@@ -1,0 +1,43 @@
+---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: faas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: faas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: faas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    component: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: faas-prometheus
+subjects:
+- kind: ServiceAccount
+  name: faas-prometheus
+  namespace: "openfaas"

--- a/yaml_armhf/prometheus-svc.yml
+++ b/yaml_armhf/prometheus-svc.yml
@@ -1,16 +1,17 @@
+---
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus
-  namespace: openfaas
   labels:
-    app: prometheus
+    app: openfaas
+    component: prometheus
+  name: prometheus
+  namespace: "openfaas"
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 9090
       protocol: TCP
-      targetPort: 9090
-      nodePort: 31119
   selector:
     app: prometheus

--- a/yaml_armhf/queueworker-dep.yml
+++ b/yaml_armhf/queueworker-dep.yml
@@ -1,24 +1,37 @@
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    app: openfaas
+    component: queue-worker
   name: queue-worker
-  namespace: openfaas
+  namespace: "openfaas"
 spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "false"
       labels:
         app: queue-worker
     spec:
       containers:
       - name:  queue-worker
+        resources:
+          requests:
+            memory: "120Mi"
+            cpu: "50m"
         image: openfaas/queue-worker:0.4.9-armhf
         imagePullPolicy: Always
         env:
-        - name: max_inflight
-          value: "1"
-        - name: ack_wait    # Max duration of any async task / request
-          value: "30s"
+        - name: faas_nats_address
+          value: "nats.openfaas.svc.cluster.local"
+        - name: faas_gateway_address
+          value: "gateway.openfaas.svc.cluster.local"
+        - name: "gateway_invoke"
+          value: "true"
         - name: faas_function_suffix
-          value: ".openfaas-fn"
- 
+          value: ".openfaas-fn.svc.cluster.local"
+        - name: ack_wait    # Max duration of any async task / request
+          value: 60s


### PR DESCRIPTION
Merge which closes: #457

- Tweak create-static-manifest to allow values files not in the chart
directory
- Add values files to set the docker images for the arm64 and armhf
- Update make to generate the arm manifest when we package the helm
chart

- Update to go 1.11 and enable go module support so that we can install
and use kubectl.  The upstream recently switched to modules and does not
work as expcted in 1.10 at the moment.  This only changes the CI go
version and should not impact the docker image builds

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>
