### PR TITLE
Helm chart should allow configuring resource requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ faas-netes can be configured with environment variables, but for a full set of o
 | `httpProbe`         | Boolean - use http probe type for function readiness and liveness. Default: `false`             |
 | `write_timeout`     | HTTP timeout for writing a response body from your function (in seconds). Default: `60s`        |
 | `read_timeout`      | HTTP timeout for reading the payload from the client caller (in seconds). Default: `60s`        |
-| `image_pull_policy` | Image pull policy for deployed functions (`Always`, `IfNotPresent`, `Never`.  Default: `Always` |
+| `image_pull_policy` | Image pull policy for deployed functions (`Always`, `IfNotPresent`, `Never`).  Default: `Always` |
+| `gateway.resource`        | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `faasnetes.resource`      | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `operator.resource`       | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `queueWorker.resource`    | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `prometheus.resource`     | CPU/Memory resource requests/limits (memory: `512Mi`)             |
+| `alertmanager.resource`   | CPU/Memory resource requests/limits (memory: `25Mi`)              |
+| `nats.resource`           | CPU/Memory resource requests/limits (memory: `120Mi`)             |
+| `faasIdler.resource`      | CPU/Memory resource requests/limits (memory: `64Mi`)              |
+| `basicAuthPlugin.resource`| CPU/Memory resource requests/limits (memory: `50Mi`, cpu: `20m`)  |
 
 ### Readiness checking
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ faas-netes can be configured with environment variables, but for a full set of o
 | `write_timeout`     | HTTP timeout for writing a response body from your function (in seconds). Default: `60s`        |
 | `read_timeout`      | HTTP timeout for reading the payload from the client caller (in seconds). Default: `60s`        |
 | `image_pull_policy` | Image pull policy for deployed functions (`Always`, `IfNotPresent`, `Never`).  Default: `Always` |
-| `gateway.resource`        | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
-| `faasnetes.resource`      | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
-| `operator.resource`       | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
-| `queueWorker.resource`    | CPU/Memory resource requests/limits (memory: `120Mi`, cpu: `50m`) |
-| `prometheus.resource`     | CPU/Memory resource requests/limits (memory: `512Mi`)             |
-| `alertmanager.resource`   | CPU/Memory resource requests/limits (memory: `25Mi`)              |
-| `nats.resource`           | CPU/Memory resource requests/limits (memory: `120Mi`)             |
-| `faasIdler.resource`      | CPU/Memory resource requests/limits (memory: `64Mi`)              |
-| `basicAuthPlugin.resource`| CPU/Memory resource requests/limits (memory: `50Mi`, cpu: `20m`)  |
+| `gateway.resources`        | CPU/Memory resources requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `faasnetes.resources`      | CPU/Memory resources requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `operator.resources`       | CPU/Memory resources requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `queueWorker.resources`    | CPU/Memory resources requests/limits (memory: `120Mi`, cpu: `50m`) |
+| `prometheus.resources`     | CPU/Memory resources requests/limits (memory: `512Mi`)             |
+| `alertmanager.resources`   | CPU/Memory resources requests/limits (memory: `25Mi`)              |
+| `nats.resources`           | CPU/Memory resources requests/limits (memory: `120Mi`)             |
+| `faasIdler.resources`      | CPU/Memory resources requests/limits (memory: `64Mi`)              |
+| `basicAuthPlugin.resources`| CPU/Memory resources requests/limits (memory: `50Mi`, cpu: `20m`)  |
 
 ### Readiness checking
 

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -24,9 +24,6 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        resources:
-          requests:
-            memory: "32Mi"
         image: {{ .Values.alertmanager.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
@@ -57,10 +54,7 @@ spec:
         - containerPort: 9093
           protocol: TCP
         resources:
-          requests:
-            memory: 25Mi
-          limits:
-            memory: 50Mi
+          {{- .Values.alertmanager.resources | toYaml | nindent 12 }}
         volumeMounts:
         - mountPath: /alertmanager.yml
           name: alertmanager-config

--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -30,9 +30,7 @@ spec:
       containers:
       - name:  basic-auth-plugin
         resources:
-          requests:
-            memory: "50Mi"
-            cpu: "20m"
+          {{- .Values.basicAuthPlugin.resources | toYaml | nindent 12 }}
         image: {{ .Values.basicAuthPlugin.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.securityContext }}

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -24,8 +24,7 @@ spec:
       containers:
         - name: faas-idler
           resources:
-            requests:
-              memory: "64Mi"
+            {{- .Values.faasIdler.resources | toYaml | nindent 12 }}
           image: {{ .Values.faasIdler.image }}
           imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
           env:

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -34,9 +34,7 @@ spec:
       containers:
       - name: gateway
         resources:
-          requests:
-            memory: "120Mi"
-            cpu: "50m"
+          {{- .Values.gateway.resources | toYaml | nindent 12 }}
         image: {{ .Values.gateway.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.securityContext }}
@@ -112,9 +110,7 @@ spec:
       {{- if .Values.operator.create }}
       - name: operator
         resources:
-          requests:
-            memory: "120Mi"
-            cpu: "50m"
+          {{- .Values.operator.resources | toYaml | nindent 12 }}
         image: {{ .Values.operator.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
@@ -154,9 +150,7 @@ spec:
       {{- else }}
       - name: faas-netes
         resources:
-          requests:
-            memory: "120Mi"
-            cpu: "50m"
+          {{- .Values.faasnetes.resources | toYaml | nindent 12 }}
         image: {{ .Values.faasnetes.image }}
         imagePullPolicy: {{ .Values.openFaasImagePullPolicy }}
         {{- if .Values.securityContext }}

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -23,8 +23,7 @@ spec:
       containers:
       - name:  nats
         resources:
-          requests:
-            memory: "120Mi"
+          {{- .Values.nats.resources | toYaml | nindent 12 }}
         image: {{ .Values.nats.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         ports:

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -26,8 +26,7 @@ spec:
       containers:
       - name: prometheus
         resources:
-          requests:
-            memory: "512Mi"
+          {{- .Values.prometheus.resources | toYaml | nindent 12 }}
         image: {{ .Values.prometheus.image }}
         command:
           - "prometheus"

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -28,9 +28,7 @@ spec:
       containers:
       - name:  queue-worker
         resources:
-          requests:
-            memory: "120Mi"
-            cpu: "50m"
+          {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
         image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         env:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -22,6 +22,10 @@ gateway:
   nodePort: 31112
   maxIdleConns: 1024
   maxIdleConnsPerHost: 1024
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
 
 faasnetes:
   image: openfaas/faas-netes:0.8.0
@@ -38,6 +42,10 @@ faasnetes:
     initialDelaySeconds: 2
     timeoutSeconds: 1
     periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
 
 # replaces faas-netes with openfaas-operator
 operator:
@@ -46,27 +54,46 @@ operator:
   # set this to false when creating multiple releases in the same cluster
   # must be true for the first one only
   createCRD: true
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
 
 queueWorker:
   image: openfaas/queue-worker:0.7.2
   ackWait : "60s"
   replicas: 1
   gatewayInvoke: true
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
 
 # monitoring and auto-scaling components
 # both components
 prometheus:
   image: prom/prometheus:v2.7.1
   create: true
+  resources:
+    requests:
+      memory: "512Mi"
 
 alertmanager:
   image: prom/alertmanager:v0.16.1
   create: true
+  resources:
+    requests:
+      memory: "25Mi"
+    limits:
+      memory: "50Mi"
 
 # async provider
 nats:
   image: nats-streaming:0.11.2
   enableMonitoring: false
+  resources:
+    requests:
+      memory: "120Mi"
 
 # ingress configuration
 ingress:
@@ -89,11 +116,18 @@ faasIdler:
   create: true
   inactivityDuration: 15m               # If a function is inactive for 15 minutes, it may be scaled to zero
   reconcileInterval: 1m                 # The interval between each attempt to scale functions to zero
-  dryRun: true                          # Set to true to enable the idler to apply changes and scale to zero
+  dryRun: true                          # Set to false to enable the idler to apply changes and scale to zero
+  resources:
+    requests:
+      memory: "64Mi"
 
 basicAuthPlugin:
   image: openfaas/basic-auth-plugin:0.1.1
   replicas: 1
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "20m"
 
 nodeSelector: {}
 

--- a/contrib/values-armhf.yaml
+++ b/contrib/values-armhf.yaml
@@ -11,6 +11,9 @@ queueWorker:
 
 prometheus:
   image: functions/prometheus:2.7.1-armhf
+  resources:
+    requests:
+      memory: "125Mi"
 
 alertmanager:
   image: functions/alertmanager:0.16.1-armhf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The Helm chart does not set nor allow setting the resource.request or resource.limit for any of the deployment objects. Each of the deployment objects should read a corresponding resources value to allow the user to set/modify the requests as appropriate to their cluster.

## Description
<!--- Describe your changes in detail -->
Move default resource values to chart/openfaas/values.yaml. User can override the value if needed.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/openfaas/faas-netes/issues/213
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed openfaas by with -f values.yaml, and I can see the resources in deployed object use the resource defined in values.yaml.
The default gateway.resources in values.yaml is:
```
  resources:
    requests:
      memory: "120Mi"
      cpu: "50m"
```
After i copy values.yaml  to values2.yaml, and update the gateway.resources to:
```
  resources:
    requests:
      memory: "120Mi"
      cpu: "50m"
    limits:
      memory: "200Mi"
      cpu: "100m"
```
And install the helm chart with option `-f values2.yaml`, i can see the resources by `kubectl describe deployment/gateway`:
```
  Containers:
   gateway:
    Image:  openfaas/gateway:0.14.4
    Port:   8080/TCP
    Limits:
      cpu:     100m
      memory:  200Mi
    Requests:
      cpu:      50m
      memory:   120Mi
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
