### PR TITLE
Install Function CRD in crd-install phase

### DIFF
--- a/chart/openfaas/templates/crd.yaml
+++ b/chart/openfaas/templates/crd.yaml
@@ -5,6 +5,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: functions.openfaas.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: openfaas.com
   version: v1alpha2


### PR DESCRIPTION
Sorry for making a PR before creating the issue! You can just close it if you want to the issue to be approved first.

## Description

This PR adds `crd-install` hook annotation to the Helm Chart. Without the annotation, the very first Helm deployment with `Function` resources fails because the `Function` CRD is not deployed yet.

- [Helm Hooks](https://github.com/helm/helm/blob/master/docs/charts_hooks.md)

## Motivation and Context

Fix #464.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Tested locally in the procedure below.

1. Create a new Helm Chart.
1. Add the `openfaas` Helm Chart as a dependency to `requirements.yaml` [with a local path](https://github.com/helm/helm/pull/1923) (e.g. `../openfaas`).
1. Run `helm upgrade --install`.

My Helm Chart cannot run locally with full features but I confirmed that `Function` CRD and my `Function` resource is created correctly without error.

```
> kubectl get crd --all-namespaces
NAME                                CREATED AT
...
functions.openfaas.com              2019-07-02T22:13:42Z
...

> kubectl get function
NAME           AGE
health-check   3m13s
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.