### PR TITLE
Allow deploying core services with http healthchecks

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -249,6 +249,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `serviceType` | Type of external service to use `NodePort/LoadBalancer` | `NodePort` |
 | `basic_auth` | Enable basic authentication on the Gateway | `true` |
 | `rbac` | Enable RBAC | `true` |
+| `httpProbe` | Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5) | `true` |
 | `securityContext` | Deploy with a `securityContext` set, this can be disabled for use with Istio sidecar injection | `true` |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
 | `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -31,6 +31,11 @@ spec:
           - "--config.file=/alertmanager.yml"
           - "--storage.path=/alertmanager"
         livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/ready
+            port: 9093
+          {{- else }}
           exec:
             command:
             - wget
@@ -39,8 +44,14 @@ spec:
             - --timeout=30
             - --spider
             - http://localhost:9093/-/ready
+          {{- end }}
           timeoutSeconds: 30
         readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/ready
+            port: 9093
+          {{- else }}
           exec:
             command:
             - wget
@@ -49,6 +60,7 @@ spec:
             - --timeout=30
             - --spider
             - http://localhost:9093/-/ready
+          {{- end }}
           timeoutSeconds: 30
         ports:
         - containerPort: 9093

--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -39,6 +39,11 @@ spec:
           runAsUser: 10001
         {{- end }}
         livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /health
+            port: 8080
+          {{- else }}
           exec:
             command:
             - wget
@@ -47,8 +52,14 @@ spec:
             - --timeout=5
             - --spider
             - http://localhost:8080/health
+          {{- end }}
           timeoutSeconds: 5
         readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /health
+            port: 8080
+          {{- else }}
           exec:
             command:
             - wget
@@ -57,6 +68,7 @@ spec:
             - --timeout=5
             - --spider
             - http://localhost:8080/health
+          {{- end }}
           timeoutSeconds: 5
         env:
         {{- if .Values.basic_auth }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -43,6 +43,11 @@ spec:
           runAsUser: 10001
         {{- end }}
         livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /healthz
+            port: 8080
+          {{- else }}
           exec:
             command:
             - wget
@@ -51,8 +56,14 @@ spec:
             - --timeout=5
             - --spider
             - http://localhost:8080/healthz
+          {{- end }}
           timeoutSeconds: 5
         readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /healthz
+            port: 8080
+          {{- else }}
           exec:
             command:
             - wget
@@ -61,6 +72,7 @@ spec:
             - --timeout=5
             - --spider
             - http://localhost:8080/healthz
+          {{- end }}
           timeoutSeconds: 5
         env:
         - name: read_timeout

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -33,6 +33,11 @@ spec:
           - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          {{- else }}
           exec:
             command:
             - wget
@@ -41,8 +46,14 @@ spec:
             - --timeout=30
             - --spider
             - http://localhost:9090/-/healthy
+          {{- end }}
           timeoutSeconds: 30
         readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          {{- else }}
           exec:
             command:
             - wget
@@ -51,6 +62,7 @@ spec:
             - --timeout=30
             - --spider
             - http://localhost:9090/-/healthy
+          {{- end }}
           timeoutSeconds: 30
         ports:
         - containerPort: 9090

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -4,6 +4,7 @@ async: true
 
 exposeServices: true
 serviceType: NodePort
+httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
 rbac: true
 securityContext: true
 basic_auth: true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- HTTP health checks are more efficient for the cluster, but can be
incompatible with systems like Istio.  This allows the user to configure
the deploy with http probes or exec probes based on their needs. The
default will be http probes to provide an initial lightweight experience
out of the box.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolved #460 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested by

1) starting the KinD environment using `make start-kind`
2) I then upgrade the install with my local chart using 

```
export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
helm upgrade openfaas --install ./chart/openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set openfaasImagePullPolicy=IfNotPresent \
    --set faasnetes.imagePullPolicy=IfNotPresent \
    --set functionNamespace=openfaas-fn
```
3) I let everything rollout and then verified that every component reached a "Running" state
4) I then verified that the pod yaml was using an httpProbe and not the exec probe

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
