### PR TITLE
Handle 'AlreadyExists' error during secret creation.

### DIFF
--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -319,6 +319,8 @@ func isNotFound(err error) bool {
 // processErrorReasons maps k8serrors.ReasonForError to http status codes
 func processErrorReasons(err error) (int, metav1.StatusReason) {
 	switch {
+	case k8serrors.IsAlreadyExists(err):
+		return http.StatusConflict, metav1.StatusReasonAlreadyExists
 	case k8serrors.ReasonForError(err) == metav1.StatusReasonConflict:
 		return http.StatusConflict, metav1.StatusReasonConflict
 	case k8serrors.ReasonForError(err) == metav1.StatusReasonInvalid:

--- a/handlers/secrets_api_test.go
+++ b/handlers/secrets_api_test.go
@@ -52,6 +52,15 @@ func Test_SecretsHandler(t *testing.T) {
 		if actualValue != secretValue {
 			t.Errorf("want secret value: '%s', got: '%s'", secretValue, actualValue)
 		}
+
+		// Attempt to re-create the secret and make sure that "409 CONFLICT" is returned.
+		newReq := httptest.NewRequest("POST", "http://example.com/foo", strings.NewReader(payload))
+		newW := httptest.NewRecorder()
+		secretsHandler(newW, newReq)
+		newResp := newW.Result()
+		if newResp.StatusCode != http.StatusConflict {
+			t.Errorf("want status code '%d', got '%d'", http.StatusConflict, newResp.StatusCode)
+		}
 	})
 
 	t.Run("update managed secrets", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds support for handling the `AlreadyExists` reason returned by the Kubernetes API whenever we try to create a secret that already exists.

## Motivation and Context

Currently, trying to create a secret that already exists returns the following message:

```
server returned unexpected status code: 500 -
```

This, alongside the companion PR https://github.com/openfaas/faas-cli/pull/655, will allow OpenFaaS to return a more meaningful, user-friendly error message:

```
a secret with the same name already exists, run "faas-cli secret update" instead
```

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

I've tested it by extending the existing unit tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
