### PR TITLE
Fix readFunction

### DIFF
--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -89,7 +89,7 @@ func readFunction(item appsv1.Deployment) *requests.Function {
 		replicas = uint64(*item.Spec.Replicas)
 	}
 
-	labels := item.Labels
+	labels := item.Spec.Template.Labels
 	function := requests.Function{
 		Name:              item.Name,
 		Replicas:          replicas,

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -3,11 +3,12 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openfaas/faas-netes/k8s"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/openfaas/faas-netes/k8s"
 
 	"github.com/openfaas/faas/gateway/requests"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +90,7 @@ func updateDeploymentSpec(
 			}
 		}
 
-		deployment.Labels = labels
+		// deployment.Labels = labels
 		deployment.Spec.Template.ObjectMeta.Labels = labels
 
 		deployment.Annotations = annotations


### PR DESCRIPTION
## Description

Fix readFunction

## Details

Unfortunately some regression was caused by
a9554655badad60b01e41d6d9afcfeffca0e1b02 which caused OpenFaaS
Cloud not to show customer functions on their first commit
i.e. "create", but always after their second commit.

The reason was a difference between the logic for create/update
for managing labels.

Change was updated to only create labels for the Pod template,
but readFunction was left reading from the Deployment template
which meant that we had no labels.

The inconsistency was due to the update code adding the labels
where readFunction expected to find them.

This has been tested e2e and as a result:

readFunction - reads from the Pod template
create - writes to the Pod template
update - creates only in the Pod template

Signed-off-by: Alex Ellis <alexellis2@gmail.com>