### PR TITLE
Add pod security policy to helm chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -254,6 +254,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `basic_auth` | Enable basic authentication on the Gateway | `true` |
 | `rbac` | Enable RBAC | `true` |
 | `httpProbe` | Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (compatible with Istio >= 1.1.5) | `true` |
+| `psp` | Enable Pod Security Policy for OpenFaaS accounts | `false` |
 | `securityContext` | Deploy with a `securityContext` set, this can be disabled for use with Istio sidecar injection | `true` |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
 | `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -254,7 +254,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `basic_auth` | Enable basic authentication on the Gateway | `true` |
 | `rbac` | Enable RBAC | `true` |
 | `httpProbe` | Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (compatible with Istio >= 1.1.5) | `true` |
-| `psp` | Enable Pod Security Policy for OpenFaaS accounts | `false` |
+| `psp` | Enable [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for OpenFaaS accounts | `false` |
 | `securityContext` | Deploy with a `securityContext` set, this can be disabled for use with Istio sidecar injection | `true` |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
 | `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |

--- a/chart/openfaas/templates/psp.yaml
+++ b/chart/openfaas/templates/psp.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.psp }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: {{ .Release.Name }}-psp
+    labels:
+        app: {{ template "openfaas.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    annotations:
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+    privileged: false
+    hostIPC: false
+    hostNetwork: false
+    hostPID: false
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    allowedCapabilities:
+        - '*'
+    fsGroup:
+        rule: RunAsAny
+    hostPorts:
+        - max: 65535
+          min: 1
+    runAsUser:
+        rule: RunAsAny
+    seLinux:
+        rule: RunAsAny
+    supplementalGroups:
+        rule: RunAsAny
+    volumes:
+        - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+    name: {{ .Release.Name }}-psp
+    labels:
+        app: {{ template "openfaas.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+rules:
+    - apiGroups: ['policy']
+      resources: ['podsecuritypolicies']
+      verbs:     ['use']
+      resourceNames:
+          - openfaas-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: {{ .Release.Name }}-psp
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: {{ .Release.Name }}-psp
+subjects:
+    # bind the PSP cluster role to all service accounts in the OF namespace
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: system:serviceaccounts:{{ .Release.Namespace }}
+      namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/openfaas/templates/psp.yaml
+++ b/chart/openfaas/templates/psp.yaml
@@ -19,7 +19,8 @@ spec:
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     allowedCapabilities:
-        - '*'
+        - NET_ADMIN
+        - NET_RAW
     fsGroup:
         rule: RunAsAny
     hostPorts:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -6,6 +6,8 @@ exposeServices: true
 serviceType: NodePort
 httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
 rbac: true
+# create pod security policies for OpenFaaS control plane
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 psp: false
 securityContext: true
 basic_auth: true

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -6,6 +6,7 @@ exposeServices: true
 serviceType: NodePort
 httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
 rbac: true
+psp: false
 securityContext: true
 basic_auth: true
 


### PR DESCRIPTION
- create OF PSP with privileged, hostIPC, hostNetwork and hostPID disabled
- bind the PSP cluster role to all service accounts in the OF namespace

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fix: #471 

## How Has This Been Tested?
Tested on EKS 1.13 with PSP enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
