### PR TITLE
Add lambda configuration to chart

### DIFF
--- a/chart/openfaas/templates/controller-rbac.yaml
+++ b/chart/openfaas/templates/controller-rbac.yaml
@@ -1,5 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if eq .Values.faasnetes.create true }}
+{{- if .Values.faasnetes.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/openfaas/templates/faas-lambda-rbac.yaml
+++ b/chart/openfaas/templates/faas-lambda-rbac.yaml
@@ -1,5 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if eq .Values.faasnetes.create true }}
+{{- if eq .Values.faaslambda.create true }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -7,10 +7,10 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: faas-controller
+    component: faas-lambda
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ .Release.Name }}-controller
+  name: {{ .Release.Name }}-lambda
   namespace: {{ .Release.Namespace | quote }}
 {{- if .Values.rbac }}
 ---
@@ -20,10 +20,10 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: faas-controller
+    component: faas-lambda
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ .Release.Name }}-controller
+  name: {{ .Release.Name }}-lambda
   namespace: {{ $functionNs | quote }}
 rules:
   - apiGroups:
@@ -77,18 +77,18 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: faas-controller
+    component: faas-lambda
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ .Release.Name }}-controller
+  name: {{ .Release.Name }}-lambda
   namespace: {{ $functionNs | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-controller
+  name: {{ .Release.Name }}-lambda
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-controller
+    name: {{ .Release.Name }}-lambda
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -22,6 +22,8 @@ spec:
     spec:
       {{- if .Values.operator.create }}
       serviceAccountName: {{ .Release.Name }}-operator
+      {{- else if .Values.faaslambda.create }}
+      serviceAccountName: {{ .Release.Name }}-lambda
       {{- else }}
       serviceAccountName: {{ .Release.Name }}-controller
       {{- end }}
@@ -83,8 +85,13 @@ spec:
           value: "{{ .Values.gateway.upstreamTimeout }}"
         - name: functions_provider_url
           value: "http://127.0.0.1:8081/"
+        {{- if .Values.faaslambda.create}}
+        - name: direct_functions
+          value: "false"
+        {{- else }}
         - name: direct_functions
           value: "true"
+        {{- end }}
         - name: direct_functions_suffix
           value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}"
         {{- if .Values.async }}
@@ -159,6 +166,75 @@ spec:
         ports:
         - containerPort: 8081
           protocol: TCP
+      {{- else if .Values.faaslambda.create }}
+      - name: faaslambda
+        resources:
+          {{- .Values.operator.resources | toYaml | nindent 12 }}
+        image: {{ .Values.faaslambda.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
+        env:
+          - name: port
+            value: "8081"
+          - name: function_namespace
+            value: {{ $functionNs | quote }}
+          - name: read_timeout
+            value: "{{ .Values.faaslambda.readTimeout }}"
+          - name: write_timeout
+            value: "{{ .Values.faaslambda.writeTimeout }}"
+          - name: image_pull_policy
+            value: {{ .Values.faaslambda.imagePullPolicy | quote }}
+          - name: http_probe
+            value: "{{ .Values.faaslambda.httpProbe }}"
+          - name: secret_mount_path
+            value: "/var/secrets"
+          {{- if .Values.basic_auth }}
+          - name: basic_auth
+            value: "{{ .Values.basic_auth }}"
+          {{- end }}
+          - name: readiness_probe_initial_delay_seconds
+            value: "{{ .Values.faaslambda.readinessProbe.initialDelaySeconds }}"
+          - name: readiness_probe_timeout_seconds
+            value: "{{ .Values.faaslambda.readinessProbe.timeoutSeconds }}"
+          - name: readiness_probe_period_seconds
+            value: "{{ .Values.faaslambda.readinessProbe.periodSeconds }}"
+          - name: liveness_probe_initial_delay_seconds
+            value: "{{ .Values.faaslambda.livenessProbe.initialDelaySeconds }}"
+          - name: liveness_probe_timeout_seconds
+            value: "{{ .Values.faaslambda.livenessProbe.timeoutSeconds }}"
+          - name: liveness_probe_period_seconds
+            value: "{{ .Values.faaslambda.livenessProbe.periodSeconds }}"
+          - name: lambda_execution_role
+            value: "{{ .Values.faaslambda.lambda_execution_role }}"
+          - name: access_token
+            value: "{{ .Values.faaslambda.access_token }}"
+          - name: access_email
+            value: "{{ .Values.faaslambda.access_email }}"
+          - name: AWS_REGION
+            value: "{{ .Values.faaslambda.aws_region }}"
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: lambda-aws-access
+                key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: lambda-aws-access
+                key: AWS_SECRET_ACCESS_KEY
+        {{- if .Values.basic_auth }}
+        volumeMounts:
+          - name: auth
+            readOnly: true
+            mountPath: "/var/secrets"
+        {{- end }}
+        ports:
+          - containerPort: 8080
+            protocol: TCP
       {{- else }}
       - name: faas-netes
         resources:

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -174,7 +174,7 @@ spec:
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.securityContext }}
         securityContext:
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsUser: 10001
         {{- end }}
         env:

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -196,24 +196,12 @@ spec:
           - name: basic_auth
             value: "{{ .Values.basic_auth }}"
           {{- end }}
-          - name: readiness_probe_initial_delay_seconds
-            value: "{{ .Values.faaslambda.readinessProbe.initialDelaySeconds }}"
-          - name: readiness_probe_timeout_seconds
-            value: "{{ .Values.faaslambda.readinessProbe.timeoutSeconds }}"
-          - name: readiness_probe_period_seconds
-            value: "{{ .Values.faaslambda.readinessProbe.periodSeconds }}"
-          - name: liveness_probe_initial_delay_seconds
-            value: "{{ .Values.faaslambda.livenessProbe.initialDelaySeconds }}"
-          - name: liveness_probe_timeout_seconds
-            value: "{{ .Values.faaslambda.livenessProbe.timeoutSeconds }}"
-          - name: liveness_probe_period_seconds
-            value: "{{ .Values.faaslambda.livenessProbe.periodSeconds }}"
           - name: lambda_execution_role
-            value: "{{ .Values.faaslambda.lambda_execution_role }}"
+            value: "{{ required "An IAM execution role is required" .Values.faaslambda.lambda_execution_role }}"
           - name: access_token
-            value: "{{ .Values.faaslambda.access_token }}"
+            value: "{{ required "An OpenFaaS Lambda access token is required" .Values.faaslambda.access_token }}"
           - name: access_email
-            value: "{{ .Values.faaslambda.access_email }}"
+            value: "{{ required "The email address used when registering your OpenFaaS Lambda access token is required" .Values.faaslambda.access_email }}"
           - name: AWS_REGION
             value: "{{ .Values.faaslambda.aws_region }}"
           - name: AWS_ACCESS_KEY_ID

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -73,14 +73,6 @@ faaslambda:
   imagePullPolicy : "Always"    # Image pull policy for deployed functions
   httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on Pods (incompatible with Istio < 1.1.5)
   setNonRootUser: false
-  readinessProbe:
-    initialDelaySeconds: 2
-    timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
-    periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
-  livenessProbe:
-    initialDelaySeconds: 2
-    timeoutSeconds: 1
-    periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
   resources:
     requests:
       memory: "120Mi"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -63,6 +63,33 @@ operator:
       memory: "120Mi"
       cpu: "50m"
 
+# configuration options for the faas-lambda provider
+faaslambda:
+  image: ewilde/faas-lambda:0.1
+  create: false
+  replicas: 1
+  readTimeout : "60s"
+  writeTimeout : "60s"
+  imagePullPolicy : "Always"    # Image pull policy for deployed functions
+  httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on Pods (incompatible with Istio < 1.1.5)
+  setNonRootUser: false
+  readinessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
+    periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  livenessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1
+    periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+  lambda_execution_role: ""
+  access_token: ""
+  access_email: ""
+  aws_region: ""
+
 queueWorker:
   image: openfaas/queue-worker:0.7.2
   ackWait : "60s"


### PR DESCRIPTION
## Description
This PR adds OpenFaaS Lambda configuration to the Helm chart

## Motivation and Context
The idea for this was raised as part of the instructions for the up coming blog: https://github.com/openfaas/openfaas.github.io/pull/124


## How Has This Been Tested?
The following manual tests of the chart have been performed:

- [x] Lambda mode
- [x] faasnetes mode
- [x] operator mode

### Lambda mode
Step 1 - deploy chart
```
$ helm repo update \
 && helm upgrade openfaas --install openfaas/openfaas \
                                     --namespace openfaas  \
                                     --set faaslambda.create=true \
                                     --set functionNamespace=openfaas-fn \
                                     --set faaslambda.aws_region=eu-west-1 \
                                     --set faaslambda.lambda_execution_role=arn:aws:iam::123445:role/openfaas-lambda \
                                     --set faaslambda.access_token=token_from_blog_instructions \
                                     --set faaslambda.access_email=you@domain.com


Release "openfaas" has been upgraded. Happy Helming!
```


Step 2 - verify containers running
```
$ kubectl get pods -n openfaas -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'

alertmanager-666c65c694-vs7gl:	prom/alertmanager:v0.16.1,
basic-auth-plugin-6d97c6dc5b-66pkl:	openfaas/basic-auth-plugin:0.1.1,
faas-idler-67f9dcd4fc-5jmfw:	openfaas/faas-idler:0.1.9,
gateway-6cbbcbfd4f-wmnvz:	openfaas/gateway:0.15.0, ewilde/faas-lambda:0.1,
nats-d4c9d8d95-kgb4t:	nats-streaming:0.11.2,
prometheus-549c7d687d-qbwl7:	prom/prometheus:v2.7.1,
queue-worker-544bcb7c67-jwpld:	openfaas/queue-worker:0.7.2,
```


Step 3 - install function and validate
```
$faas store deploy "SSL/TLS cert info"
faas list

echo -n 'google.com' | faas invoke certinfo                                                  


Host 74.125.193.101
Port 443
Issuer Google Internet Authority G3
CommonName *.google.com
NotBefore 2019-06-18 08:21:58 +0000 UTC
NotAfter 2019-09-10 08:15:00 +0000 UTC
NotAfterUnix 1568103300
SANs [*.google.com *.android.com *.appengine.google.com *.cloud.google.com *.crowdsource.google.com *.g.co *.gcp.gvt2.com *.gcpcdn.gvt1.com *.ggpht.cn *.google-analytics.com *.google.ca *.google.cl *.google.co.in *.google.co.jp *.google.co.uk *.google.com.ar *.google.com.au *.google.com.br *.google.com.co *.google.com.mx *.google.com.tr *.google.com.vn *.google.de *.google.es *.google.fr *.google.hu *.google.it *.google.nl *.google.pl *.google.pt *.googleadapis.com *.googleapis.cn *.googlecnapps.cn *.googlecommerce.com *.googlevideo.com *.gstatic.cn *.gstatic.com *.gstaticcnapps.cn *.gvt1.com *.gvt2.com *.metric.gstatic.com *.urchin.com *.url.google.com *.youtube-nocookie.com *.youtube.com *.youtubeeducation.com *.youtubekids.com *.yt.be *.ytimg.com android.clients.google.com android.com developer.android.google.cn developers.android.google.cn g.co ggpht.cn goo.gl google-analytics.com google.com googlecnapps.cn googlecommerce.com source.android.google.cn urchin.com www.goo.gl youtu.be youtube.com youtubeeducation.com youtubekids.com yt.be]
TimeRemaining 1 month from now
```


### faas-netes mode
Step 1 - deploy chart
```
helm upgrade openfaas \
   --install openfaas/openfaas  \
   --namespace openfaas  \
   --set basic_auth=true \
   --set functionNamespace=openfaas-fn
```

Step 2 - verify containers running
```
$ k get pods -n openfaas -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'

alertmanager-666c65c694-vs7gl:	prom/alertmanager:v0.16.1,
basic-auth-plugin-6d97c6dc5b-66pkl:	openfaas/basic-auth-plugin:0.1.1,
faas-idler-67f9dcd4fc-5jmfw:	openfaas/faas-idler:0.1.9,
gateway-7c687d498f-7gtpn:	openfaas/gateway:0.15.0, openfaas/faas-netes:0.8.1,
nats-d4c9d8d95-kgb4t:	nats-streaming:0.11.2,
prometheus-549c7d687d-qbwl7:	prom/prometheus:v2.7.1,
queue-worker-544bcb7c67-jwpld:	openfaas/queue-worker:0.7.2
```

Step 3 - install function and validate
```
$ faas store deploy "SSL/TLS cert info"
faas list

faas list                                                                                    
Function                      	Invocations    	Replicas
certinfo                      	0              	1

$ echo -n 'google.com' | faas invoke certinfo        

Host 216.58.206.110
Port 443
Issuer Google Internet Authority G3
CommonName *.google.com
NotBefore 2019-06-18 08:21:58 +0000 UTC
NotAfter 2019-09-10 08:15:00 +0000 UTC
NotAfterUnix 1568103300
SANs [*.google.com *.android.com *.appengine.google.com *.cloud.google.com *.crowdsource.google.com *.g.co *.gcp.gvt2.com *.gcpcdn.gvt1.com *.ggpht.cn *.google-analytics.com *.google.ca *.google.cl *.google.co.in *.google.co.jp *.google.co.uk *.google.com.ar *.google.com.au *.google.com.br *.google.com.co *.google.com.mx *.google.com.tr *.google.com.vn *.google.de *.google.es *.google.fr *.google.hu *.google.it *.google.nl *.google.pl *.google.pt *.googleadapis.com *.googleapis.cn *.googlecnapps.cn *.googlecommerce.com *.googlevideo.com *.gstatic.cn *.gstatic.com *.gstaticcnapps.cn *.gvt1.com *.gvt2.com *.metric.gstatic.com *.urchin.com *.url.google.com *.youtube-nocookie.com *.youtube.com *.youtubeeducation.com *.youtubekids.com *.yt.be *.ytimg.com android.clients.google.com android.com developer.android.google.cn developers.android.google.cn g.co ggpht.cn goo.gl google-analytics.com google.com googlecnapps.cn googlecommerce.com source.android.google.cn urchin.com www.goo.gl youtu.be youtube.com youtubeeducation.com youtubekids.com yt.be]
TimeRemaining 1 month from now
```

### operator mode
Step 1 - deploy chart
```
helm upgrade openfaas \
   --install openfaas/openfaas  \
   --namespace openfaas  \
   --set basic_auth=true \
   --set functionNamespace=openfaas-fn \
   --set operator.create=true
```

Step 2 - verify containers running
```
$ k get pods -n openfaas -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'

alertmanager-666c65c694-vs7gl:	prom/alertmanager:v0.16.1,
basic-auth-plugin-6d97c6dc5b-66pkl:	openfaas/basic-auth-plugin:0.1.1,
faas-idler-67f9dcd4fc-5jmfw:	openfaas/faas-idler:0.1.9,
gateway-858b6746c7-xwrwk:	openfaas/gateway:0.15.0, openfaas/openfaas-operator:0.9.7,
nats-d4c9d8d95-kgb4t:	nats-streaming:0.11.2,
prometheus-549c7d687d-qbwl7:	prom/prometheus:v2.7.1,
queue-worker-544bcb7c67-jwpld:	openfaas/queue-worker:0.7.2,
```

Step 3 - install function and validate
```
$ faas store deploy "SSL/TLS cert info"
faas list

faas list                                                                                    
Function                      	Invocations    	Replicas
certinfo                      	0              	1

$ echo -n 'google.com' | faas invoke certinfo        

Host 216.58.210.238
Port 443
Issuer Google Internet Authority G3
CommonName *.google.com
NotBefore 2019-06-18 08:21:58 +0000 UTC
NotAfter 2019-09-10 08:15:00 +0000 UTC
NotAfterUnix 1568103300
SANs [*.google.com *.android.com *.appengine.google.com *.cloud.google.com *.crowdsource.google.com *.g.co *.gcp.gvt2.com *.gcpcdn.gvt1.com *.ggpht.cn *.google-analytics.com *.google.ca *.google.cl *.google.co.in *.google.co.jp *.google.co.uk *.google.com.ar *.google.com.au *.google.com.br *.google.com.co *.google.com.mx *.google.com.tr *.google.com.vn *.google.de *.google.es *.google.fr *.google.hu *.google.it *.google.nl *.google.pl *.google.pt *.googleadapis.com *.googleapis.cn *.googlecnapps.cn *.googlecommerce.com *.googlevideo.com *.gstatic.cn *.gstatic.com *.gstaticcnapps.cn *.gvt1.com *.gvt2.com *.metric.gstatic.com *.urchin.com *.url.google.com *.youtube-nocookie.com *.youtube.com *.youtubeeducation.com *.youtubekids.com *.yt.be *.ytimg.com android.clients.google.com android.com developer.android.google.cn developers.android.google.cn g.co ggpht.cn goo.gl google-analytics.com google.com googlecnapps.cn googlecommerce.com source.android.google.cn urchin.com www.goo.gl youtu.be youtube.com youtubeeducation.com youtubekids.com yt.be]
TimeRemaining 1 month from now
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
