### PR TITLE
Sort env-vars by string name

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -291,6 +292,10 @@ func buildEnvVars(request *types.FunctionDeployment) []corev1.EnvVar {
 			Value: v,
 		})
 	}
+
+	sort.SliceStable(envVars, func(i, j int) bool {
+		return strings.Compare(envVars[i].Name, envVars[j].Name) == -1
+	})
 
 	return envVars
 }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -1,11 +1,12 @@
 package handlers
 
 import (
-	"github.com/openfaas/faas-netes/k8s"
-	"k8s.io/client-go/kubernetes/fake"
 	"testing"
 
-	"github.com/openfaas/faas/gateway/requests"
+	"github.com/openfaas/faas-netes/k8s"
+	types "github.com/openfaas/faas-provider/types"
+	"k8s.io/client-go/kubernetes/fake"
+
 	apiv1 "k8s.io/api/core/v1"
 )
 
@@ -90,4 +91,65 @@ func Test_SetNonRootUser(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_buildEnvVars_TwoSortedKeys(t *testing.T) {
+	firstKey := "first"
+	lastKey := "last"
+
+	inputEnvs := map[string]string{
+		lastKey:  "",
+		firstKey: "",
+	}
+
+	function := types.FunctionDeployment{
+		EnvVars: inputEnvs,
+	}
+
+	coreEnvs := buildEnvVars(&function)
+
+	if coreEnvs[0].Name != firstKey {
+		t.Errorf("first want: %s, got: %s", firstKey, coreEnvs[0].Name)
+		t.Fail()
+	}
+}
+
+func Test_buildEnvVars_FourSortedKeys(t *testing.T) {
+	firstKey := "alex"
+	secondKey := "elliot"
+	thirdKey := "stefan"
+	lastKey := "zane"
+
+	inputEnvs := map[string]string{
+		lastKey:   "",
+		firstKey:  "",
+		thirdKey:  "",
+		secondKey: "",
+	}
+
+	function := types.FunctionDeployment{
+		EnvVars: inputEnvs,
+	}
+
+	coreEnvs := buildEnvVars(&function)
+
+	if coreEnvs[0].Name != firstKey {
+		t.Errorf("first want: %s, got: %s", firstKey, coreEnvs[0].Name)
+		t.Fail()
+	}
+
+	if coreEnvs[1].Name != secondKey {
+		t.Errorf("second want: %s, got: %s", secondKey, coreEnvs[1].Name)
+		t.Fail()
+	}
+
+	if coreEnvs[2].Name != thirdKey {
+		t.Errorf("third want: %s, got: %s", thirdKey, coreEnvs[2].Name)
+		t.Fail()
+	}
+
+	if coreEnvs[3].Name != lastKey {
+		t.Errorf("last want: %s, got: %s", lastKey, coreEnvs[3].Name)
+		t.Fail()
+	}
 }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -93,6 +93,22 @@ func Test_SetNonRootUser(t *testing.T) {
 
 }
 
+func Test_buildEnvVars_NoSortedKeys(t *testing.T) {
+
+	inputEnvs := map[string]string{}
+
+	function := types.FunctionDeployment{
+		EnvVars: inputEnvs,
+	}
+
+	coreEnvs := buildEnvVars(&function)
+
+	if len(coreEnvs) != 0 {
+		t.Errorf("want: %d env-vars, got: %d", 0, len(coreEnvs))
+		t.Fail()
+	}
+}
+
 func Test_buildEnvVars_TwoSortedKeys(t *testing.T) {
 	firstKey := "first"
 	lastKey := "last"

--- a/handlers/secrets_test.go
+++ b/handlers/secrets_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/openfaas/faas/gateway/requests"
+	types "github.com/openfaas/faas-provider/types"
 	appsv1 "k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Sort env-vars by string name

## Motivation and Context

This issue fixes the non-determinism observed by @LucasRoesler
and @bmcstdio which caused Function Pods to be re-created due
to the order of environment variables changing in the Deployment
and PodSpec.

Ref: https://github.com/openfaas/faas-netes/issues/484

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
