### PR TITLE
Helm chart:  Add support for Istio mTLS

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -179,7 +179,7 @@ Now [verify your installation](#verify-the-installation).
 You can run the following command from within the `faas-netes/chart` folder in the `faas-netes` repo.
 
 ```sh
-helm upgrade --install openfaas openfaas/ \
+helm upgrade --install openfaas openfaas/openfaas \
     --namespace openfaas  \
     --set basic_auth=true \
     --set functionNamespace=openfaas-fn
@@ -218,6 +218,23 @@ By default services will be exposed with following hostnames (can be changed, se
 ### SSL / TLS
 
 If you require TLS/SSL then please make use of an IngressController. A full guide is provided to [enable TLS for the OpenFaaS Gateway using cert-manager and Let's Encrypt](https://docs.openfaas.com/reference/ssl/kubernetes-with-cert-manager/).
+
+### Istio mTLS
+
+To install OpenFaaS with Istio mTLS pass  `--set istio.mtls=true` and disable the HTTP probes:
+
+```
+helm upgrade openfaas --install chart/openfaas \
+    --namespace openfaas  \
+    --set basic_auth=true \
+    --set functionNamespace=openfaas-fn \
+    --set exposeServices=false \
+    --set faasnetes.httpProbe=false \
+    --set httpProbe=false \
+    --set istio.mtls=true
+```
+
+The above command will enable mTLS for the openfaas control plane services and functions excluding NATS.
 
 ## Zero scale
 
@@ -284,6 +301,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasIdler.dryRun` | When set to false the OpenFaaS API will be called to scale down idle functions, by default this is set to only print in the logs. | `true` |
 | `prometheus.create` | Create the Prometheus component | `true` |
 | `alertmanager.create` | Create the AlertManager component | `true` |
+| `istio.mtls` | Create Istio policies and destination rules to enforce mTLS for OpenFaaS components and functions | `false` |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -236,6 +236,8 @@ helm upgrade openfaas --install chart/openfaas \
 
 The above command will enable mTLS for the openfaas control plane services and functions excluding NATS.
 
+> Note that the above instructions were tested on GKE 1.13 and Istio 1.2
+
 ## Zero scale
 
 ### Scale-up from zero (on by default)

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         app: alertmanager
       annotations:
-        sidecar.istio.io/inject: "false"
+        sidecar.istio.io/inject: "true"
         checksum/alertmanager-config: {{ include (print $.Template.BasePath "/alertmanager-cfg.yaml") . | sha256sum | quote  }}
     spec:
       containers:
@@ -30,6 +30,7 @@ spec:
           - "alertmanager"
           - "--config.file=/alertmanager.yml"
           - "--storage.path=/alertmanager"
+          - "--cluster.listen-address="
         livenessProbe:
           {{- if .Values.httpProbe }}
           httpGet:

--- a/chart/openfaas/templates/istio-mtls.yaml
+++ b/chart/openfaas/templates/istio-mtls.yaml
@@ -1,0 +1,58 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.istio.mtls -}}
+# enforce mTLS to openfaas control plane
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+    name: default
+    namespace: {{ .Release.Namespace }}
+spec:
+    peers:
+        - mtls: {}
+---
+# enforce mTLS to openfaas control plane
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+    name: default
+    namespace: {{ .Release.Namespace }}
+spec:
+    host: "*.openfaas.svc.cluster.local"
+    trafficPolicy:
+        tls:
+            mode: ISTIO_MUTUAL
+---
+# enforce mTLS to functions
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+    name: default
+    namespace: {{ $functionNs }}
+spec:
+    peers:
+        - mtls: {}
+---
+# enforce mTLS to functions
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+    name: default
+    namespace: {{ $functionNs | quote }}
+spec:
+    host: "*.openfaas-fn.svc.cluster.local"
+    trafficPolicy:
+        tls:
+            mode: ISTIO_MUTUAL
+---
+# disable mTLS to nats, the nats protocol is not supported by Istio
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+    name: "nats-no-mtls"
+    namespace: {{ .Release.Namespace }}
+spec:
+    host: "nats.openfaas.svc.cluster.local"
+    trafficPolicy:
+        tls:
+            mode: DISABLE
+{{- end -}}

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -19,7 +19,7 @@ spec:
       labels:
         app: prometheus
       annotations:
-        sidecar.istio.io/inject: "false"
+        sidecar.istio.io/inject: "true"
         checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-cfg.yaml") . | sha256sum | quote }}
     spec:
       serviceAccountName: {{ .Release.Name }}-prometheus

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -140,3 +140,6 @@ tolerations: []
 affinity: {}
 
 kubernetesDNSDomain: cluster.local
+
+istio:
+  mtls: false


### PR DESCRIPTION
## Description

This PR adds the `istio.mtls` option to the Helm chart. When enabled, creates Istio policies and destination rules to enforce mTLS to all OpenFaaS components and functions excluding NATS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fix: #473 

## How Has This Been Tested?

Autoscaling and asyc invocation was tested on GKE v1.13 and Istio v1.2.3 with Istio gateway exposing openfaas with LE TLS.

Sync invocation LE TLS -> Istio Gateway -> mTLS -> OF Gateway -> mTLS -> Function:

<img width="914" alt="Screenshot 2019-08-07 at 21 55 17" src="https://user-images.githubusercontent.com/3797675/62653031-64790900-b965-11e9-940c-a65c20f761b1.png">

Async invocation mTLS for worker -> function and plain TCP for worker -> nats and gateway -> nats:

<img width="913" alt="Screenshot 2019-08-07 at 22 49 04" src="https://user-images.githubusercontent.com/3797675/62653201-bde13800-b965-11e9-82f8-650c00b0d005.png">

The OpenFaaS gateway accepts only mTLS inbound traffic:

<img width="692" alt="Screenshot 2019-08-07 at 21 58 27" src="https://user-images.githubusercontent.com/3797675/62653272-e23d1480-b965-11e9-8827-1f34066c8a2b.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
