### PR TITLE
Allow configuring of gateway-external svc annotations via helm chart

### DIFF
--- a/chart/openfaas/templates/gateway-external-svc.yaml
+++ b/chart/openfaas/templates/gateway-external-svc.yaml
@@ -9,6 +9,9 @@ metadata:
     component: gateway
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.gatewayExternal.annotations }}
+  annotations: {{ toYaml .Values.gatewayExternal.annotations | nindent 4 }}
+{{- end }}
   name: gateway-external
   namespace: {{ .Release.Namespace | quote }}
 spec:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -15,6 +15,9 @@ basic_auth: true
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
 openfaasImagePullPolicy: "Always"
 
+gatewayExternal:
+  annotations: {}
+
 gateway:
   image: openfaas/gateway:0.16.0
   readTimeout : "65s"


### PR DESCRIPTION
Signed-off-by: Hai Li <hail@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->
The Helm chart does not allow setting the gateway-external svc annotations. However, There're some features in k8s env which relies on svc annotations to determine if the feature will be enabled or not. This change expose gateway-external svc annotations to helm chart.

## Description
Add a new item `gatewayExternal` in values.yaml to host any specific settings for `gateway-external` service. In this change, only `annotations` is added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas-netes/issues/490


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed an OpenFaaS with default setting:
```
helm repo update \
 && helm upgrade openfaas --install openfaas/openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set functionNamespace=openfaas-fn
```
There's no `Annotations` when running `kubectl describe svc gateway-external`. Then upgrade the openffas after appending `-f values2.yaml`.  The `values2.yaml` has:
```
gatewayExternal:
  annotations:
    service.beta.kubernetes.io/load-balancer-https-backend-ports: "8080"
    service.beta.kubernetes.io/load-balancer-https-redirection-ports: "8080: 8080"
```
Finally, you'll see the annotations are setting in the svc  by running `kubectl describe svc gateway-external`:
```
Annotations:     service.beta.kubernetes.io/load-balancer-https-backend-ports: 8080
                 service.beta.kubernetes.io/load-balancer-https-redirection-ports: 8080: 8080

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.