### PR TITLE
[Need Help with Testing] Update images for prometheus and alertmanager

### DIFF
--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -10,13 +10,13 @@ queueWorker:
   image: openfaas/queue-worker:0.8.0-arm64
 
 prometheus:
-  image: functions/prometheus:2.7.1-arm64
+  image: prom/prometheus:v2.11.0
   resources:
     requests:
       memory: "125Mi"
 
 alertmanager:
-  image: functions/alertmanager:0.16.1-arm64
+  image: prom/alertmanager:v0.18.0
 
 faasIdler:
   image: openfaas/faas-idler:0.2.0-arm64

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -10,13 +10,13 @@ queueWorker:
   image: openfaas/queue-worker:0.8.0-armhf
 
 prometheus:
-  image: functions/prometheus:2.7.1-armhf
+  image: prom/prometheus:v2.11.0
   resources:
     requests:
       memory: "125Mi"
 
 alertmanager:
-  image: functions/alertmanager:0.16.1-armhf
+  image: prom/alertmanager:v0.18.0
 
 faasIdler:
   image: openfaas/faas-idler:0.2.0-armhf

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -79,14 +79,14 @@ queueWorker:
 # monitoring and auto-scaling components
 # both components
 prometheus:
-  image: prom/prometheus:v2.7.1
+  image: prom/prometheus:v2.11.0
   create: true
   resources:
     requests:
       memory: "512Mi"
 
 alertmanager:
-  image: prom/alertmanager:v0.16.1
+  image: prom/alertmanager:v0.18.0
   create: true
   resources:
     requests:

--- a/yaml/alertmanager-dep.yml
+++ b/yaml/alertmanager-dep.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: prom/alertmanager:v0.16.1
+        image: prom/alertmanager:v0.18.0
         imagePullPolicy: Always
         command:
           - "alertmanager"

--- a/yaml/prometheus-dep.yml
+++ b/yaml/prometheus-dep.yml
@@ -25,7 +25,7 @@ spec:
             requests:
               memory: 512Mi
             
-        image: prom/prometheus:v2.7.1
+        image: prom/prometheus:v2.11.0
         command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"


### PR DESCRIPTION
This commit updates yaml files to use multi architecture image for prometheus
and alertmanager. Prometheus is updated to v2.11.0 and alertmanager is updated
to v0.18.0.

Fixes: #422

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#422 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on local using Kind. 

```
./hey -z=30s -q 5 -c 2 -m POST -d=Test http://127.0.0.1:31112/function/echo

Summary:
  Total:	30.0138 secs
  Slowest:	0.0282 secs
  Fastest:	0.0049 secs
  Average:	0.0087 secs
  Requests/sec:	9.9954

  Total data:	1200 bytes
  Size/request:	4 bytes

Response time histogram:
  0.005 [1]	|
  0.007 [85]	|■■■■■■■■■■■■■■■■■■■■■■■■
  0.010 [141]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.012 [51]	|■■■■■■■■■■■■■■
  0.014 [15]	|■■■■
  0.017 [3]	|■
  0.019 [0]	|
  0.021 [0]	|
  0.024 [1]	|
  0.026 [1]	|
  0.028 [2]	|■


Latency distribution:
  10% in 0.0063 secs
  25% in 0.0071 secs
  50% in 0.0083 secs
  75% in 0.0095 secs
  90% in 0.0114 secs
  95% in 0.0128 secs
  99% in 0.0252 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0049 secs, 0.0282 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0010 secs
  resp wait:	0.0085 secs, 0.0048 secs, 0.0250 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0004 secs

Status code distribution:
  [200]	300 responses
```

```
kubectl get pods -n openfaas-fn --watch
NAME                    READY   STATUS    RESTARTS   AGE
echo-5cf679b455-kv6s9   1/1     Running   0          87m
echo-5cf679b455-bdmt6   0/1     Pending   0          0s
echo-5cf679b455-9zsfl   0/1     Pending   0          0s
echo-5cf679b455-k9v6w   0/1     Pending   0          0s
echo-5cf679b455-bdmt6   0/1     Pending   0          0s
echo-5cf679b455-9zsfl   0/1     Pending   0          0s
echo-5cf679b455-k9v6w   0/1     Pending   0          0s
echo-5cf679b455-vjv5r   0/1     Pending   0          0s
echo-5cf679b455-vjv5r   0/1     Pending   0          0s
echo-5cf679b455-bdmt6   0/1     ContainerCreating   0          0s
echo-5cf679b455-9zsfl   0/1     ContainerCreating   0          0s
echo-5cf679b455-k9v6w   0/1     ContainerCreating   0          0s
echo-5cf679b455-vjv5r   0/1     ContainerCreating   0          0s
echo-5cf679b455-9zsfl   0/1     Running             0          5s
echo-5cf679b455-vjv5r   0/1     Running             0          6s
echo-5cf679b455-9zsfl   1/1     Running             0          7s
echo-5cf679b455-k9v6w   0/1     Running             0          7s
echo-5cf679b455-bdmt6   0/1     Running             0          9s
echo-5cf679b455-k9v6w   1/1     Running             0          9s
echo-5cf679b455-vjv5r   1/1     Running             0          9s
echo-5cf679b455-bdmt6   1/1     Running             0          12s
echo-5cf679b455-9zsfl   1/1     Terminating         0          20s
echo-5cf679b455-bdmt6   1/1     Terminating         0          20s
echo-5cf679b455-vjv5r   1/1     Terminating         0          20s
echo-5cf679b455-k9v6w   1/1     Terminating         0          20s
echo-5cf679b455-bdmt6   0/1     Terminating         0          24s
echo-5cf679b455-9zsfl   0/1     Terminating         0          25s
echo-5cf679b455-k9v6w   0/1     Terminating         0          25s
echo-5cf679b455-vjv5r   0/1     Terminating         0          25s
echo-5cf679b455-9zsfl   0/1     Terminating         0          32s
echo-5cf679b455-9zsfl   0/1     Terminating         0          32s
echo-5cf679b455-k9v6w   0/1     Terminating         0          32s
echo-5cf679b455-bdmt6   0/1     Terminating         0          32s
echo-5cf679b455-bdmt6   0/1     Terminating         0          32s
echo-5cf679b455-vjv5r   0/1     Terminating         0          33s
echo-5cf679b455-bdmt6   0/1     Terminating         0          33s
echo-5cf679b455-bdmt6   0/1     Terminating         0          33s
echo-5cf679b455-k9v6w   0/1     Terminating         0          34s
echo-5cf679b455-k9v6w   0/1     Terminating         0          34s
echo-5cf679b455-vjv5r   0/1     Terminating         0          42s
echo-5cf679b455-vjv5r   0/1     Terminating         0          42s
echo-5cf679b455-9zsfl   0/1     Terminating         0          42s
echo-5cf679b455-9zsfl   0/1     Terminating         0          42s
```


<img width="1427" alt="Screen Shot 2019-09-08 at 2 33 11 AM" src="https://user-images.githubusercontent.com/3869193/64480269-16fcef80-d1e2-11e9-9465-c564c55b8ccb.png">

<img width="929" alt="Screen Shot 2019-09-08 at 2 33 21 AM" src="https://user-images.githubusercontent.com/3869193/64480276-41e74380-d1e2-11e9-8aaa-e4b8b773e175.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
