### PR TITLE
Add ingress-operator in the openfaas Helm chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -286,7 +286,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `ingressOperator.create` | Create the ingress-operator component | `true` |
 | `ingressOperator.replicas` | Replicas of the ingress-operator| `1` |
 | `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.4.0` |
-| `ingressOperator.resources` | Limits and requests for memory and CPU usage | `openfaas/ingress-operator:0.4.0` |
+| `ingressOperator.resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi / Memory Limits 128Mi |
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -283,6 +283,10 @@ Additional OpenFaaS options in `values.yaml`.
 | `operator.createCRD` | Create the CRD for OpenFaaS Function definition | `true` |
 | `ingress.enabled` | Create ingress resources | `false` |
 | `faasnetes.httpProbe` | Use a httpProbe instead of exec | `false` |
+| `ingressOperator.create` | Create the ingress-operator component | `true` |
+| `ingressOperator.replicas` | Replicas of the ingress-operator| `1` |
+| `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.4.0` |
+| `ingressOperator.resources` | Limits and requests for memory and CPU usage | `openfaas/ingress-operator:0.4.0` |
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -283,7 +283,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `operator.createCRD` | Create the CRD for OpenFaaS Function definition | `true` |
 | `ingress.enabled` | Create ingress resources | `false` |
 | `faasnetes.httpProbe` | Use a httpProbe instead of exec | `false` |
-| `ingressOperator.create` | Create the ingress-operator component | `true` |
+| `ingressOperator.create` | Create the ingress-operator component | `false` |
 | `ingressOperator.replicas` | Replicas of the ingress-operator| `1` |
 | `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.4.0` |
 | `ingressOperator.resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi / Memory Limits 128Mi |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -286,7 +286,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `ingressOperator.create` | Create the ingress-operator component | `false` |
 | `ingressOperator.replicas` | Replicas of the ingress-operator| `1` |
 | `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.4.0` |
-| `ingressOperator.resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi / Memory Limits 128Mi |
+| `ingressOperator.resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi |
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |

--- a/chart/openfaas/templates/ingress-operator-crd.yaml
+++ b/chart/openfaas/templates/ingress-operator-crd.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.ingressOperator.create }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: functioningresses.openfaas.com
+spec:
+  group: openfaas.com
+  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
+  names:
+    singular: functioningress
+    plural: functioningresses
+    kind: FunctionIngress
+    shortNames:
+    - fni
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - domain
+          properties:
+            name:
+              type: string
+              pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            domain:
+              type: string
+            ingressType:
+              type: string
+            tls:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                issuerRef:
+                  type: object
+                  anyOf:
+                    - type: string
+                    - type: object
+                  required: ['kind', 'name']
+                  properties:
+                    name:
+                      type: string
+                    kind:
+                      type: string
+{{- end }}

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -23,9 +23,7 @@ spec:
       labels:
         app: ingress-operator
     spec:
-      {{- if .Values.rbac }}
       serviceAccountName: ingress-operator
-      {{- end }}
       containers:
       - name: operator
         resources:

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -1,0 +1,42 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.ingressOperator.create }}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: ingress-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: ingress-operator
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.ingressOperator.replicas }}
+  selector:
+    matchLabels:
+      app: ingress-operator
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+      labels:
+        app: ingress-operator
+    spec:
+      {{- if .Values.rbac }}
+      serviceAccountName: ingress-operator
+      {{- end }}
+      containers:
+      - name: operator
+        resources:
+          {{- .Values.ingressOperator.resources | toYaml | nindent 10 }}
+        image: {{ .Values.ingressOperator.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        command:
+          - ./ingress-operator
+          - -logtostderr
+          - -v=2
+        env:
+        - name: function_namespace
+          value: {{ $functionNs | quote }}
+{{- end }}

--- a/chart/openfaas/templates/ingress-operator-rbac.yaml
+++ b/chart/openfaas/templates/ingress-operator-rbac.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.ingressOperator.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingress-operator
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: ingress-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+
+{{- if .Values.rbac }}    
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ingress-operator-rw
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: ingress-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["openfaas.com"]
+  resources: ["functioningresses"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["certmanager.k8s.io"]
+  resources: ["certificates"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ingress-operator-rw
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: ingress-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-operator-rw
+subjects:
+- kind: ServiceAccount
+  name: ingress-operator
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+{{- end }}

--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -18,5 +18,8 @@ prometheus:
 alertmanager:
   image: functions/alertmanager:0.16.1-arm64
 
+ingressOperator:
+  create: false
+
 faasIdler:
   image: openfaas/faas-idler:0.2.1-arm64

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -20,6 +20,7 @@ alertmanager:
 
 ingressOperator:
   image: openfaas/ingress-operator:0.4.0-armhf
+  create: false
 
 faasIdler:
   image: openfaas/faas-idler:0.2.0-armhf

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -18,10 +18,12 @@ prometheus:
 alertmanager:
   image: functions/alertmanager:0.16.1-armhf
 
+ingressOperator:
+  image: openfaas/ingress-operator:0.4.0-armhf
+
 faasIdler:
   image: openfaas/faas-idler:0.2.0-armhf
 
 basicAuthPlugin:
   image: openfaas/basic-auth-plugin:0.17.0-armhf
   replicas: 1
-

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -119,7 +119,7 @@ ingress:
 ingressOperator:
   image: openfaas/ingress-operator:0.4.0
   replicas: 1
-  create: true
+  create: false
   resources:
     limits:
       memory: 128Mi

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -116,6 +116,16 @@ ingress:
   tls:
     # Secrets must be manually created in the namespace.
 
+ingressOperator:
+  image: openfaas/ingress-operator:0.4.0
+  replicas: 1
+  create: true
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 25Mi
+
 # faas-idler configuration
 faasIdler:
   image: openfaas/faas-idler:0.2.1

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -123,10 +123,8 @@ ingressOperator:
   replicas: 1
   create: false
   resources:
-    limits:
-      memory: 128Mi
     requests:
-      memory: 25Mi
+      memory: "25Mi"
 
 # faas-idler configuration
 faasIdler:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -116,6 +116,8 @@ ingress:
   tls:
     # Secrets must be manually created in the namespace.
 
+# ingressOperator (optional) – component to have specific FQDN and TLS for Functions
+# https://github.com/openfaas-incubator/ingress-operator
 ingressOperator:
   image: openfaas/ingress-operator:0.4.0
   replicas: 1


### PR DESCRIPTION
Signed-off-by: Jonatas Baldin <jonatas.baldin@gmail.com>

## Description
Adding the `ingress-operator` to the Helm chart.

## TODO
This a list of potential things that I think still needs to be done. Please provide feedback here:
- [ ] Create an `amr64` image version of `ingress-operator` (to add in `values-arm64.yaml`)
- [ ] Bump the chart version

## Motivation and Context
Solves #502.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
I tested by upgrading the Helm release with new templates/values and by deploying this new version from scratch.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
