### PR TITLE
Enable namespace selection for scaling

### DIFF
--- a/handlers/replicas.go
+++ b/handlers/replicas.go
@@ -67,8 +67,11 @@ func MakeReplicaUpdater(defaultNamespace string, clientset *kubernetes.Clientset
 			return
 		}
 
+		oldReplicas := *deployment.Spec.Replicas
 		replicas := int32(req.Replicas)
-		log.Printf("Set replicas - %s %s, %d/%d\n", functionName, lookupNamespace, replicas, deployment.Spec.Replicas)
+
+		log.Printf("Set replicas - %s %s, %d/%d\n", functionName, lookupNamespace, replicas, oldReplicas)
+
 		deployment.Spec.Replicas = &replicas
 
 		_, err = clientset.ExtensionsV1beta1().Deployments(lookupNamespace).Update(deployment)
@@ -112,7 +115,7 @@ func MakeReplicaReader(defaultNamespace string, clientset *kubernetes.Clientset)
 			return
 		}
 
-		log.Printf("Read replicas - %s %s, %d/%d\n", functionName, namespace, function.AvailableReplicas, function.Replicas)
+		log.Printf("Read replicas - %s %s, %d/%d\n", functionName, lookupNamespace, function.AvailableReplicas, function.Replicas)
 
 		functionBytes, _ := json.Marshal(function)
 		w.Header().Set("Content-Type", "application/json")

--- a/handlers/validate.go
+++ b/handlers/validate.go
@@ -1,0 +1,25 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"fmt"
+	"regexp"
+
+	types "github.com/openfaas/faas-provider/types"
+)
+
+// Regex for RFC-1123 validation:
+// 	k8s.io/kubernetes/pkg/util/validation/validation.go
+var validDNS = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// ValidateDeployRequest validates that the service name is valid for Kubernetes
+func ValidateDeployRequest(request *types.FunctionDeployment) error {
+	matched := validDNS.MatchString(request.Service)
+	if matched {
+		return nil
+	}
+
+	return fmt.Errorf("(%s) must be a valid DNS entry for service name", request.Service)
+}

--- a/types/requests.go
+++ b/types/requests.go
@@ -4,6 +4,7 @@
 package types
 
 type ScaleServiceRequest struct {
-	ServiceName string `json:"serviceName"`
-	Replicas    uint64 `json:"replicas"`
+	ServiceName      string `json:"serviceName"`
+	ServiceNamespace string `json:"serviceNamespace"`
+	Replicas         uint64 `json:"replicas"`
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable namespace selection for scaling

## Motivation and Context

https://github.com/openfaas/faas-netes/issues/511

This patch enables the user to pass in a namespace when
requesting to scale or to query replicas for a function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested e2e with Kubernetes 1.15.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
