### PR TITLE
Add namespaces lister endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -149,7 +149,7 @@
   version = "0.17.3"
 
 [[projects]]
-  digest = "1:65979387f3042412e8ddf943c31a307b34b315e65434223c7a80faec677d0f05"
+  digest = "1:e02df3904d1a0f00b8e82654be61ca5bac94a64d52951de533b9bb86a4978726"
   name = "github.com/openfaas/faas-provider"
   packages = [
     ".",
@@ -159,8 +159,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "ba3fa3b0ae00f0b9222851f3e03b2e6ea8672998"
-  version = "0.10.1"
+  revision = "eafd85a3b360d8e0982c3a1db43e6d5fee9b85e2"
+  version = "0.10.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"
-  version = "0.10.1"
+  version = "0.10.2"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -76,7 +76,7 @@ func MakeDeployHandler(functionNamespace string, factory k8s.FunctionFactory) ht
 			return
 		}
 
-		log.Println("Created deployment - " + request.Service + "," + namespace)
+		log.Printf("Deployment created: %s.%s\n", request.Service, namespace)
 
 		service := factory.Client.Core().Services(namespace)
 		serviceSpec := makeServiceSpec(request, factory)
@@ -89,8 +89,9 @@ func MakeDeployHandler(functionNamespace string, factory k8s.FunctionFactory) ht
 			return
 		}
 
-		log.Println("Created service - " + request.Service + "," + namespace)
-		log.Println(string(body))
+		log.Printf("Service created: %s.%s\n", request.Service, namespace)
+
+		// log.Println(string(body))
 
 		w.WriteHeader(http.StatusAccepted)
 
@@ -307,7 +308,6 @@ func createSelector(constraints []string) map[string]string {
 		}
 	}
 
-	// log.Println("selector: ", selector)
 	return selector
 }
 

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import "net/http"

--- a/handlers/info.go
+++ b/handlers/info.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/log.go
+++ b/handlers/log.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -1,4 +1,5 @@
 // Copyright (c) Alex Ellis 2017. All rights reserved.
+// Copyright 2019 OpenFaaS Author(s)
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 package handlers

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -1,0 +1,65 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MakeNamespacesLister builds a list of namespaces with an "openfaas" tag, or the default name
+func MakeNamespacesLister(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Query namespaces")
+
+		res := list(defaultNamespace, clientset)
+
+		out, _ := json.Marshal(res)
+		w.Header().Set("Content-Type", "application/json")
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write(out)
+	}
+}
+
+func list(defaultNamespace string, clientset *kubernetes.Clientset) []string {
+	listOptions := metav1.ListOptions{}
+	namespaces, err := clientset.CoreV1().Namespaces().List(listOptions)
+
+	set := []string{}
+
+	// Assume that an error means that a Role, instead of ClusterRole is being used
+	// the Role will not be able to list namespaces, so all functions are in the
+	// defaultNamespace
+	if err != nil {
+		log.Printf("Error listing namespaces: %s", err.Error())
+		set = append(set, defaultNamespace)
+		return set
+	}
+
+	for _, n := range namespaces.Items {
+		if _, ok := n.Annotations["openfaas"]; ok {
+			set = append(set, n.Name)
+		}
+	}
+
+	if !findNamespace(defaultNamespace, set) {
+		set = append(set, defaultNamespace)
+	}
+
+	return set
+}
+
+func findNamespace(target string, items []string) bool {
+	for _, n := range items {
+		if n == target {
+			return true
+		}
+	}
+	return false
+}

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Copyright 2019 OpenFaaS Author(s)
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 package handlers

--- a/handlers/namespaces_test.go
+++ b/handlers/namespaces_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import "testing"
+
+func Test_findNamespace_Found(t *testing.T) {
+	got := findNamespace("fn", []string{"fn", "openfaas-fn"})
+	want := true
+
+	if got != want {
+		t.Errorf("findNamespace - want: %v, got %v", want, got)
+	}
+}
+
+func Test_findNamespace_NotFound(t *testing.T) {
+	got := findNamespace("fn", []string{"openfaas-fn"})
+	want := false
+
+	if got != want {
+		t.Errorf("findNamespace - want: %v, got %v", want, got)
+	}
+}

--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/secrets_api_test.go
+++ b/handlers/secrets_api_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/secrets_test.go
+++ b/handlers/secrets_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package handlers
 
 import (

--- a/server.go
+++ b/server.go
@@ -67,17 +67,18 @@ func main() {
 	factory := k8s.NewFunctionFactory(clientset, deployConfig)
 
 	bootstrapHandlers := bootTypes.FaaSHandlers{
-		FunctionProxy:  handlers.MakeProxy(functionNamespace, cfg.ReadTimeout),
-		DeleteHandler:  handlers.MakeDeleteHandler(functionNamespace, clientset),
-		DeployHandler:  handlers.MakeDeployHandler(functionNamespace, factory),
-		FunctionReader: handlers.MakeFunctionReader(functionNamespace, clientset),
-		ReplicaReader:  handlers.MakeReplicaReader(functionNamespace, clientset),
-		ReplicaUpdater: handlers.MakeReplicaUpdater(functionNamespace, clientset),
-		UpdateHandler:  handlers.MakeUpdateHandler(functionNamespace, factory),
-		HealthHandler:  handlers.MakeHealthHandler(),
-		InfoHandler:    handlers.MakeInfoHandler(version.BuildVersion(), version.GitCommit),
-		SecretHandler:  handlers.MakeSecretHandler(functionNamespace, clientset),
-		LogHandler:     logs.NewLogHandlerFunc(handlers.NewLogRequestor(clientset, functionNamespace), cfg.WriteTimeout),
+		FunctionProxy:        handlers.MakeProxy(functionNamespace, cfg.ReadTimeout),
+		DeleteHandler:        handlers.MakeDeleteHandler(functionNamespace, clientset),
+		DeployHandler:        handlers.MakeDeployHandler(functionNamespace, factory),
+		FunctionReader:       handlers.MakeFunctionReader(functionNamespace, clientset),
+		ReplicaReader:        handlers.MakeReplicaReader(functionNamespace, clientset),
+		ReplicaUpdater:       handlers.MakeReplicaUpdater(functionNamespace, clientset),
+		UpdateHandler:        handlers.MakeUpdateHandler(functionNamespace, factory),
+		HealthHandler:        handlers.MakeHealthHandler(),
+		InfoHandler:          handlers.MakeInfoHandler(version.BuildVersion(), version.GitCommit),
+		SecretHandler:        handlers.MakeSecretHandler(functionNamespace, clientset),
+		LogHandler:           logs.NewLogHandlerFunc(handlers.NewLogRequestor(clientset, functionNamespace), cfg.WriteTimeout),
+		ListNamespaceHandler: handlers.MakeNamespacesLister(functionNamespace, clientset),
 	}
 
 	var port int

--- a/vendor/github.com/openfaas/faas-provider/Dockerfile
+++ b/vendor/github.com/openfaas/faas-provider/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.10.4-alpine3.8
+FROM golang:1.11-alpine3.10
+
+ENV CGO_ENABLED=0
 
 RUN mkdir -p /go/src/github.com/openfaas/faas-provider/
 

--- a/vendor/github.com/openfaas/faas-provider/serve.go
+++ b/vendor/github.com/openfaas/faas-provider/serve.go
@@ -65,6 +65,8 @@ func Serve(handlers *types.FaaSHandlers, config *types.FaaSConfig) {
 	r.HandleFunc("/system/secrets", handlers.SecretHandler).Methods(http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete)
 	r.HandleFunc("/system/logs", handlers.LogHandler).Methods(http.MethodGet)
 
+	r.HandleFunc("/system/namespaces", handlers.ListNamespaceHandler).Methods("GET")
+
 	// Open endpoints
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}", handlers.FunctionProxy)
 	r.HandleFunc("/function/{name:["+NameExpression+"]+}/", handlers.FunctionProxy)

--- a/vendor/github.com/openfaas/faas-provider/types/config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/config.go
@@ -7,11 +7,13 @@ import (
 
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
-	FunctionReader http.HandlerFunc
-	DeployHandler  http.HandlerFunc
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
 	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.
-	FunctionProxy  http.HandlerFunc
+	FunctionProxy http.HandlerFunc
+
+	FunctionReader http.HandlerFunc
+	DeployHandler  http.HandlerFunc
+
 	DeleteHandler  http.HandlerFunc
 	ReplicaReader  http.HandlerFunc
 	ReplicaUpdater http.HandlerFunc
@@ -19,10 +21,11 @@ type FaaSHandlers struct {
 	// LogHandler provides streaming json logs of functions
 	LogHandler http.HandlerFunc
 
-	// Optional: Update an existing function
-	UpdateHandler http.HandlerFunc
-	HealthHandler http.HandlerFunc
-	InfoHandler   http.HandlerFunc
+	// UpdateHandler an existing function/service
+	UpdateHandler        http.HandlerFunc
+	HealthHandler        http.HandlerFunc
+	InfoHandler          http.HandlerFunc
+	ListNamespaceHandler http.HandlerFunc
 }
 
 // FaaSConfig set config for HTTP handlers

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,6 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package version
 
 var (


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add namespaces lister endpoint

## Motivation and Context

This is required to list namespaces as part of #511.

The default namespace is matched, and any additional namespaces
must be annotated with the "openfaas" label. This is to prevent
kube-system, etc from being used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested e2e with k3s/k8s 1.15 - the default ns showed, a new ns
was created and annotated, which then showed up in the results
subsequently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
