### PR TITLE
Allow for customizing the security context of the OpenFaaS control-plane.

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 5.1.4
+version: 6.0.0
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -4,6 +4,30 @@
 
 [OpenFaaS](https://github.com/openfaas/faas) (Functions as a Service) is a framework for building serverless functions with Docker and Kubernetes which has first class support for metrics. Any process can be packaged as a function enabling you to consume a range of web events without repetitive boiler-plate coding.
 
+## Important notes
+
+If you are upgrading from pre-`6.0.0` and have `securityContext` set to `true`, please...
+
+* ... tweak the `securityContexts` field in `values.yaml` according to your requirements. By default, the new pods will have an empty `securityContext` field. To keep your existing configuration for this field, use
+
+  ```yaml
+  securityContexts:
+    basicAuthPlugin:
+      containers:
+        basicAuthPlugin:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+    gateway:
+      containers:
+        faasNetes:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        gateway:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+  ```
+* ... remove the `securityContext` field, which has been replaced by the aforementioned one.
+
 ## Highlights
 
 * Ease of use through UI portal and *one-click* install
@@ -277,7 +301,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `rbac` | Enable RBAC | `true` |
 | `httpProbe` | Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (compatible with Istio >= 1.1.5) | `true` |
 | `psp` | Enable [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for OpenFaaS accounts | `false` |
-| `securityContext` | Deploy with a `securityContext` set, this can be disabled for use with Istio sidecar injection | `true` |
+| `securityContexts` | Security contexts to use for each pod and container. | (see `values.yaml`) |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
 | `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |
 | `operator.create` | Use the OpenFaaS operator CRD controller, default uses faas-netes as the Kubernetes controller | `false` |

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -25,10 +25,14 @@ spec:
         sidecar.istio.io/inject: "true"
         checksum/alertmanager-config: {{ include (print $.Template.BasePath "/alertmanager-cfg.yaml") . | sha256sum | quote  }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.alertmanager.pod | nindent 8 }}
       containers:
       - name: alertmanager
         image: {{ .Values.alertmanager.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContexts.alertmanager.containers.alertmanager | nindent 10 }}
         command:
           - "alertmanager"
           - "--config.file=/alertmanager.yml"

--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -24,6 +24,8 @@ spec:
       labels:
         app: basic-auth-plugin
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.basicAuthPlugin.pod | nindent 8 }}
       {{- if .Values.basic_auth }}
       volumes:
       - name: auth
@@ -36,11 +38,8 @@ spec:
           {{- .Values.basicAuthPlugin.resources | toYaml | nindent 12 }}
         image: {{ .Values.basicAuthPlugin.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
-        {{- if .Values.securityContext }}
         securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 10001
-        {{- end }}
+          {{- toYaml .Values.securityContexts.basicAuthPlugin.containers.basicAuthPlugin | nindent 10 }}
         livenessProbe:
           {{- if .Values.httpProbe }}
           httpGet:

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -24,12 +24,16 @@ spec:
       labels:
         app: faas-idler
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.faasIdler.pod | nindent 8 }}
       containers:
         - name: faas-idler
           resources:
             {{- .Values.faasIdler.resources | toYaml | nindent 12 }}
           image: {{ .Values.faasIdler.image }}
           imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContexts.faasIdler.containers.faasIdler | nindent 12 }}
           env:
             - name: gateway_url
               value: "http://gateway.{{ .Release.Namespace }}:8080/"

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         app: gateway
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.gateway.pod | nindent 8 }}
       {{- if .Values.operator.create }}
       serviceAccountName: {{ .Release.Name }}-operator
       {{- else }}
@@ -42,11 +44,8 @@ spec:
           {{- .Values.gateway.resources | toYaml | nindent 12 }}
         image: {{ .Values.gateway.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
-        {{- if .Values.securityContext }}
         securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 10001
-        {{- end }}
+          {{- toYaml .Values.securityContexts.gateway.containers.gateway | nindent 10 }}
         livenessProbe:
           {{- if .Values.httpProbe }}
           httpGet:
@@ -132,6 +131,8 @@ spec:
           {{- .Values.operator.resources | toYaml | nindent 12 }}
         image: {{ .Values.operator.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContexts.gateway.containers.operator | nindent 10 }}
         command:
           - ./openfaas-operator
           - -logtostderr
@@ -172,11 +173,8 @@ spec:
           {{- .Values.faasnetes.resources | toYaml | nindent 12 }}
         image: {{ .Values.faasnetes.image }}
         imagePullPolicy: {{ .Values.openFaasImagePullPolicy }}
-        {{- if .Values.securityContext }}
         securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: 10001
-        {{- end }}
+          {{- toYaml .Values.securityContexts.gateway.containers.faasNetes | nindent 10 }}
         env:
         - name: port
           value: "8081"

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         app: ingress-operator
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.ingressOperator.pod | nindent 8 }}
       serviceAccountName: ingress-operator
       containers:
       - name: operator
@@ -30,6 +32,8 @@ spec:
           {{- .Values.ingressOperator.resources | toYaml | nindent 10 }}
         image: {{ .Values.ingressOperator.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContexts.ingressOperator.containers.ingressOperator | nindent 10 }}
         command:
           - ./ingress-operator
           - -logtostderr

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -23,12 +23,16 @@ spec:
       labels:
         app: nats
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.nats.pod | nindent 8 }}
       containers:
       - name:  nats
         resources:
           {{- .Values.nats.resources | toYaml | nindent 12 }}
         image: {{ .Values.nats.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContexts.nats.containers.nats | nindent 10 }}
         ports:
         - containerPort: 4222
           protocol: TCP

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -25,6 +25,8 @@ spec:
         sidecar.istio.io/inject: "true"
         checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-cfg.yaml") . | sha256sum | quote }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.prometheus.pod | nindent 8 }}
       serviceAccountName: {{ .Release.Name }}-prometheus
       containers:
       - name: prometheus
@@ -35,6 +37,8 @@ spec:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContexts.prometheus.containers.prometheus | nindent 10 }}
         livenessProbe:
           {{- if .Values.httpProbe }}
           httpGet:

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: queue-worker
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContexts.queueWorker.pod | nindent 8 }}
       {{- if .Values.basic_auth }}
       volumes:
       - name: auth
@@ -34,6 +36,8 @@ spec:
           {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
         image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContexts.queueWorker.containers.queueWorker | nindent 10 }}
         env:
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -11,7 +11,6 @@ clusterRole: false            # Set to true to have OpenFaaS administrate multip
 # create pod security policies for OpenFaaS control plane
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 psp: false
-securityContext: true
 basic_auth: true
 
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
@@ -158,3 +157,39 @@ kubernetesDNSDomain: cluster.local
 
 istio:
   mtls: false
+
+securityContexts:
+  alertmanager:
+    containers:
+      alertmanager: {}
+    pod: {}
+  basicAuthPlugin:
+    containers:
+      basicAuthPlugin: {}
+    pod: {}
+  faasIdler:
+    containers:
+      faasIdler: {}
+    pod: {}
+  gateway:
+    containers:
+      faasNetes: {}
+      gateway: {}
+      operator: {}
+    pod: {}
+  ingressOperator:
+    containers:
+      ingressOperator: {}
+    pod: {}
+  nats:
+    containers:
+      nats: {}
+    pod: {}
+  prometheus:
+    containers:
+      prometheus: {}
+    pod: {}
+  queueWorker:
+    containers:
+      queueWorker: {}
+    pod: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A follow-up to #521 and alternative to #509 (closes #509).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

The same as #509, but without modifying the included pod security policy and using, I believe, the "safest" default of all for each `securityContext` field, `{}`.

## How Has This Been Tested?

By rendering the templates, inspecting them for errors and installing the resulting manifests in a Minikube cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
