### PR TITLE
PoC patch to show distribution across endpoints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -141,6 +141,14 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:da252652270fa34c1f69e7a31f2cd62933afe24355a9f9e79919c9ba64f5c3c3"
+  name = "github.com/openfaas-incubator/openfaas-operator"
+  packages = ["pkg/signals"]
+  pruneopts = "UT"
+  revision = "8a2f0aa0fb60957147b46c9f4f3312763b86c27a"
+  version = "0.11.0"
+
+[[projects]]
   digest = "1:0250441ac9f681c839722297897952ee6d633f2a37dc254eca9d6d21bd1e877d"
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
@@ -565,6 +573,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/gorilla/mux",
+    "github.com/openfaas-incubator/openfaas-operator/pkg/signals",
     "github.com/openfaas/faas-provider",
     "github.com/openfaas/faas-provider/logs",
     "github.com/openfaas/faas-provider/types",

--- a/server.go
+++ b/server.go
@@ -67,7 +67,7 @@ func main() {
 	factory := k8s.NewFunctionFactory(clientset, deployConfig)
 
 	bootstrapHandlers := bootTypes.FaaSHandlers{
-		FunctionProxy:        handlers.MakeProxy(functionNamespace, cfg.ReadTimeout),
+		FunctionProxy:        handlers.MakeProxy(functionNamespace, cfg.ReadTimeout, clientset),
 		DeleteHandler:        handlers.MakeDeleteHandler(functionNamespace, clientset),
 		DeployHandler:        handlers.MakeDeployHandler(functionNamespace, factory),
 		FunctionReader:       handlers.MakeFunctionReader(functionNamespace, clientset),

--- a/vendor/github.com/openfaas-incubator/openfaas-operator/LICENSE
+++ b/vendor/github.com/openfaas-incubator/openfaas-operator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2018 OpenFaaS Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/openfaas-incubator/openfaas-operator/pkg/signals/signal.go
+++ b/vendor/github.com/openfaas-incubator/openfaas-operator/pkg/signals/signal.go
@@ -1,0 +1,27 @@
+package signals
+
+import (
+	"os"
+	"os/signal"
+)
+
+var onlyOneSignalHandler = make(chan struct{})
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() (stopCh <-chan struct{}) {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}

--- a/vendor/github.com/openfaas-incubator/openfaas-operator/pkg/signals/signal_posix.go
+++ b/vendor/github.com/openfaas-incubator/openfaas-operator/pkg/signals/signal_posix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package signals
+
+import (
+	"os"
+	"syscall"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/vendor/github.com/openfaas-incubator/openfaas-operator/pkg/signals/signal_windows.go
+++ b/vendor/github.com/openfaas-incubator/openfaas-operator/pkg/signals/signal_windows.go
@@ -1,0 +1,7 @@
+package signals
+
+import (
+	"os"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

PoC patch to show distribution across endpoints

This is just a PoC to demonstrate the use of the Kubernetes endpoints API for load-balancing. It is for discussion and not for merge.

## Motivation / context

https://github.com/openfaas/faas/issues/1322

## Start by installing OpenFaaS with helm

https://github.com/openfaas/faas-netes/blob/master/HELM.md

https://github.com/openfaas/faas-netes/blob/master/chart/openfaas/README.md 

## Add the metrics server for `kubectl top`

```
helm install --name metrics-server --namespace kube-system \
  stable/metrics-server \
  --set args[0]=--kubelet-insecure-tls
```

## Show the existing behaviour

Deploy OpenFaaS as per normal

Install the metrics-server

* Install hey

  https://github.com/rakyll/hey

* Deploy [echo-fn](https://github.com/alexellis/echo-fn)

* Run a load test and check the balance

```
watch "kubectl top pod -n openfaas-fn"
hey -z 1m -c 10 http://192.168.0.26:31112/function/nodeinfo
```

You should see one Pod getting most of the work

```
Every 2.0s: kubectl top pod -A|grep nodeinfo                                                               

openfaas-fn    nodeinfo-6c8c6648dd-26rnq                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-2t4xr                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-52gp8                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-fzp5n                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-j2wvl                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-k7mzx                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-mtgp2                                     1m           2Mi
openfaas-fn    nodeinfo-6c8c6648dd-ql4hp                                     6591m        68Mi
openfaas-fn    nodeinfo-6c8c6648dd-qtvzb                                     1m           2Mi
```

## Test only forwarding to faas-netes

* Set `direct_functions` to `false` in the env-var here:

  `kubectl edit -n openfaas deploy/gateway`

Now run a load test and watch `kubectl top pod -n openfaas-fn`

```
watch "kubectl top pod -n openfaas-fn"
hey -z 1m -c 10 http://192.168.0.26:31112/function/nodeinfo
```

## Test the patch to use endpoints

* Keep `direct_functions` as `false`

* Update your faas-netes image

  `kubectl -n openfaas --record deploy/gateway set image deploy/gateway faas-netes=alexellis2/faas-netes:invoke-4`

* Run a load test and check the balance

```
watch "kubectl top pod -n openfaas-fn"
hey -z 1m -c 10 http://192.168.0.26:31112/function/nodeinfo
```

You should see an equal balance as the Pods get auto-scaled up

```
Every 2.0s: kubectl top pod -A|grep nodeinfo                                                                                           nuc7: Sat Sep 28 10:18:06 2019

openfaas-fn    nodeinfo-6c8c6648dd-256fr                                     346m         10Mi
openfaas-fn    nodeinfo-6c8c6648dd-2vbxb                                     345m         7Mi
openfaas-fn    nodeinfo-6c8c6648dd-6bhpx                                     320m         7Mi
openfaas-fn    nodeinfo-6c8c6648dd-7hgkk                                     335m         9Mi
openfaas-fn    nodeinfo-6c8c6648dd-88kr4                                     305m         12Mi
openfaas-fn    nodeinfo-6c8c6648dd-8gx88                                     332m         10Mi
openfaas-fn    nodeinfo-6c8c6648dd-bjgct                                     378m         16Mi
openfaas-fn    nodeinfo-6c8c6648dd-dh972                                     301m         10Mi
openfaas-fn    nodeinfo-6c8c6648dd-dp8rv                                     360m         11Mi
openfaas-fn    nodeinfo-6c8c6648dd-frgdx                                     292m         15Mi
openfaas-fn    nodeinfo-6c8c6648dd-fx5lj                                     338m         9Mi
openfaas-fn    nodeinfo-6c8c6648dd-gbpmn                                     371m         11Mi
openfaas-fn    nodeinfo-6c8c6648dd-ql4hp                                     277m         18Mi
openfaas-fn    nodeinfo-6c8c6648dd-qn65p                                     273m         16Mi
openfaas-fn    nodeinfo-6c8c6648dd-sd564                                     323m         14Mi
openfaas-fn    nodeinfo-6c8c6648dd-wlnmz                                     373m         12Mi
openfaas-fn    nodeinfo-6c8c6648dd-xfbrr                                     374m         8Mi
openfaas-fn    nodeinfo-6c8c6648dd-xftc6                                     364m         9Mi
openfaas-fn    nodeinfo-6c8c6648dd-xgx2g                                     228m         9Mi
openfaas-fn    nodeinfo-6c8c6648dd-zs4nj                                     257m         8Mi
```