### PR TITLE
Move to KinD binary instead of fetching source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 
 before_script:
 - bash contrib/set_travis_experimental_mode.sh
-- curl -sSL get.docker.com | sudo -E sh
+- curl -sSLf https://get.docker.com | sed s/sleep\ 20/sleep\ 0/g | sudo -E sh
 - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
 script:

--- a/contrib/get_kind.sh
+++ b/contrib/get_kind.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-echo "go get -u sigs.k8s.io/kind@v0.4.0"
+# echo "go get -u sigs.k8s.io/kind@v0.4.0"
 
-export GO111MODULE="on"
-go get -u sigs.k8s.io/kind@v0.4.0
+# export GO111MODULE="on"
+# go get -u sigs.k8s.io/kind@v0.4.0
+
+# Edited by Alex Ellis - KinD via binary is *much* faster, 
+# Go modules now adds several minutes to the build / test time :-(
+curl -SLfs https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64 > kind-linux-amd64
+chmod +x kind-linux-amd64 
+sudo mv kind-linux-amd64 /usr/local/bin/kind


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Move to KinD binary instead of fetching source

## Motivation and Context

Getting the KinD via binary is *much* faster,  Go modules now
adds several minutes to the build / test time.