### PR TITLE
[WIP] Route on path when using proxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -157,13 +157,14 @@
   version = "0.17.3"
 
 [[projects]]
-  digest = "1:e02df3904d1a0f00b8e82654be61ca5bac94a64d52951de533b9bb86a4978726"
+  digest = "1:f879843be21485d1cf3c32c5a1395af47c67526aa6a321d5e65425a6a1fa69d1"
   name = "github.com/openfaas/faas-provider"
   packages = [
     ".",
     "auth",
     "httputil",
     "logs",
+    "proxy",
     "types",
   ]
   pruneopts = "UT"
@@ -588,6 +589,7 @@
     "github.com/gorilla/mux",
     "github.com/openfaas/faas-provider",
     "github.com/openfaas/faas-provider/logs",
+    "github.com/openfaas/faas-provider/proxy",
     "github.com/openfaas/faas-provider/types",
     "github.com/openfaas/faas/gateway/requests",
     "github.com/pkg/errors",
@@ -603,7 +605,6 @@
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
   ]

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -1,0 +1,30 @@
+// Copyright 2019 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type FunctionLookup struct {
+}
+
+func (l *FunctionLookup) Resolve(name string) (url.URL, error) {
+	namespace := "openfaas-fn"
+
+	urlRes, errRes := url.Parse(fmt.Sprintf("http://%s.%s:8080", name, namespace))
+
+	return *urlRes, errRes
+}
+
+func NewFunctionLookup() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		w.WriteHeader(http.StatusOK)
+
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/openfaas/faas-provider/proxy"
+
 	"github.com/openfaas/faas-netes/k8s"
 
 	"github.com/openfaas/faas-netes/handlers"
@@ -76,7 +78,7 @@ func main() {
 	factory := k8s.NewFunctionFactory(clientset, deployConfig)
 
 	bootstrapHandlers := bootTypes.FaaSHandlers{
-		FunctionProxy:        handlers.MakeProxy(functionNamespace, cfg.ReadTimeout),
+		FunctionProxy:        proxy.NewHandlerFunc(cfg.ReadTimeout, &handlers.FunctionLookup{}),
 		DeleteHandler:        handlers.MakeDeleteHandler(functionNamespace, clientset),
 		DeployHandler:        handlers.MakeDeployHandler(functionNamespace, factory),
 		FunctionReader:       handlers.MakeFunctionReader(functionNamespace, clientset),

--- a/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
+++ b/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
@@ -1,0 +1,216 @@
+// Package proxy provides a default function invocation proxy method for OpenFaaS providers.
+//
+// The function proxy logic is used by the Gateway when `direct_functions` is set to false.
+// This means that the provider will direct call the function and return the results.  This
+// involves resolving the function by name and then copying the result into the original HTTP
+// request.
+//
+// openfaas-provider has implemented a standard HTTP HandlerFunc that will handle setting
+// timeout values, parsing the request path, and copying the request/response correctly.
+// 		bootstrapHandlers := bootTypes.FaaSHandlers{
+// 			FunctionProxy:  proxy.NewHandlerFunc(timeout, resolver),
+// 			DeleteHandler:  handlers.MakeDeleteHandler(clientset),
+// 			DeployHandler:  handlers.MakeDeployHandler(clientset),
+// 			FunctionReader: handlers.MakeFunctionReader(clientset),
+// 			ReplicaReader:  handlers.MakeReplicaReader(clientset),
+// 			ReplicaUpdater: handlers.MakeReplicaUpdater(clientset),
+// 			InfoHandler:    handlers.MakeInfoHandler(),
+// 		}
+//
+// proxy.NewHandlerFunc is optional, but does simplify the logic of your provider.
+package proxy
+
+import (
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/openfaas/faas-provider/httputil"
+)
+
+const (
+	watchdogPort           = "8080"
+	defaultContentType     = "text/plain"
+	errMissingFunctionName = "Please provide a valid route /function/function_name."
+)
+
+// BaseURLResolver URL resolver for proxy requests
+//
+// The FaaS provider implementation is responsible for providing the resolver function implementation.
+// BaseURLResolver.Resolve will receive the function name and should return the URL of the
+// function service.
+type BaseURLResolver interface {
+	Resolve(functionName string) (url.URL, error)
+}
+
+// NewHandlerFunc creates a standard http.HandlerFunc to proxy function requests.
+// The returned http.HandlerFunc will ensure:
+//
+// 	- proper proxy request timeouts
+// 	- proxy requests for GET, POST, PATCH, PUT, and DELETE
+// 	- path parsing including support for extracing the function name, sub-paths, and query paremeters
+// 	- passing and setting the `X-Forwarded-Host` and `X-Forwarded-For` headers
+// 	- logging errors and proxy request timing to stdout
+//
+// Note that this will panic if `resolver` is nil.
+func NewHandlerFunc(timeout time.Duration, resolver BaseURLResolver) http.HandlerFunc {
+	if resolver == nil {
+		panic("NewHandlerFunc: empty proxy handler resolver, cannot be nil")
+	}
+
+	proxyClient := http.Client{
+		// these Transport values ensure that the http Client will eventually timeout and prevents
+		// infinite retries. The default http.Client configure these timeouts.  The specific
+		// values tuned via performance testing/benchmarking
+		//
+		// Additional context can be found at
+		// - https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779
+		// - https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   timeout,
+				KeepAlive: 1 * time.Second,
+			}).DialContext,
+			IdleConnTimeout:       120 * time.Millisecond,
+			ExpectContinueTimeout: 1500 * time.Millisecond,
+		},
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+
+		switch r.Method {
+		case http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+			http.MethodGet:
+
+			proxyRequest(w, r, proxyClient, resolver)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// proxyRequest handles the actual resolution of and then request to the function service.
+func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient http.Client, resolver BaseURLResolver) {
+	ctx := originalReq.Context()
+
+	pathVars := mux.Vars(originalReq)
+	functionName := pathVars["name"]
+	if functionName == "" {
+		httputil.Errorf(w, http.StatusBadRequest, errMissingFunctionName)
+		return
+	}
+
+	functionAddr, resolveErr := resolver.Resolve(functionName)
+	if resolveErr != nil {
+		// TODO: Should record the 404/not found error in Prometheus.
+		log.Printf("resolver error: cannot find %s: %s\n", functionName, resolveErr.Error())
+		httputil.Errorf(w, http.StatusNotFound, "Cannot find service: %s.", functionName)
+		return
+	}
+
+	proxyReq, err := buildProxyRequest(originalReq, functionAddr, pathVars["params"])
+	if err != nil {
+		httputil.Errorf(w, http.StatusInternalServerError, "Failed to resolve service: %s.", functionName)
+		return
+	}
+	if proxyReq.Body != nil {
+		defer proxyReq.Body.Close()
+	}
+
+	start := time.Now()
+	response, err := proxyClient.Do(proxyReq.WithContext(ctx))
+	seconds := time.Since(start)
+
+	if err != nil {
+		log.Printf("error with proxy request to: %s, %s\n", proxyReq.URL.String(), err.Error())
+
+		httputil.Errorf(w, http.StatusInternalServerError, "Can't reach service for: %s.", functionName)
+		return
+	}
+
+	log.Printf("%s took %f seconds\n", functionName, seconds.Seconds())
+
+	clientHeader := w.Header()
+	copyHeaders(clientHeader, &response.Header)
+	w.Header().Set("Content-Type", getContentType(response.Header, originalReq.Header))
+
+	w.WriteHeader(response.StatusCode)
+	io.Copy(w, response.Body)
+}
+
+// buildProxyRequest creates a request object for the proxy request, it will ensure that
+// the original request headers are preserved as well as setting openfaas system headers
+func buildProxyRequest(originalReq *http.Request, baseURL url.URL, extraPath string) (*http.Request, error) {
+
+	host := baseURL.Host
+	if baseURL.Port() == "" {
+		host = baseURL.Host + ":" + watchdogPort
+	}
+
+	url := url.URL{
+		Scheme:   baseURL.Scheme,
+		Host:     host,
+		Path:     extraPath,
+		RawQuery: originalReq.URL.RawQuery,
+	}
+
+	upstreamReq, err := http.NewRequest(originalReq.Method, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	copyHeaders(upstreamReq.Header, &originalReq.Header)
+
+	if len(originalReq.Host) > 0 && upstreamReq.Header.Get("X-Forwarded-Host") == "" {
+		upstreamReq.Header["X-Forwarded-Host"] = []string{originalReq.Host}
+	}
+	if upstreamReq.Header.Get("X-Forwarded-For") == "" {
+		upstreamReq.Header["X-Forwarded-For"] = []string{originalReq.RemoteAddr}
+	}
+
+	if originalReq.Body != nil {
+		upstreamReq.Body = originalReq.Body
+	}
+
+	return upstreamReq, nil
+}
+
+// copyHeaders clones the header values from the source into the destination.
+func copyHeaders(destination http.Header, source *http.Header) {
+	for k, v := range *source {
+		vClone := make([]string, len(v))
+		copy(vClone, v)
+		destination[k] = vClone
+	}
+}
+
+// getContentType resolves the correct Content-Type for a proxied function.
+func getContentType(request http.Header, proxyResponse http.Header) (headerContentType string) {
+	responseHeader := proxyResponse.Get("Content-Type")
+	requestHeader := request.Get("Content-Type")
+
+	if len(responseHeader) > 0 {
+		headerContentType = responseHeader
+	} else if len(requestHeader) > 0 {
+		headerContentType = requestHeader
+	} else {
+		headerContentType = defaultContentType
+	}
+
+	return headerContentType
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Route on path when using proxy

## Motivation and Context

system-dashboard in OpenFaaS Cloud was getting an invalid path when Using faas-netes in pass-through mode for proxying to functions.

The change to use faas-provider means that functions can now
be invoked with a path. An additional change will be required
for any namespace parameter required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With faas-federation and the OFC dashboard, it failed to work before due to invalid paths.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
