### PR TITLE
Add namespace flag to secrets handlers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN license-check -path /go/src/github.com/openfaas/faas-netes/ --verbose=false "Alex Ellis" "OpenFaaS Author(s)"
 RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*") \
-    && go test ./test/ ./handlers/ \
+    && go test ./test/ \
     && VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
     && GIT_COMMIT=$(git rev-list -1 HEAD) \
     && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -157,7 +157,7 @@
   version = "0.17.3"
 
 [[projects]]
-  digest = "1:e02df3904d1a0f00b8e82654be61ca5bac94a64d52951de533b9bb86a4978726"
+  digest = "1:add7a1c43234b668ff5ce8f6a7d5e0a453d866d51cdb2f7014fe94808154f431"
   name = "github.com/openfaas/faas-provider"
   packages = [
     ".",
@@ -167,8 +167,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "eafd85a3b360d8e0982c3a1db43e6d5fee9b85e2"
-  version = "0.10.2"
+  revision = "478f741b64cbcfaaee852156b060514be56623b3"
+  version = "0.12.0"
 
 [[projects]]
   branch = "master"
@@ -603,7 +603,6 @@
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"
-  version = "0.10.2"
+  version = "0.12.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"
@@ -22,4 +22,3 @@
 [prune]
   go-tests = true
   unused-packages = true
-

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MakeNamespacesLister builds a list of namespaces with an "openfaas" tag, or the default name
-func MakeNamespacesLister(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
+func MakeNamespacesLister(defaultNamespace string, clientset kubernetes.Interface) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Query namespaces")
 
@@ -28,7 +28,7 @@ func MakeNamespacesLister(defaultNamespace string, clientset *kubernetes.Clients
 	}
 }
 
-func list(defaultNamespace string, clientset *kubernetes.Clientset) []string {
+func list(defaultNamespace string, clientset kubernetes.Interface) []string {
 	listOptions := metav1.ListOptions{}
 	namespaces, err := clientset.CoreV1().Namespaces().List(listOptions)
 

--- a/vendor/github.com/openfaas/faas-provider/auth/credentials.go
+++ b/vendor/github.com/openfaas/faas-provider/auth/credentials.go
@@ -17,7 +17,7 @@ type BasicAuthCredentials struct {
 }
 
 type ReadBasicAuth interface {
-	Read() (error, *BasicAuthCredentials)
+	Read() (*BasicAuthCredentials, error)
 }
 
 type ReadBasicAuthFromDisk struct {

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -93,6 +93,7 @@ type FunctionStatus struct {
 
 // Secret for underlying orchestrator
 type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Value     string `json:"value,omitempty"`
 }


### PR DESCRIPTION
## Description
Add support to Namespace in Secrets.

I created the `getLookupNamespace` function, which I'm not 100% proud of, since it reads the `r.Body` and puts it back into the `r` struct. BUT this way I didn't need to change all the signatures of all the other handlers, also, if there's any verification for the namespace we can do in one place.

Depends on (build will fail before merging the PRs below and bumping their version in this project):
- [faas-provider #28](https://github.com/openfaas/faas-provider/pull/28).
- [faas #1334](https://github.com/openfaas/faas/pull/1334).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) [faas-netes #511](https://github.com/openfaas/faas-netes/issues/511).

## How Has This Been Tested?
Added tests ✨ Also I deployed locally and tested with the following commands:
```bash
$ faas-cli secret create secret-cli --from-literal=value

$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets
[{"name":"secret-cli","namespace":"openfaas-fn"}]

# no secret in the default ns
$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets\?namespace\=default    
[]

# creates a secret in the default ns
$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets -X POST -d '{"name": "secret-api", "value": "value", "namespace": "default"}' -H 'Content-Type: application/json

# doesn't list the default secret 
$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets                    
[{"name":"secret-cli","namespace":"openfaas-fn"}]

# list the default secret
$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets\?namespace\=default
[{"name":"secret-api","namespace":"default"}

# changes the secret value from default ns
$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets -X PUT -d '{"name": "secret-api", "value": "value-PUT", "namespace": "default"}' -H 'Content-Type: application/j
son'

# verify secret value
$ k get secret secret-api -o jsonpath='{.data.secret-api}' | base64 -D
value-PUT

# delete secret
$ curl -u admin:$PASSWORD $OPENFAAS_URL/system/secrets -X DELETE -d '{"name": "secret-api", "namespace": "defa
ult"}' -H 'Content-Type: application/json' 

# verify deletion of `secret-api`
$ faas-cli secret list

NAME
secret-cli
```

Yay! ❤️

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
