### PR TITLE
Update faas-provider to 0.13.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -165,7 +165,7 @@
   version = "0.18.2"
 
 [[projects]]
-  digest = "1:ca48ab4a85175261336d42e14cc31dfa2c874118136b404dca5cca8686a6250b"
+  digest = "1:99dadc2c1ee4102a3ffc1e84d9e182dcb20bed29a89c9f937310b7a969de7f7d"
   name = "github.com/openfaas/faas-provider"
   packages = [
     ".",
@@ -176,8 +176,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "478f741b64cbcfaaee852156b060514be56623b3"
-  version = "0.12.0"
+  revision = "78c25aab33bbdaae7b6d031006535d363eaacda5"
+  version = "0.13.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"
-  version = "0.12.0"
+  version = "0.13.1"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/test/read_config_test.go
+++ b/test/read_config_test.go
@@ -4,9 +4,7 @@
 package test
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/openfaas/faas-netes/types"
 )
@@ -28,85 +26,13 @@ func (e EnvBucket) Getenv(key string) string {
 func (e EnvBucket) Setenv(key string, value string) {
 	e.Items[key] = value
 }
-
-func TestRead_EmptyTimeoutConfig(t *testing.T) {
-	defaults := NewEnvBucket()
-	readConfig := types.ReadConfig{}
-
-	config := readConfig.Read(defaults)
-	defaultVal := time.Duration(10) * time.Second
-	if (config.ReadTimeout) != defaultVal {
-		t.Logf("ReadTimeout want: %s, got %s", defaultVal.String(), config.ReadTimeout.String())
-		t.Fail()
-	}
-	if (config.WriteTimeout) != defaultVal {
-		t.Logf("WriteTimeout want: %s, got %s", defaultVal.String(), config.ReadTimeout.String())
-		t.Fail()
-	}
-
-	wantPort := 8080
-
-	if config.Port != wantPort {
-		t.Logf("Port want: %d, got %d", wantPort, config.Port)
-		t.Fail()
-	}
-}
-
-func TestRead_ReadPortConfig(t *testing.T) {
-	defaults := NewEnvBucket()
-	wantPort := 8082
-
-	defaults.Setenv("port", fmt.Sprintf("%d", wantPort))
-
-	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
-
-	if config.Port != wantPort {
-		t.Logf("Port incorrect, want: %d, got: %d\n", wantPort, config.Port)
-		t.Fail()
-	}
-}
-
-func TestRead_ReadAndWriteIntegerTimeoutConfig(t *testing.T) {
-	defaults := NewEnvBucket()
-	defaults.Setenv("read_timeout", "10")
-	defaults.Setenv("write_timeout", "60")
-
-	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
-
-	if (config.ReadTimeout) != time.Duration(10)*time.Second {
-		t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
-		t.Fail()
-	}
-	if (config.WriteTimeout) != time.Duration(60)*time.Second {
-		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
-		t.Fail()
-	}
-}
-
-func TestRead_ReadAndWriteDurationTimeoutConfig(t *testing.T) {
-	defaults := NewEnvBucket()
-	defaults.Setenv("read_timeout", "10s")
-	defaults.Setenv("write_timeout", "60s")
-
-	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
-
-	if (config.ReadTimeout) != time.Duration(10)*time.Second {
-		t.Logf("ReadTimeout incorrect, got: %d\n", config.ReadTimeout)
-		t.Fail()
-	}
-	if (config.WriteTimeout) != time.Duration(60)*time.Second {
-		t.Logf("WriteTimeout incorrect, got: %d\n", config.WriteTimeout)
-		t.Fail()
-	}
-}
-
 func TestRead_EmptyProbeConfig(t *testing.T) {
 	defaults := NewEnvBucket()
 	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("Unexpected error while reading env %s", err.Error())
+	}
 	want := false
 	if config.HTTPProbe != want {
 		t.Logf("EnableFunctionReadinressProbe incorrect, want: %t, got: %t", want, config.HTTPProbe)
@@ -119,7 +45,10 @@ func TestRead_HTTPProbeConfig(t *testing.T) {
 	defaults.Setenv("http_probe", "false")
 
 	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("Unexpected error while reading env %s", err.Error())
+	}
 
 	if config.HTTPProbe {
 		t.Logf("HTTPProbe incorrect, got: %v\n", config.HTTPProbe)
@@ -132,7 +61,10 @@ func TestRead_HTTPProbeConfig_true(t *testing.T) {
 	defaults.Setenv("http_probe", "true")
 
 	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("Unexpected error while reading env %s", err.Error())
+	}
 
 	if !config.HTTPProbe {
 		t.Logf("HTTPProbe incorrect, got: %v\n", config.HTTPProbe)
@@ -145,7 +77,10 @@ func TestRead_ImagePullPolicy_set(t *testing.T) {
 	defaults.Setenv("image_pull_policy", "IfNotPresent")
 
 	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("Unexpected error while reading env %s", err.Error())
+	}
 
 	if (config.ImagePullPolicy) != "IfNotPresent" {
 		t.Logf("ImagePullPolicy incorrect, got: %v\n", config.ImagePullPolicy)
@@ -158,7 +93,10 @@ func TestRead_ImagePullPolicy_empty(t *testing.T) {
 	defaults.Setenv("image_pull_policy", "")
 
 	readConfig := types.ReadConfig{}
-	config := readConfig.Read(defaults)
+	config, err := readConfig.Read(defaults)
+	if err != nil {
+		t.Fatalf("Unexpected error while reading env %s", err.Error())
+	}
 
 	if (config.ImagePullPolicy) != "Always" {
 		t.Logf("ImagePullPolicy incorrect, got: %v\n", config.ImagePullPolicy)

--- a/types/read_config.go
+++ b/types/read_config.go
@@ -3,91 +3,35 @@
 package types
 
 import (
-	"os"
-	"strconv"
-	"time"
+	ftypes "github.com/openfaas/faas-provider/types"
 )
-
-// OsEnv implements interface to wrap os.Getenv
-type OsEnv struct {
-}
-
-// Getenv wraps os.Getenv
-func (OsEnv) Getenv(key string) string {
-	return os.Getenv(key)
-}
-
-// HasEnv provides interface for os.Getenv
-type HasEnv interface {
-	Getenv(key string) string
-}
 
 // ReadConfig constitutes config from env variables
 type ReadConfig struct {
 }
 
-func parseIntValue(val string, fallback int) int {
-	if len(val) > 0 {
-		parsedVal, parseErr := strconv.Atoi(val)
-		if parseErr == nil && parsedVal >= 0 {
-			return parsedVal
-		}
-	}
-	return fallback
-}
-
-func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
-	if len(val) > 0 {
-		parsedVal, parseErr := strconv.Atoi(val)
-		if parseErr == nil && parsedVal >= 0 {
-			return time.Duration(parsedVal) * time.Second
-		}
-	}
-
-	duration, durationErr := time.ParseDuration(val)
-	if durationErr != nil {
-		return fallback
-	}
-
-	return duration
-}
-
-func parseBoolValue(val string, fallback bool) bool {
-	if len(val) > 0 {
-		return val == "true"
-	}
-	return fallback
-}
-
-func parseString(val string, fallback string) string {
-	if len(val) > 0 {
-		return val
-	}
-	return fallback
-}
-
 // Read fetches config from environmental variables.
-func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
+func (ReadConfig) Read(hasEnv ftypes.HasEnv) (BootstrapConfig, error) {
 	cfg := BootstrapConfig{}
 
-	httpProbe := parseBoolValue(hasEnv.Getenv("http_probe"), false)
-	setNonRootUser := parseBoolValue(hasEnv.Getenv("set_nonroot_user"), false)
+	faasConfig, err := ftypes.ReadConfig{}.Read(hasEnv)
+	if err != nil {
+		return cfg, err
+	}
 
-	readinessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
-	readinessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
-	readinessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("readiness_probe_period_seconds"), 10)
+	cfg.FaaSConfig = *faasConfig
 
-	livenessProbeInitialDelaySeconds := parseIntValue(hasEnv.Getenv("liveness_probe_initial_delay_seconds"), 3)
-	livenessProbeTimeoutSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_timeout_seconds"), 1)
-	livenessProbePeriodSeconds := parseIntValue(hasEnv.Getenv("liveness_probe_period_seconds"), 10)
+	httpProbe := ftypes.ParseBoolValue(hasEnv.Getenv("http_probe"), false)
+	setNonRootUser := ftypes.ParseBoolValue(hasEnv.Getenv("set_nonroot_user"), false)
 
-	readTimeout := parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10)
-	writeTimeout := parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10)
+	readinessProbeInitialDelaySeconds := ftypes.ParseIntValue(hasEnv.Getenv("readiness_probe_initial_delay_seconds"), 3)
+	readinessProbeTimeoutSeconds := ftypes.ParseIntValue(hasEnv.Getenv("readiness_probe_timeout_seconds"), 1)
+	readinessProbePeriodSeconds := ftypes.ParseIntValue(hasEnv.Getenv("readiness_probe_period_seconds"), 10)
 
-	imagePullPolicy := parseString(hasEnv.Getenv("image_pull_policy"), "Always")
-
-	cfg.ReadTimeout = readTimeout
-	cfg.WriteTimeout = writeTimeout
+	livenessProbeInitialDelaySeconds := ftypes.ParseIntValue(hasEnv.Getenv("liveness_probe_initial_delay_seconds"), 3)
+	livenessProbeTimeoutSeconds := ftypes.ParseIntValue(hasEnv.Getenv("liveness_probe_timeout_seconds"), 1)
+	livenessProbePeriodSeconds := ftypes.ParseIntValue(hasEnv.Getenv("liveness_probe_period_seconds"), 10)
+	imagePullPolicy := ftypes.ParseString(hasEnv.Getenv("image_pull_policy"), "Always")
 
 	cfg.HTTPProbe = httpProbe
 	cfg.SetNonRootUser = setNonRootUser
@@ -102,10 +46,7 @@ func (ReadConfig) Read(hasEnv HasEnv) BootstrapConfig {
 
 	cfg.ImagePullPolicy = imagePullPolicy
 
-	defaultTCPPort := 8080
-	cfg.Port = parseIntValue(hasEnv.Getenv("port"), defaultTCPPort)
-
-	return cfg
+	return cfg, nil
 }
 
 // BootstrapConfig for the process.
@@ -120,8 +61,6 @@ type BootstrapConfig struct {
 	LivenessProbeInitialDelaySeconds  int
 	LivenessProbeTimeoutSeconds       int
 	LivenessProbePeriodSeconds        int
-	ReadTimeout                       time.Duration
-	WriteTimeout                      time.Duration
 	ImagePullPolicy                   string
-	Port                              int
+	FaaSConfig                        ftypes.FaaSConfig
 }

--- a/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
+++ b/vendor/github.com/openfaas/faas-provider/proxy/proxy.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/openfaas/faas-provider/httputil"
+	"github.com/openfaas/faas-provider/types"
 )
 
 const (
@@ -57,33 +58,12 @@ type BaseURLResolver interface {
 // 	- logging errors and proxy request timing to stdout
 //
 // Note that this will panic if `resolver` is nil.
-func NewHandlerFunc(timeout time.Duration, resolver BaseURLResolver) http.HandlerFunc {
+func NewHandlerFunc(config types.FaaSConfig, resolver BaseURLResolver) http.HandlerFunc {
 	if resolver == nil {
 		panic("NewHandlerFunc: empty proxy handler resolver, cannot be nil")
 	}
 
-	proxyClient := http.Client{
-		// these Transport values ensure that the http Client will eventually timeout and prevents
-		// infinite retries. The default http.Client configure these timeouts.  The specific
-		// values tuned via performance testing/benchmarking
-		//
-		// Additional context can be found at
-		// - https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779
-		// - https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   timeout,
-				KeepAlive: 1 * time.Second,
-			}).DialContext,
-			IdleConnTimeout:       120 * time.Millisecond,
-			ExpectContinueTimeout: 1500 * time.Millisecond,
-		},
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	proxyClient := NewProxyClientFromConfig(config)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Body != nil {
@@ -105,8 +85,52 @@ func NewHandlerFunc(timeout time.Duration, resolver BaseURLResolver) http.Handle
 	}
 }
 
+// NewProxyClientFromConfig creates a new http.Client designed for proxying requests and enforcing
+// certain minimum configuration values.
+func NewProxyClientFromConfig(config types.FaaSConfig) *http.Client {
+	return NewProxyClient(config.GetReadTimeout(), config.GetMaxIdleConns(), config.GetMaxIdleConnsPerHost())
+}
+
+// NewProxyClient creates a new http.Client designed for proxying requests, this is exposed as a
+// convenience method for internal or advanced uses. Most people should use NewProxyClientFromConfig.
+func NewProxyClient(timeout time.Duration, maxIdleConns int, maxIdleConnsPerHost int) *http.Client {
+	return &http.Client{
+		// these Transport values ensure that the http Client will eventually timeout and prevents
+		// infinite retries. The default http.Client configure these timeouts.  The specific
+		// values tuned via performance testing/benchmarking
+		//
+		// Additional context can be found at
+		// - https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779
+		// - https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
+		//
+		// Additionally, these overrides for the default client enable re-use of connections and prevent
+		// CoreDNS from rate limiting under high traffic
+		//
+		// See also two similar projects where this value was updated:
+		// https://github.com/prometheus/prometheus/pull/3592
+		// https://github.com/minio/minio/pull/5860
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   timeout,
+				KeepAlive: 1 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          maxIdleConns,
+			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+			IdleConnTimeout:       120 * time.Millisecond,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1500 * time.Millisecond,
+		},
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 // proxyRequest handles the actual resolution of and then request to the function service.
-func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient http.Client, resolver BaseURLResolver) {
+func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient *http.Client, resolver BaseURLResolver) {
 	ctx := originalReq.Context()
 
 	pathVars := mux.Vars(originalReq)
@@ -143,6 +167,7 @@ func proxyRequest(w http.ResponseWriter, originalReq *http.Request, proxyClient 
 		httputil.Errorf(w, http.StatusInternalServerError, "Can't reach service for: %s.", functionName)
 		return
 	}
+	defer response.Body.Close()
 
 	log.Printf("%s took %f seconds\n", functionName, seconds.Seconds())
 

--- a/vendor/github.com/openfaas/faas-provider/types/config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/config.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+const (
+	defaultReadTimeout  = 10 * time.Second
+	defaultMaxIdleConns = 1024
+)
+
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
@@ -30,10 +35,48 @@ type FaaSHandlers struct {
 
 // FaaSConfig set config for HTTP handlers
 type FaaSConfig struct {
-	TCPPort         *int
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	EnableHealth    bool
+	// TCPPort is the public port for the API.
+	TCPPort *int
+	// HTTP timeout for reading a request from clients.
+	ReadTimeout time.Duration
+	// HTTP timeout for writing a response from functions.
+	WriteTimeout time.Duration
+	// EnableHealth enables/disables the default health endpoint bound to "/healthz".
+	EnableHealth bool
+	// EnableBasicAuth enforces basic auth on the API. If set, reads secrets from file-system
+	// location specificed in `SecretMountPath`.
 	EnableBasicAuth bool
+	// SecretMountPath specifies where to read secrets from for embedded basic auth.
 	SecretMountPath string
+	// MaxIdleConns with a default value of 1024, can be used for tuning HTTP proxy performance.
+	MaxIdleConns int
+	// MaxIdleConnsPerHost with a default value of 1024, can be used for tuning HTTP proxy performance.
+	MaxIdleConnsPerHost int
+}
+
+// GetReadTimeout is a helper to safely return the configured ReadTimeout or the default value of 10s
+func (c *FaaSConfig) GetReadTimeout() time.Duration {
+	if c.ReadTimeout <= 0*time.Second {
+		return defaultReadTimeout
+	}
+	return c.ReadTimeout
+}
+
+// GetMaxIdleConns is a helper to safely return the configured MaxIdleConns or the default value of 1024
+func (c *FaaSConfig) GetMaxIdleConns() int {
+	if c.MaxIdleConns < 1 {
+		return defaultMaxIdleConns
+	}
+
+	return c.MaxIdleConns
+}
+
+// GetMaxIdleConns is a helper to safely return the configured MaxIdleConns or the default value which
+// should then match the MaxIdleConns
+func (c *FaaSConfig) GetMaxIdleConnsPerHost() int {
+	if c.MaxIdleConnsPerHost < 1 {
+		return c.GetMaxIdleConns()
+	}
+
+	return c.MaxIdleConnsPerHost
 }

--- a/vendor/github.com/openfaas/faas-provider/types/read_config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/read_config.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// OsEnv implements interface to wrap os.Getenv
+type OsEnv struct {
+}
+
+// Getenv wraps os.Getenv
+func (OsEnv) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// HasEnv provides interface for os.Getenv
+type HasEnv interface {
+	Getenv(key string) string
+}
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+// ParseIntValue parses the the int in val or, if there is an error, returns the
+// specified default value
+func ParseIntValue(val string, fallback int) int {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return parsedVal
+		}
+	}
+	return fallback
+}
+
+// ParseIntOrDurationValue parses the the duration in val or, if there is an error, returns the
+// specified default value
+func ParseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+
+	return duration
+}
+
+// ParseBoolValue parses the the boolean in val or, if there is an error, returns the
+// specified default value
+func ParseBoolValue(val string, fallback bool) bool {
+	if len(val) > 0 {
+		return val == "true"
+	}
+	return fallback
+}
+
+// ParseString verifies the string in val is not empty. When empty, it returns the
+// specified default value
+func ParseString(val string, fallback string) string {
+	if len(val) > 0 {
+		return val
+	}
+	return fallback
+}
+
+// Read fetches config from environmental variables.
+func (ReadConfig) Read(hasEnv HasEnv) (*FaaSConfig, error) {
+	cfg := &FaaSConfig{
+		ReadTimeout:  ParseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*10),
+		WriteTimeout: ParseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*10),
+		// default value from Gateway
+		EnableBasicAuth: ParseBoolValue(hasEnv.Getenv("basic_auth"), false),
+		// default value from Gateway
+		SecretMountPath: ParseString(hasEnv.Getenv("secret_mount_path"), "/run/secrets/"),
+	}
+
+	port := ParseIntValue(hasEnv.Getenv("port"), 8080)
+	cfg.TCPPort = &port
+
+	cfg.MaxIdleConns = 1024
+	maxIdleConns := hasEnv.Getenv("max_idle_conns")
+	if len(maxIdleConns) > 0 {
+		val, err := strconv.Atoi(maxIdleConns)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns: %s", maxIdleConns)
+		}
+		cfg.MaxIdleConns = val
+
+	}
+
+	cfg.MaxIdleConnsPerHost = 1024
+	maxIdleConnsPerHost := hasEnv.Getenv("max_idle_conns_per_host")
+	if len(maxIdleConnsPerHost) > 0 {
+		val, err := strconv.Atoi(maxIdleConnsPerHost)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns_per_host: %s", maxIdleConnsPerHost)
+		}
+		cfg.MaxIdleConnsPerHost = val
+
+	}
+
+	return cfg, nil
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Update faas-provider to 0.13.1
- Update the types configuration reading to use the standardized env
    parsing from faas-provider. Embed the standardized FaaSConfig so that it can
    be used in the function proxy.
- Remove unused config code and tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Related to openfaas/faas-swarm#59

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Current tests pass and should cover these changes
- I have deployed a build with these changes and have successfully run a function 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
