### PR TITLE
Ensure that static manifest inherit the default values

### DIFF
--- a/contrib/create-static-manifest.sh
+++ b/contrib/create-static-manifest.sh
@@ -16,6 +16,7 @@
 
 CHART_DIR=${1:-"./chart/openfaas"}
 OUTPUT_DIR=${2:-"./yaml"}
+BASEVALUESNAME="$CHART_DIR/values.yaml"
 VALUESNAME=${3:-"$CHART_DIR/values.yaml"}
 NAMEPSPACE=${4:-"openfaas"}
 FUNCTIONNAMESPACE=${5:-"openfaas-fn"}
@@ -25,7 +26,7 @@ for filepath in $TEMPLATE_FILE; do
     filename=$(basename $filepath)
     outputname="${filename%%.*}.yml"
     # Use helm to generate the yaml and then use sed to remove the helm specific lables/annotations.
-    helm template "$CHART_DIR" --name=faas --namespace="$NAMEPSPACE" --set "functionNamespace=$FUNCTIONNAMESPACE" -x templates/$filename --values="$VALUESNAME" \
+    helm template "$CHART_DIR" --name=faas --namespace="$NAMEPSPACE" --set "functionNamespace=$FUNCTIONNAMESPACE" -x templates/$filename --values="$BASEVALUESNAME" --values="$VALUESNAME" \
         | sed -E '/(chart:)|(release:)|(heritage:)/d' \
         | sed -E '/# Source:/d' \
         | sed -E '/^$/d' \


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Use both the default values and the arm sepecific values files so that
  defaults can be cleanly defined in the main chart and inherited when
  creating the static manifests


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


This came from a discussion with Alex while trying to debug something in the chart and realizing that the arm manifests might not be inheriting all of the default values.  This should allow him to test and verify 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
