### PR TITLE
Fix issues with namespace usage

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -30,7 +30,10 @@ const initialReplicasCount = 1
 // MakeDeployHandler creates a handler to create new functions in the cluster
 func MakeDeployHandler(functionNamespace string, factory k8s.FunctionFactory) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
 
 		body, _ := ioutil.ReadAll(r.Body)
 

--- a/handlers/reader.go
+++ b/handlers/reader.go
@@ -19,6 +19,7 @@ import (
 // MakeFunctionReader handler for reading functions deployed in the cluster as deployments.
 func MakeFunctionReader(defaultNamespace string, clientset *kubernetes.Clientset) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+
 		q := r.URL.Query()
 		namespace := q.Get("namespace")
 
@@ -30,6 +31,7 @@ func MakeFunctionReader(defaultNamespace string, clientset *kubernetes.Clientset
 
 		if lookupNamespace == "kube-system" {
 			http.Error(w, "unable to list within the kube-system namespace", http.StatusUnauthorized)
+			return
 		}
 
 		functions, err := getServiceList(lookupNamespace, clientset)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix issues with namespace usage

## Motivation and Context

The update handler was trying to read the namespace from a
query-string, but clients pass this in the request body. The
handler was changed to match the approach of the create handler.

Fixes: #541

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested e2e with Kubernetes 1.14.1

Additionally the delete handler was writing HTTP headers more than
once in some conditions. This has also been updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
