### PR TITLE
Fix PSP name in ClusterRole and Rolebinding Namespace

### DIFF
--- a/chart/openfaas/templates/psp.yaml
+++ b/chart/openfaas/templates/psp.yaml
@@ -49,12 +49,13 @@ rules:
       resources: ['podsecuritypolicies']
       verbs:     ['use']
       resourceNames:
-          - openfaas-psp
+          - {{ .Release.Name }}-psp
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: {{ .Release.Name }}-psp
+    namespace: {{ .Release.Namespace | quote }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole


### PR DESCRIPTION

## Description
- Change the reference in the ClusterRole to use the ReleaseName instead of hardcoded **openfaas**
- Place the RoleBinding in the correct namespace

## Motivation and Context
When deploying the helm chart with a different release name, the PSP name and the reference included in the ClusterRole are not aligned.

Fix for #539

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
1. Enable PSP (guide)[https://octetz.com/posts/setting-up-psps]
2. Install openfaas
```
helm install -n customname openfaas/openfaas \
    --namespace openfaas  \
    --set psp=true \
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
