### PR TITLE
Load env process value into function status

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -275,7 +275,7 @@ func buildEnvVars(request *types.FunctionDeployment) []corev1.EnvVar {
 
 	if len(request.EnvProcess) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  "fprocess",
+			Name:  k8s.EnvProcessName,
 			Value: request.EnvProcess,
 		})
 	}

--- a/k8s/function_status.go
+++ b/k8s/function_status.go
@@ -1,0 +1,43 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package k8s
+
+import (
+	types "github.com/openfaas/faas-provider/types"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// EnvProcessName is the name of the env variable containing the function process
+const EnvProcessName = "fprocess"
+
+// AsFunctionStatus reads a Deployment object into an OpenFaaS FunctionStatus, parsing the
+// Deployment and Container spec into a simplified summary of the Function
+func AsFunctionStatus(item appsv1.Deployment) *types.FunctionStatus {
+	var replicas uint64
+	if item.Spec.Replicas != nil {
+		replicas = uint64(*item.Spec.Replicas)
+	}
+
+	functionContainer := item.Spec.Template.Spec.Containers[0]
+
+	labels := item.Spec.Template.Labels
+	function := types.FunctionStatus{
+		Name:              item.Name,
+		Replicas:          replicas,
+		Image:             functionContainer.Image,
+		AvailableReplicas: uint64(item.Status.AvailableReplicas),
+		InvocationCount:   0,
+		Labels:            &labels,
+		Annotations:       &item.Spec.Template.Annotations,
+		Namespace:         item.Namespace,
+	}
+
+	for _, v := range functionContainer.Env {
+		if EnvProcessName == v.Name {
+			function.EnvProcess = v.Value
+		}
+	}
+
+	return &function
+}

--- a/k8s/function_status_test.go
+++ b/k8s/function_status_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 OpenFaaS Authors
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_AsFunctionStatus(t *testing.T) {
+
+	name := "test-func"
+	replicas := int32(2)
+	image := "openfaas/func:latest"
+	availableReplicas := int32(1)
+	labels := map[string]string{"foo": "foovalue"}
+	annotations := map[string]string{"data": "datavalue"}
+	namespace := "func-namespace"
+	envProcess := "process string here"
+
+	deploy := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  name,
+							Image: image,
+							Env: []corev1.EnvVar{
+								{Name: "fprocess", Value: envProcess},
+								{Name: "customEnv", Value: "customValue"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: availableReplicas,
+		},
+	}
+	status := AsFunctionStatus(deploy)
+
+	if status.Name != name {
+		t.Errorf("incorrect Name: expected %s, got %s", name, status.Name)
+	}
+
+	if status.Replicas != uint64(replicas) {
+		t.Errorf("incorrect Replicas: expected %d, got %d", replicas, status.Replicas)
+	}
+
+	if status.Image != image {
+		t.Errorf("incorrect Image: expected %s, got %s", image, status.Image)
+	}
+
+	if status.AvailableReplicas != uint64(availableReplicas) {
+		t.Errorf("incorrect AvailableReplicas: expected %d, got %d", availableReplicas, status.AvailableReplicas)
+	}
+
+	if !reflect.DeepEqual(status.Labels, &labels) {
+		t.Errorf("incorrect Labels: expected %+v, got %+v", labels, status.Labels)
+	}
+
+	if !reflect.DeepEqual(status.Annotations, &annotations) {
+		t.Errorf("incorrect Annotations: expected %+v, got %+v", annotations, status.Annotations)
+	}
+
+	if status.Namespace != namespace {
+		t.Errorf("incorrect Namespace: expected %s, got %s", namespace, status.Namespace)
+	}
+
+	if status.EnvProcess != envProcess {
+		t.Errorf("incorrect EnvProcess: expected %s, got %s", envProcess, status.EnvProcess)
+	}
+
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Copies the `readFunction` method as `AsFunctionStatus` in the k8s package
  for loading a function Deployment into a FunctionStatus struct. This
  includes new tests for the method


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Issue is documented on [trello](https://trello.com/c/M77G8sZo/233-read-envprocess-back-in-the-function-spec-in-faas-netes)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have pushed a build of the branch to `theaxer/faas-netes:latest-envprocess`

1. Deploy the branch
    ```sh
    $ kubectl create namespace of-test
    $ helm upgrade of-secrets-test --install openfaas/openfaas \
        --namespace of-test  \
        --set basic_auth=false \
        --set functionNamespace=of-test \
        --set faasnetes.image=theaxer/faas-netes:latest-envprocess

    $ kubectl -n of-test get deploy/gateway -o yaml | grep image:
            image: openfaas/gateway:0.18.2
            image: theaxer/faas-netes:latest-envprocess

    $ kubectl -n of-test port-forward deploy/gateway 8080
    ```

2. Test the env process is read correctly 
    ```sh
    $ faas-cli deploy  \
        --fprocess=cat \
        --image=functions/alpine \
        --name echo

    $ faas-cli describe echo | grep "Function process"
    Function process:    cat
    ```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
