### PR TITLE
Allow for using an externally-managed NATS Streaming server.

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 5.2.2
+version: 5.3.0
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -284,7 +284,7 @@ Additional OpenFaaS options in `values.yaml`.
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `functionNamespace` | Functions namespace, preferred `openfaas-fn` | `default` |
 | `clusterRole` | Set to `true` if you'd like to use multiple namespaces for functions | `false` |
-| `async` | Deploys NATS | `true` |
+| `async` | Enables asynchronous function invocations. If `.nats.external.enabled` is `false`, also deploys NATS Streaming | `true` |
 | `exposeServices` | Expose `NodePorts/LoadBalancer`  | `true` |
 | `serviceType` | Type of external service to use `NodePort/LoadBalancer` | `NodePort` |
 | `basic_auth` | Enable basic authentication on the Gateway | `true` |
@@ -316,7 +316,11 @@ Additional OpenFaaS options in `values.yaml`.
 | `gateway.maxIdleConnsPerHost` | Set max idle connections from gateway to functions per host | `1024` |
 | `queueWorker.replicas` | Replicas of the queue-worker, pick more than `1` for HA | `1` |
 | `queueWorker.ackWait` | Max duration of any async task/request | `60s` |
-| `nats.enableMonitoring` | Enable the NATS monitoring endpoints on port `8222` | `false` |
+| `nats.external.clusterName` | The name of the externally-managed NATS Streaming server | `` |
+| `nats.external.enabled` | Whether to use an externally-managed NATS Streaming server | `false` |
+| `nats.external.host` | The host at which the externally-managed NATS Streaming server can be reached | `""` |
+| `nats.external.port` | The port at which the externally-managed NATS Streaming server can be reached | `""` |
+| `nats.enableMonitoring` | Enable the NATS monitoring endpoints on port `8222` for NATS Streaming deployments managed by this chart | `false` |
 | `faasIdler.create` | Create the faasIdler component | `true` |
 | `faasIdler.inactivityDuration` | Duration after which faas-idler will scale function down to 0 | `15m` |
 | `faasIdler.reconcileInterval` | The time between each of reconciliation | `1m` |

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -98,11 +98,20 @@ spec:
           value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: function_namespace
           value: {{ $functionNs | quote }}
+        {{- if .Values.nats.external.enabled }}
+        - name: faas_nats_address
+          value: "{{ .Values.nats.external.host }}"
+        - name: faas_nats_port
+          value: "{{ .Values.nats.external.port }}"
+        - name: faas_nats_cluster_name
+          value: "{{ .Values.nats.external.clusterName }}"
+        {{- else }}
         {{- if .Values.async }}
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: faas_nats_port
           value: "4222"
+        {{- end }}
         {{- end }}
         {{- if .Values.basic_auth }}
         - name: basic_auth

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.async }}
+{{- if and .Values.async (not .Values.nats.external.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/openfaas/templates/nats-svc.yaml
+++ b/chart/openfaas/templates/nats-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.async }}
+{{- if and .Values.async (not .Values.nats.external.enabled) }}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -35,8 +35,17 @@ spec:
         image: {{ .Values.queueWorker.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         env:
+        {{- if .Values.nats.external.enabled }}
+        - name: faas_nats_address
+          value: "{{ .Values.nats.external.host }}"
+        - name: faas_nats_port
+          value: "{{ .Values.nats.external.port }}"
+        - name: faas_nats_cluster_name
+          value: "{{ .Values.nats.external.clusterName }}"
+        {{- else }}
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        {{- end}}
         - name: faas_gateway_address
           value: "gateway.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: "gateway_invoke"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -99,6 +99,11 @@ alertmanager:
 
 # async provider
 nats:
+  external:
+    clusterName: ""
+    enabled: false
+    host: ""
+    port: ""
   image: nats-streaming:0.11.2
   enableMonitoring: false
   resources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR makes it possible to use an externally-managed NATS Streaming server when OpenFaaS is deployed using the Helm chart, and it does so in a backwards-compatible way.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This comes in the same context as #547—the need/desire to use an externally-managed, pre-existing NATS Streaming cluster with OpenFaaS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
