### PR TITLE
[WIP] Allow user to specify tail param without restricting on time when those lines were logged

### DIFF
--- a/handlers/log.go
+++ b/handlers/log.go
@@ -30,7 +30,7 @@ func NewLogRequestor(client kubernetes.Interface, functionNamespace string) *Log
 // This implementation ignores the r.Limit value because the OF-Provider already handles server side
 // line limits.
 func (l LogRequestor) Query(ctx context.Context, r logs.Request) (<-chan logs.Message, error) {
-	logStream, err := k8s.GetLogs(ctx, l.client, r.Name, l.functionNamespace, int64(r.Tail), r.Since, r.Follow)
+	logStream, err := k8s.GetLogs(ctx, l.client, r.Name, l.functionNamespace, int64(r.Tail), r.Since, r.SinceDuration, r.Follow)
 	if err != nil {
 		log.Printf("LogRequestor: get logs failed: %s\n", err)
 		return nil, err

--- a/k8s/logs.go
+++ b/k8s/logs.go
@@ -94,14 +94,17 @@ func podLogs(ctx context.Context, i v1.PodInterface, pod, container, namespace s
 	defer log.Printf("Logger: stopping log stream for %s\n", pod)
 
 	opts := &corev1.PodLogOptions{
-		Follow:       follow,
-		Timestamps:   true,
-		Container:    container,
-		SinceSeconds: parseSince(since, sinceDuration),
+		Follow:     follow,
+		Timestamps: true,
+		Container:  container,
 	}
 
 	if tail > 0 {
 		opts.TailLines = &tail
+	}
+
+	if opts.TailLines == nil || (since != nil || sinceDuration != nil) {
+		opts.SinceSeconds = parseSince(since, sinceDuration)
 	}
 
 	stream, err := i.GetLogs(pod, opts).Stream()

--- a/vendor/github.com/openfaas/faas-provider/logs/handler.go
+++ b/vendor/github.com/openfaas/faas-provider/logs/handler.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -126,6 +127,19 @@ func parseRequest(r *http.Request) (logRequest Request, err error) {
 		if err != nil {
 			return logRequest, err
 		}
+	}
+
+	sinceDuration := getValue(query, "since-duration")
+	if sinceDuration != "" {
+		sinceDuration, err := time.ParseDuration(sinceDuration)
+		logRequest.SinceDuration = &sinceDuration
+		if err != nil {
+			return logRequest, err
+		}
+	}
+
+	if logRequest.Since != nil && logRequest.SinceDuration != nil {
+		return logRequest, fmt.Errorf("since and sinceDuration are to be used exclusively")
 	}
 
 	return logRequest, nil

--- a/vendor/github.com/openfaas/faas-provider/logs/logs.go
+++ b/vendor/github.com/openfaas/faas-provider/logs/logs.go
@@ -20,6 +20,8 @@ type Request struct {
 	Instance string `json:"instance"`
 	// Since is the optional datetime value to start the logs from
 	Since *time.Time `json:"since"`
+	// Since duration is the optional duration for which logs are requested
+	SinceDuration *time.Duration `json:"since-duration"`
 	// Tail sets the maximum number of log messages to return, <=0 means unlimited
 	Tail int `json:"tail"`
 	// Follow is allows the user to request a stream of logs until the timeout


### PR DESCRIPTION


## Description
These changes allow user to request last N lines of log irrespective when they were logged.

## Motivation and Context
Currently when we query logs function for last N lines of logs, it also restricts the request to last 5 minutes of logs

With this change, we can query for last N lines of logs irrespective when they were logged. It helps in scenarios such as 'show me last 100 lines of logs as I see there were some errors this morning in my function, but i am not exactly sure of when this happened'

<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I deployed faas-netes using kind cluster on my laptop and tested the logs function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
