### PR TITLE
Allow param tail to be used without param since

### DIFF
--- a/k8s/logs.go
+++ b/k8s/logs.go
@@ -94,14 +94,17 @@ func podLogs(ctx context.Context, i v1.PodInterface, pod, container, namespace s
 	defer log.Printf("Logger: stopping log stream for %s\n", pod)
 
 	opts := &corev1.PodLogOptions{
-		Follow:       follow,
-		Timestamps:   true,
-		Container:    container,
-		SinceSeconds: parseSince(since),
+		Follow:     follow,
+		Timestamps: true,
+		Container:  container,
 	}
 
 	if tail > 0 {
 		opts.TailLines = &tail
+	}
+
+	if opts.TailLines == nil || since != nil {
+		opts.SinceSeconds = parseSince(since)
 	}
 
 	stream, err := i.GetLogs(pod, opts).Stream()


### PR DESCRIPTION

## Description
These changes allow user to request last N lines of log irrespective when they were logged.

## Motivation and Context
Currently when we query logs function for last N lines of logs, it also restricts the request to last 5 minutes of logs

With this change, we can query for last N lines of logs irrespective when they were logged. It helps in scenarios such as 'show me last 100 lines of logs as I see there were some errors this morning in my function, but i am not exactly sure of when this happened'

<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I deployed faas-netes using kind cluster on my laptop and tested the logs function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
