### PR TITLE
Update cron-connector chart to apps/v1

### DIFF
--- a/chart/cron-connector/templates/deployment.yaml
+++ b/chart/cron-connector/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -16,11 +16,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: {{ template "connector.name" . }}
       name: {{ template "connector.name" . }}
       component: cron-connector
   template:
     metadata:
       labels:
+        app: {{ template "connector.name" . }}
         name: {{ template "connector.name" . }}
         component: cron-connector
     spec:


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update cron-connector chart to use apps/v1 api rather than the 1.16 deprecated extensions/v1beta1
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas-incubator/cron-connector/issues/1

## How Has This Been Tested?
Chart has been tested locally by creating static yaml ~(helm template) then applying to a 1.16 k8s cluster on DO

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
