### PR TITLE
Move Ingress to the new Kubernetes apiVersion

### DIFF
--- a/chart/openfaas/templates/ingress.yaml
+++ b/chart/openfaas/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "openfaas.name" . }}-ingress


### PR DESCRIPTION
apiVersion "extensions/v1beta1" was removed in Kubernetes 1.16.
See https://git.k8s.io/kubernetes/CHANGELOG-1.16.md#deprecations-and-removals

## Description
Changed one line.

## Motivation and Context
apiVersion "extensions/v1beta1" was removed in Kubernetes 1.16.
See https://git.k8s.io/kubernetes/CHANGELOG-1.16.md#deprecations-and-removals


## How Has This Been Tested?
helm install

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
 