### PR TITLE
Change namespaces handler status code

### DIFF
--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -26,7 +26,7 @@ func MakeNamespacesLister(defaultNamespace string, clientset kubernetes.Interfac
 		out, _ := json.Marshal(res)
 		w.Header().Set("Content-Type", "application/json")
 
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusOK)
 		w.Write(out)
 	}
 }


### PR DESCRIPTION
Changing namespaces handler status code to return
200 when requested instead of 202

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Change status code of namsepaces handler to `200
`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #567 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As per:
![image](https://user-images.githubusercontent.com/34942004/70862287-0f688780-1f43-11ea-82f6-05f298986213.png)

```
$ ./faas-cli namespaces --gateway=http://192.168.99.103:31112
Namespaces:
openfaas-fn
```
No error ^ for 202

Image with the change: `martindekov/faas-netes:0.9.14-rc1`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Semantic fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
