### PR TITLE
Add helm chart for vcenter-connector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install-armhf: namespaces
 	kubectl apply -f yaml_armhf/
 
 charts:
-	cd chart && helm package openfaas/ && helm package kafka-connector/ && helm package cron-connector/
+	cd chart && helm package openfaas/ && helm package kafka-connector/ && helm package cron-connector/ && helm package vcenter-connector/
 	mv chart/*.tgz docs/
 	helm repo index docs --url https://openfaas.github.io/faas-netes/ --merge ./docs/index.yaml
 	./contrib/create-static-manifest.sh

--- a/chart/vcenter-connector/.helmignore
+++ b/chart/vcenter-connector/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/vcenter-connector/Chart.yaml
+++ b/chart/vcenter-connector/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+description: Connect OpenFaaS functions to vCenter events
+name: vcenter-connector
+version: 0.4.0
+sources:
+- https://github.com/openfaas-incubator/openfaas-vcenter-connector
+home: https://www.openfaas.com
+icon: https://raw.githubusercontent.com/openfaas/media/master/OpenFaaS_logo_stacked_opaque.png
+keywords:
+- functions
+- service
+- vCenter
+- vmware
+maintainers:
+- name: alexellis
+  email: alex@openfaas.com
+- name: embano1
+  email: mgasch@vmware.com

--- a/chart/vcenter-connector/README.md
+++ b/chart/vcenter-connector/README.md
@@ -1,0 +1,74 @@
+# OpenFaaS vCenter Connector
+
+The [OpenFaaS vCenter connector](https://github.com/openfaas-incubator/openfaas-vcenter-connector) brings vCenter events to OpenFaaS by invoking functions based on vCenter event(s) topic annotations.
+
+## Prerequisites
+
+- Install OpenFaaS
+
+  You must have a working OpenFaaS installation. You can find [instructions in the docs](https://docs.openfaas.com/deployment/kubernetes/#pick-helm-or-yaml-files-for-deployment-a-or-b), including instructions to also install OpenFaaS via Helm.
+
+- Have a working VMware vCenter environment (dev/testing) that you can connect to
+
+## Install the Chart
+
+- Create a Kubernetes secret holding the vCenter credentials to be used by the vcenter-connector
+
+```
+kubectl create secret generic vcenter-secrets \
+  -n openfaas \
+  --from-literal vcenter-username=user \
+  --from-literal vcenter-password=pass
+```
+
+> **Note:** Replace "user" and "pass" with the actual values. It is a good practice to use a dedicated vCenter service account instead of an administrator role for the vcenter-connector.
+
+- Add the OpenFaaS chart repo and deploy the `vcenter-connector` chart. We recommend installing it in the same namespace as the rest of OpenFaaS
+
+```sh
+$ helm repo add openfaas https://openfaas.github.io/faas-netes/
+$ helm upgrade vcenter-connector openfaas/vcenter-connector \
+    --install \
+    --namespace openfaas
+```
+
+> **Note:** The above command will also update your helm repo to pull in any new releases.
+
+After you have [verified](#verify-the-installationtroubleshooting) that the installation succeeded you might want to run through an actual [function example](https://github.com/openfaas-incubator/openfaas-vcenter-connector#examples--community).
+
+### Verify the installation/Troubleshooting
+
+1) Check that the `vcenter-connector` deployment in the given Kubernetes namespace (default: "openfaas") is ready, i.e. shows `1/1` pods in running state
+2) If you see error messages or `0/1` (note: it might take some time to pull the container image) verify that  
+   1) you have followed the [installation](#install-the-chart) steps as outlined above (vCenter secret deployed?)
+   2) the status of the corresponding `ReplicaSet` with `kubectl -n openfaas get rs`
+   3) the logs of the container don't show any errors with `kubectl -n openfaas logs deploy/vcenter-connector`
+
+## Customizing the Helm Chart
+
+Additional vcenter-connector options in `values.yaml`:
+
+| Parameter            | Description                                                                       | Default                        |
+|----------------------|-----------------------------------------------------------------------------------|--------------------------------|
+| `resources.requests` | Compute resources Kubernetes will guarantee to this pod                           | `100m (CPU), 120Mi (Memory)`   |
+| `vc_k8s_secret`      | vCenter secrets name as stored in Kubernetes                                      | `vcenter-secrets`              |
+| `basic_auth`         | Use basic authentication against OpenFaaS gateway                                 | `true`                         |
+| `extraArgs.gateway`  | The URL of the OpenFaaS API gateway                                               | `http://gateway.openfaas:8080` |
+| `extraArgs.vcenter`  | The URL of the vCenter server                                                     | `http://vcsim.openfaas:8989`   |
+| `extraArgs.insecure` | Don't verify vCenter server certificate (remove this parameter to force checking) | `insecure`                     |
+
+Specify each parameter you want to change using the `--set key=value[,key=value]` argument to `helm install`, e.g.:
+
+```
+helm install vcenter-connector ./vcenter-connector --namespace openfaas --set extraArgs.vcenter=https://10.160.94.63/sdk
+```
+
+See `values.yaml` for detailed configuration.
+
+## Removing the vCenter Connector
+
+The vCenter connector can be cleaned up with the following helm command:
+
+```sh
+helm uninstall vcenter-connector --namespace openfaas
+```

--- a/chart/vcenter-connector/templates/NOTES.txt
+++ b/chart/vcenter-connector/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Thank you for installing vcenter-connector. Please follow the instructions below to retrieve the status of the connector. 
+If you experience problems please also refer to the troubleshooting instructions in the README provided with this chart.
+
+You can watch the Connector logs to see incoming vCenter events and invoked functions based on topic annotations (if any):
+
+$ kubectl logs -n {{ .Release.Namespace }} deploy/{{ template "connector.fullname" . }} -f
+

--- a/chart/vcenter-connector/templates/_helpers.tpl
+++ b/chart/vcenter-connector/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "connector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "connector.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "connector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+

--- a/chart/vcenter-connector/templates/deployment.yml
+++ b/chart/vcenter-connector/templates/deployment.yml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    # Original Helm labels v
+    app: {{ template "connector.name" . }}
+    component: vcenter-connector
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    # Helm/k8s recommended label names v
+    app.kubernetes.io/name: {{ template "connector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/component: vcenter-connector
+    app.kubernetes.io/part-of: openfaas
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "connector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "connector.name" . }}
+      component: vcenter-connector
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: {{ template "connector.name" . }}
+        component: vcenter-connector
+    spec:
+      volumes:
+        - name: auth-secrets-projected
+          projected:
+            defaultMode: 420
+            sources:
+            {{- if .Values.basic_auth }}
+            - secret:
+                items:
+                  - key: basic-auth-user
+                    path: basic-auth-user
+                  - key: basic-auth-password
+                    path: basic-auth-password
+                name: basic-auth
+            {{- end }}
+            - secret:
+                items:
+                  - key: vcenter-username
+                    path: vcenter-username
+                  - key: vcenter-password
+                    path: vcenter-password
+                name: {{ .Values.vc_k8s_secret | quote }}
+      containers:
+        - name: vcenter
+          image: {{ .Values.image }}
+          resources:
+            {{- .Values.resources | toYaml | nindent 12 }}
+          command: ["./connector"]
+          args:
+          {{- range $key, $value := .Values.extraArgs }}
+              {{- if $value }}
+              - --{{ $key }}={{ $value }}
+              {{- else }}
+              - --{{ $key }}
+              {{- end }}
+          {{- end }}
+          env:
+            - name: gateway_url
+              value: {{ .Values.extraArgs.gateway | quote }}
+            - name: print_response
+              value: {{ .Values.print_response | quote }}
+            - name: print_response_body
+              value: {{ .Values.print_response_body | quote }}
+            - name: secret_mount_path
+              value: {{ .Values.secret_mount | quote }}
+            {{- if .Values.basic_auth }}
+            - name: basic_auth
+              value: "true"
+            {{- end }}
+            {{- if .Values.upstream_timeout }}
+            - name: upstream_timeout
+              value: {{ .Values.upstream_timeout | quote }}
+            {{- end }}
+            {{- if .Values.rebuild_interval }}
+            - name: rebuild_interval
+              value: {{ .Values.rebuild_interval | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: auth-secrets-projected
+              readOnly: true
+              mountPath: "/var/openfaas/secrets/"
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/chart/vcenter-connector/values.yaml
+++ b/chart/vcenter-connector/values.yaml
@@ -1,0 +1,21 @@
+image: openfaas/vcenter-connector:0.4.0
+replicas: 1
+resources:
+  requests:
+    memory: "120Mi"
+    cpu: "100m"
+vc_k8s_secret: vcenter-secrets
+secret_mount: /var/openfaas/secrets/
+basic_auth: true
+extraArgs:
+  gateway: http://gateway.openfaas:8080
+  vcenter: http://vcsim.openfaas:8989
+  vc-user-secret-name: vcenter-username
+  vc-pass-secret-name: vcenter-password
+  insecure:
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit adds a helm chart for the OpenFaaS [vcenter-connector](https://github.com/openfaas-incubator/vcenter-connector).

The chart is a modified version of the `kafka-connector` helm chart provided in this repo.
This commit includes:

- [x] A README how to use the chart
- [x] A chart following the ones provided in the OpenFaaS `faas-netes` repository
- [x] vcenter-connector uses flags so `values.yaml` was modified to
support flags (`extraArgs`)
- [x] Resource requests to guarantee compute resources for the connector
- [x] Updates to the Makefile to include this chart in the Helm chart
index

Fixes: https://github.com/openfaas-incubator/openfaas-vcenter-connector/issues/32

Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Versions used:

```
kubectl version                                                                                                                                                                                                                           
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.3", GitCommit:"b3cbbae08ec52a7fc73d334838e18d17e8512749", GitTreeState:"clean", BuildDate:"2019-11-14T04:24:34Z", GoVersion:"go1.12.13", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-20T18:57:36Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
```

```
helm version
version.BuildInfo{Version:"v3.0.1", GitCommit:"7c22ef9ce89e0ebeb7125ba2ebf7d421f3e82ffa", GitTreeState:"clean", GoVersion:"go1.13.4"}
```

```
openfaas/gateway:0.18.3
```

Deploy the chart (from local dev folder used in this commit) against a vCenter:

```
helm install vcenter-connector ./vcenter-connector --namespace openfaas --set extraArgs.vcenter=https://vcenter.ip/sdk
```

Verify the connector starts successfully:

```
kubectl logs -n openfaas deploy/vcenter-connector -f
2019/12/18 10:58:10 Object Folder:group-d1
2019/12/18 10:58:10 Event [0] &{{{{} 16307 16307 2019-12-18 10:58:08.769208 +0000 UTC VSPHERE.LOCAL\Administrator <nil> <nil> <nil> <nil> <nil> <nil> <nil> User VSPHERE.LOCAL\Administrator@10.30.3.204 logged in as Go-http-client/1.1 }} 10.30.3.204 Go-http-client/1.1 en_US 52557e10-f3c0-0534-10d1-b3198513d564}
2019/12/18 10:58:12 message: {"topic":"user.login.session","category":"info","source":"10.160.94.63","userName":"VSPHERE.LOCAL\\Administrator","createdTime":"2019-12-18T10:58:08.769208Z"}
2019/12/18 10:58:12 Message on topic: user.login.session
2019/12/18 10:58:19 Syncing topic map
```

Verify uninstallation:

```
helm uninstall vcenter-connector --namespace openfaas
release "vcenter-connector" uninstalled
```

The resulting deployment YAML created by helm using the defaults in `values.yaml`:

```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
  creationTimestamp: "2019-12-18T10:58:07Z"
  generation: 1
  labels:
    app: vcenter-connector
    app.kubernetes.io/component: vcenter-connector
    app.kubernetes.io/instance: vcenter-connector
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: vcenter-connector
    app.kubernetes.io/part-of: openfaas
    app.kubernetes.io/version: 0.4.0
    chart: vcenter-connector-0.4.0
    component: vcenter-connector
    helm.sh/chart: vcenter-connector-0.4.0
    heritage: Helm
    release: vcenter-connector
  name: vcenter-connector
  namespace: openfaas
  resourceVersion: "17004"
  selfLink: /apis/extensions/v1beta1/namespaces/openfaas/deployments/vcenter-connector
  uid: 73ce06a8-7ecd-4979-9ead-780f5e470c14
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: vcenter-connector
      component: vcenter-connector
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        prometheus.io.scrape: "false"
      creationTimestamp: null
      labels:
        app: vcenter-connector
        component: vcenter-connector
    spec:
      containers:
      - args:
        - --gateway=http://gateway.openfaas:8080
        - --insecure
        - --vc-pass-secret-name=vcenter-password
        - --vc-user-secret-name=vcenter-username
        - --vcenter=https://10.160.94.63/sdk
        command:
        - ./connector
        env:
        - name: gateway_url
          value: http://gateway.openfaas:8080
        - name: print_response
        - name: print_response_body
        - name: secret_mount_path
          value: /var/openfaas/secrets/
        - name: basic_auth
          value: "true"
        image: openfaas/vcenter-connector:0.4.0
        imagePullPolicy: IfNotPresent
        name: vcenter
        resources:
          requests:
            cpu: 100m
            memory: 120Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /var/openfaas/secrets/
          name: auth-secrets-projected
          readOnly: true
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - name: auth-secrets-projected
        projected:
          defaultMode: 420
          sources:
          - secret:
              items:
              - key: basic-auth-user
                path: basic-auth-user
              - key: basic-auth-password
                path: basic-auth-password
              name: basic-auth
          - secret:
              items:
              - key: vcenter-username
                path: vcenter-username
              - key: vcenter-password
                path: vcenter-password
              name: vcenter-secrets
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2019-12-18T10:58:08Z"
    lastUpdateTime: "2019-12-18T10:58:08Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2019-12-18T10:58:07Z"
    lastUpdateTime: "2019-12-18T10:58:08Z"
    message: ReplicaSet "vcenter-connector-99688cd46" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 1
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
