### PR TITLE
Generate basic auth credentials on Helm install

### DIFF
--- a/chart/openfaas/templates/NOTES.txt
+++ b/chart/openfaas/templates/NOTES.txt
@@ -1,3 +1,9 @@
 To verify that openfaas has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get deployments -l "release={{ .Release.Name }}, app={{ template "openfaas.name" . }}"
+  kubectl -n {{ .Release.Namespace }} get deployments -l "release={{ .Release.Name }}, app={{ template "openfaas.name" . }}"
+
+{{- if .Values.generateBasicAuth }}
+To retrieve the admin password, run:
+
+  echo $(kubectl -n {{ .Release.Namespace }} get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode)
+{{- end }}

--- a/chart/openfaas/templates/secret.yaml
+++ b/chart/openfaas/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.generateBasicAuth }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: gateway
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+data:
+  basic-auth-user: {{ "admin" | b64enc | quote }}
+  # kubectl -n openfaas get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode
+  basic-auth-password: {{ randAlphaNum 12 | b64enc | quote }}
+{{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -13,6 +13,7 @@ clusterRole: false            # Set to true to have OpenFaaS administrate multip
 psp: false
 securityContext: true
 basic_auth: true
+generateBasicAuth: false
 
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
 openfaasImagePullPolicy: "Always"


### PR DESCRIPTION
## Description

This PR allows OpenFaaS to be managed by Flux Helm Operator without manual altering the cluster state to create the basic auth secret.

- add `generateBasicAuth` boolean to chart options
- generate admin password and basic auth secret with a pre-install Helm hook
- add credentials retrieval commands to chart readme

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested on EKS 1.14 with:

```sh
helmv3 upgrade -i openfaas ./chart/openfaas --wait \
--namespace openfaas \
--set functionNamespace=openfaas-fn \
--set generateBasicAuth=true \
--set operator.create=true
```

Get admin password:

```sh
echo $(kubectl -n openfaas get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode)
```

Login:

```sh
echo -n $PASSWORD | faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
