### PR TITLE
FIXED wrong async-path: it's "async-functions", not "async/functions"

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -89,7 +89,7 @@ The concept of a cold-start in OpenFaaS only applies if you A) use faas-idler an
 There are two ways to reduce the Kubernetes cold-start for a pre-pulled image, which is 1-2 seconds.
 
 1) Don't set the function to scale down to zero, just set it a minimum availability i.e. 1/1 replicas
-2) Use async invocations via the `/async/function/<name>` route
+2) Use async invocations via the `/async-function/<name>` route
 3) Tune the readinessProbes to be aggressively low values. This will reduce the cold-start at the cost of more `kubelet` CPU usage
 
 To achieve around 1s coldstart, set `values.yaml`:


### PR DESCRIPTION
Signed-off-by: Oliver Lippert <oliver@lipperts-web.de>

Found wrong path in the docs, fixed it.

## Description
"async/functions" should really be "async-functions"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

I'am new to OpenFaas and found this reallly irritating. Discussed it with @LucasRoesler on Slack.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I run async OpenFaas functions, no test required. Also discussed with @LucasRoesler, which confirmed the outdated / wrong doc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
