### PR TITLE
[WIP] Cold-start tuning experiment with endpoints

### DIFF
--- a/handlers/replicas.go
+++ b/handlers/replicas.go
@@ -127,6 +127,8 @@ func MakeReplicaReader(defaultNamespace string, clientset *kubernetes.Clientset)
 					len(endpoints.Subsets[0].Addresses) > 0 {
 					function.AvailableReplicas = 1
 				}
+			} else {
+				log.Printf("Endpoints for %s, subnets %d notready %d ready %d\n", function.Name, 0, 0, 0)
 			}
 		}
 


### PR DESCRIPTION
This patch makes the gateway think that an endpoint is ready when
Kubernetes says that it is not. It is an experimental patch and
not to be merged.

This is an experiment to tune cold-starts for Pods.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
