### PR TITLE
Add oauth2Plugin configuration

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -122,10 +122,17 @@ spec:
           value: "true"
         - name: secret_mount_path
           value: "/var/secrets"
+        {{- if .Values.oauth2Plugin.enabled }}
+        - name: auth_proxy_url
+          value: "http://oauth2-plugin.{{ .Release.Namespace }}:8080/validate"
+        - name: auth_pass_body
+          value: "false"
+        {{- else }}
         - name: auth_proxy_url
           value: "http://basic-auth-plugin.{{ .Release.Namespace }}:8080/validate"
         - name: auth_pass_body
           value: "false"
+        {{- end }}
         {{- end }}
         - name: scale_from_zero
           value: "{{ .Values.gateway.scaleFromZero }}"

--- a/chart/openfaas/templates/oauth2-plugin-dep.yaml
+++ b/chart/openfaas/templates/oauth2-plugin-dep.yaml
@@ -1,41 +1,38 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if .Values.basic_auth }}
-{{- if not .Values.oauth2Plugin.enabled }}
+{{- if .Values.oauth2Plugin.enabled }}
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: basic-auth-plugin
+    component: oauth2-plugin
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: basic-auth-plugin
+  name: oauth2-plugin
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.basicAuthPlugin.replicas }}
+  replicas: {{ .Values.oauth2Plugin.replicas }}
   selector:
     matchLabels:
-      app: basic-auth-plugin
+      app: oauth2-plugin
   template:
     metadata:
       annotations:
         prometheus.io.scrape: "false"
       labels:
-        app: basic-auth-plugin
+        app: oauth2-plugin
     spec:
-      {{- if .Values.basic_auth }}
       volumes:
-      - name: auth
-        secret:
-          secretName: basic-auth
-      {{- end }}
+      - name: oauth2-plugin-temp-volume
+        emptyDir: {}
       containers:
-      - name:  basic-auth-plugin
+      - name:  oauth2-plugin
         resources:
-          {{- .Values.basicAuthPlugin.resources | toYaml | nindent 12 }}
-        image: {{ .Values.basicAuthPlugin.image }}
+          {{- .Values.oauth2Plugin.resources | toYaml | nindent 12 }}
+        image: {{ .Values.oauth2Plugin.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.securityContext }}
         securityContext:
@@ -74,21 +71,43 @@ spec:
             - http://localhost:8080/health
           {{- end }}
           timeoutSeconds: 5
+        args:
+        - "-license={{- .Values.oauth2Plugin.license}}"
         env:
-        {{- if .Values.basic_auth }}
-        - name: secret_mount_path
-          value: "/var/secrets"
-        - name: basic_auth
-          value: "{{ .Values.basic_auth }}"
+        - name: client_id
+          value: "{{- .Values.oauth2Plugin.clientID}}"
+        - name: client_secret
+          value: "{{- .Values.oauth2Plugin.clientSecret}}"
+        - name: cookie_domain
+          value: "{{- .Values.oauth2Plugin.cookieDomain}}"
+        - name: base_host
+          value: "{{- .Values.oauth2Plugin.baseHost}}"
+        - name: port
+          value: "8080"
+        - name: authorize_url
+          value: "{{- .Values.oauth2Plugin.authorizeURL}}"
+        - name: welcome_page_url
+          value: "{{- .Values.oauth2Plugin.welcomePageURL}}"
+        - name: public_key_path
+          value: ""  # leave blank if using jwks
+        - name: audience
+          value: "{{- .Values.oauth2Plugin.audience}}"
+        - name: token_url
+          value: "{{- .Values.oauth2Plugin.tokenURL}}"
+        - name: scopes
+          value: "{{- .Values.oauth2Plugin.scopes}}"
+        - name: jwks_url
+          value: "{{- .Values.oauth2Plugin.jwksURL}}"
+        - name: insecure_tls
+          value: "{{- .Values.oauth2Plugin.insecureTLS}}"
         volumeMounts:
-        - name: auth
-          readOnly: true
-          mountPath: "/var/secrets"
+        - mountPath: /tmp
+          name: oauth2-plugin-temp-volume
         ports:
         - name: http
           containerPort: 8080
           protocol: TCP
-        {{- end }}
+
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -102,5 +121,4 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
 
-{{- end }}
 {{- end }}

--- a/chart/openfaas/templates/oauth2-plugin-svc.yaml
+++ b/chart/openfaas/templates/oauth2-plugin-svc.yaml
@@ -1,0 +1,26 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.oauth2Plugin.enabled }}
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: oauth2-plugin
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: oauth2-plugin
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: oauth2-plugin
+
+{{- end }}

--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -4,6 +4,9 @@ gateway:
   image: openfaas/gateway:0.18.2-arm64
   directFunctions: true
 
+oauth2Plugin:
+  enabled: false
+
 faasnetes:
   image: openfaas/faas-netes:0.9.7-arm64
 

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -4,6 +4,9 @@ gateway:
   image: openfaas/gateway:0.18.2-armhf
   directFunctions: true
 
+oauth2Plugin:
+  enabled: false
+
 faasnetes:
   image: openfaas/faas-netes:0.9.7-armhf
 

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -38,6 +38,37 @@ gateway:
       memory: "120Mi"
       cpu: "50m"
 
+basicAuthPlugin:
+  image: openfaas/basic-auth-plugin:0.17.0
+  replicas: 1
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "20m"
+
+oauth2Plugin:
+  enabled: false
+  license: "example"
+  insecureTLS: false
+  scopes: "openid profile email"
+  jwksURL: https://example.eu.auth0.com/.well-known/jwks.json
+  tokenURL: https://example.eu.auth0.com/oauth/token
+  audience: https://example.eu.auth0.com/api/v2/
+  authorizeURL: https://example.eu.auth0.com/authorize
+  welcomePageURL: https://gw.oauth.example.com
+  cookieDomain: ".oauth.example.com"
+  baseHost: "http://auth.oauth.example.com"
+  clientSecret: SECRET
+  clientID: ID
+
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+  replicas: 1
+  image: alexellis2/openfaas-oidc-plugin:0.2.5-arm64
+  securityContext: true
+
 faasnetes:
   image: openfaas/faas-netes:0.9.15
   readTimeout : "60s"
@@ -149,14 +180,6 @@ faasIdler:
   resources:
     requests:
       memory: "64Mi"
-
-basicAuthPlugin:
-  image: openfaas/basic-auth-plugin:0.17.0
-  replicas: 1
-  resources:
-    requests:
-      memory: "50Mi"
-      cpu: "20m"
 
 nodeSelector:
   beta.kubernetes.io/arch: amd64


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Add oauth2Plugin configuration to helm chart

After merge, the instructions in the docs can be simplified.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Adds a service and deployment for the oauth2Plugin, but doesn't
configure the gateway to use it. This is the initial patch
towards making it easier to adopt the OAuth2/oidc plugin.

## Testing

Setup a Kubernetes cluster on a public cloud, or with inlets-pro such that you have:

* Kubernetes 1.13 or higher
* nginx-ingress
* cert-manager
* OpenFaaS installed with this helm chart and the `oauth2Plugin` portion of `values.yaml` populated

Additional information on how to configure Auth0:

https://docs.openfaas.com/reference/authentication/#oauth2-support-in-the-api-gateway-commercial-add-on

Plugin repo:

https://github.com/alexellis/openfaas-oidc-plugin-pkg

To obtain a license - contact me on Slack.

Workflow for testing:

* Install various apps with k3sup including OpenFaaS 
* Clone this repo
* Add an ingress for the auth service and the gateway, with TLS and DNS
* Configure Auth0
* Edit values.yaml according to the docs and output on Auth0 website
* `make charts`
* Apply the chart again `kubectl apply -f ./yaml`

```sh
k3sup app install nginx-ingress
# Get your public IP, create two domains

# gw.oauth.example.com
# auth.oauth.example.com

export DOMAIN="example.com"
export EMAIL="webmaster@$DOMAIN"

k3sup app install cert-manager
k3sup app install openfaas
k3sup app install openfaas-ingress --email $EMAIL --domain gw.$DOMAIN
```

Now apply an ingress for the auth service, in this example for `oauth.auth.myfaas.club`:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: openfaas-auth
  namespace: openfaas
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
spec:
  rules:
  - host: auth.oauth.myfaas.club
    http:
      paths:
      - backend:
          serviceName: oauth2-plugin
          servicePort: 8080
        path: /
  tls:
  - hosts:
    - auth.oauth.myfaas.club
    secretName: openfaas-auth
```

Now populate values.yaml as per the docs link above.

Now run:

```sh
make charts

kubectl apply -f ./yaml/
```

Once merged, the docs can be updates as per: https://github.com/openfaas/docs/pull/201