### PR TITLE
Add helm3 usage to chart README

### DIFF
--- a/HELM.md
+++ b/HELM.md
@@ -13,9 +13,7 @@ curl -sSLf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 
 That's it, no tiller is required for using helm3.
 
-Now deploy OpenFaaS via Helm:
-
-How to install chart please follow install instructions in chart's [readme](chart/openfaas/README.md).
+Now deploy OpenFaaS via Helm: using the [Chart's readme](chart/openfaas/README.md).
 
 ## Helm 2 (legacy)
 
@@ -61,6 +59,4 @@ helm init --skip-refresh --upgrade --service-account tiller
 
 > Note: this step installs a server component in your cluster. It can take anywhere between a few seconds to a few minutes to be installed properly. You should see tiller appear on: `kubectl get pods -n kube-system`.
 
-Now deploy OpenFaaS via Helm:
-
-How to install chart please follow install instructions in chart's [readme](chart/openfaas/README.md).
+Now deploy OpenFaaS via Helm: using the [Chart's readme](chart/openfaas/README.md).

--- a/HELM.md
+++ b/HELM.md
@@ -1,7 +1,25 @@
 # Helm
 
 [Helm](https://github.com/kubernetes/helm) is a client CLI used to deploy Kubernetes
-applications. It supports templating of configuration files, but also needs a server
+applications.
+
+## Helm 3
+
+Get the binary:
+
+```sh
+curl -sSLf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+```
+
+That's it, no tiller is required for using helm3.
+
+Now deploy OpenFaaS via Helm:
+
+How to install chart please follow install instructions in chart's [readme](chart/openfaas/README.md).
+
+## Helm 2 (legacy)
+
+It supports templating of configuration files, but also needs a server
 component installing called `tiller`.
 
 For more information on using Helm, refer to the Helm's [documentation](https://docs.helm.sh/using_helm/#quickstart-guide).
@@ -43,6 +61,6 @@ helm init --skip-refresh --upgrade --service-account tiller
 
 > Note: this step installs a server component in your cluster. It can take anywhere between a few seconds to a few minutes to be installed properly. You should see tiller appear on: `kubectl get pods -n kube-system`.
 
-## Deploy OpenFaaS via Helm
+Now deploy OpenFaaS via Helm:
 
 How to install chart please follow install instructions in chart's [readme](chart/openfaas/README.md).

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -314,6 +314,34 @@ The faas-idler will only scale down functions which have marked themselves as el
 
 See also: [faas-idler README](https://docs.openfaas.com/architecture/autoscaling/#zero-scale).
 
+## Removing the OpenFaaS
+
+All control plane components can be cleaned up with helm:
+
+Helm 3:
+
+```sh
+helm delete openfaas --namespace openfaas
+```
+
+Helm 2:
+
+```sh
+helm delete --purge openfaas
+```
+
+Follow this by the following to remove all other associated objects:
+
+```sh
+kubectl delete namespace openfaas openfaas-fn
+```
+
+In some cases your additional functions may need to be either deleted before deleting the chart with `faas-cli` or manually deleted using `kubectl delete`.
+
+## Getting help
+
+Feel free to seek out help using the [OpenFaaS Slack workspace](https://slack.openfaas.io/), please do not raise issues for technical support, unless you suspect and can provide instructions for reproducing an error in the chart.
+
 ## Configuration
 
 Additional OpenFaaS options in `values.yaml`.
@@ -374,27 +402,3 @@ Additional OpenFaaS options in `values.yaml`.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 See values.yaml for detailed configuration.
-
-## Removing the OpenFaaS
-
-All control plane components can be cleaned up with helm:
-
-Helm 3:
-
-```sh
-helm delete openfaas --namespace openfaas
-```
-
-Helm 2:
-
-```sh
-helm delete --purge openfaas
-```
-
-Follow this by the following to remove all other associated objects:
-
-```sh
-kubectl delete namespace openfaas openfaas-fn
-```
-
-In some cases your additional functions may need to be either deleted before deleting the chart with `faas-cli` or manually deleted using `kubectl delete`.

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -26,7 +26,9 @@
 ---
 ### Install
 
-See also: [Install Helm](https://github.com/openfaas/faas-netes/blob/master/HELM.md)
+To use the chart, you will need Helm 2 or 3:
+
+* [Install helm](https://github.com/openfaas/faas-netes/blob/master/HELM.md)
 
 We recommend creating two namespaces, one for the OpenFaaS *core services* and one for the *functions*:
 
@@ -49,6 +51,10 @@ Now decide how you want to expose the services and edit the `helm upgrade` comma
 * To use an IngressController add `--set ingress.enabled=true`
 
 > Note: even without a LoadBalancer or IngressController you can access your gateway at any time via `kubectl port-forward`.
+
+### Deploy
+
+Note that the commands will differ slightly between versions, if not specified, the instructions are for helm 2.
 
 Now deploy OpenFaaS from the helm chart repo:
 
@@ -166,25 +172,42 @@ The faas-netes controller is the most tested, stable and supported version of th
 See also: [Introducing the OpenFaaS Operator](https://www.openfaas.com/blog/kubernetes-operator-crd/)
 
 ## Deployment with `helm template`
-This option is good for those that have issues with installing Tiller, the server/cluster component of helm. Using the `helm` CLI, we can pre-render and then apply the templates using `kubectl`.
+
+This option is good for those that have issues with or concerns about installing Tiller, the server/cluster component of helm. Using the `helm` CLI, we can pre-render and then apply the templates using `kubectl`.
 
 1. Clone the faas-netes repository
+    ```sh
     git clone https://github.com/openfaas/faas-netes.git
+    cd faas-netes
+    ```
 
 2. Render the chart to a Kubernetes manifest called `openfaas.yaml`
+
+    Helm 3:
     ```sh
-    helm template faas-netes/chart/openfaas \
+    helm template \
+      openfaas chart/openfaas/ \
+      --namespace openfaas \
+      --set basic_auth=true \
+      --set functionNamespace=openfaas-fn > openfaas.yaml
+    ```
+
+    Helm 2:
+
+    ```sh
+    helm template chart/openfaas \
         --name openfaas \
         --namespace openfaas  \
         --set basic_auth=true \
-        --set functionNamespace=openfaas-fn > $HOME/openfaas.yaml
+        --set functionNamespace=openfaas-fn > openfaas.yaml
     ```
+
     You can set the values and overrides just as you would in the install/upgrade commands above.
 
 3. Install the components using `kubectl`
+
     ```sh
-    kubectl apply -f faas-netes/namespaces.yml
-    kubectl apply -f $HOME/openfaas.yaml
+    kubectl apply -f namespaces.yml,openfaas.yaml
     ```
 
 Now [verify your installation](#verify-the-installation).
@@ -355,6 +378,14 @@ See values.yaml for detailed configuration.
 ## Removing the OpenFaaS
 
 All control plane components can be cleaned up with helm:
+
+Helm 3:
+
+```sh
+helm delete openfaas --namespace openfaas
+```
+
+Helm 2:
 
 ```sh
 helm delete --purge openfaas


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add helm3 usage to chart README

## Motivation and Context

The easiest way to install is via:
"k3sup app install openfaas -helm3", however this brings parity
to the helm README file and HELM.md install instructions with
k3sup.

Tested against a k3d cluster, including the deletion command
which is different. Beware that helm uses namespaces to store
its own configuration.

Closes #577 and ref: #520 