### PR TITLE
Add ability to change logs_provider_url env variable

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 5.4.1
+version: 5.4.2
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -381,6 +381,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `gateway.scaleFromZero` | Enables an intercepting proxy which will scale any function from 0 replicas to the desired amount | `true` |
 | `gateway.maxIdleConns` | Set max idle connections from gateway to functions | `1024` |
 | `gateway.maxIdleConnsPerHost` | Set max idle connections from gateway to functions per host | `1024` |
+| `gateway.logsProviderURL` | Set a custom logs provider url | `""` |
 | `queueWorker.durableQueueSubscriptions` | Whether to use a durable queue subscription | `false` |
 | `queueWorker.queueGroup` | The name of the queue group used to process asynchronous function invocations | `faas` |
 | `queueWorker.replicas` | Replicas of the queue-worker, pick more than `1` for HA | `1` |

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -80,6 +80,10 @@ spec:
           {{- end }}
           timeoutSeconds: 5
         env:
+        {{- if .Values.gateway.logsProviderURL }}
+        - name: logs_provider_url
+          value: "{{ .Values.gateway.logsProviderURL }}"
+        {{- end }}
         - name: read_timeout
           value: "{{ .Values.gateway.readTimeout }}"
         - name: write_timeout

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -33,6 +33,9 @@ gateway:
   maxIdleConns: 1024
   maxIdleConnsPerHost: 1024
   directFunctions: true
+  # Custom logs provider url. For example openfaas-loki would be
+  # "http://ofloki-openfaas-loki.openfaas:9191/"
+  logsProviderURL: ""
   resources:
     requests:
       memory: "120Mi"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Allow setting logs_provider_url env variable
## Description
<!--- Describe your changes in detail -->
Adds the ability to specify logs_provider_url environment variable on the gateway container.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There was no way to set the logs_provider_url environment variable via the helm chart.

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #474 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Deployed the forked chart into our cluster. First with the change (logsProviderUrl left blank), then with logsProviderUrl set to our openfaas-loki deployment.

<!--- Include details of your testing environment, and the tests you ran to -->
We have a dev kubernetes cluster running argocd. We deployed the chart in this PR into that cluster.

Ran `kubectl get deployment gateway -n openfaas -o yaml` after updating the helm chart

<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.