### PR TITLE
Fix overriding of prometheus scrape

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -268,7 +268,9 @@ func buildAnnotations(request types.FunctionDeployment) map[string]string {
 		annotations = map[string]string{}
 	}
 
-	annotations["prometheus.io.scrape"] = "false"
+	if _, ok := annotations["prometheus.io.scrape"]; !ok {
+		annotations["prometheus.io.scrape"] = "false"
+	}
 	return annotations
 }
 

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -32,6 +32,25 @@ func Test_buildAnnotations_Empty_In_CreateRequest(t *testing.T) {
 	}
 }
 
+func Test_buildAnnotations_Premetheus_NotOverridden(t *testing.T) {
+	request := types.FunctionDeployment{Annotations: &map[string]string{"prometheus.io.scrape": "true"}}
+
+	annotations := buildAnnotations(request)
+
+	if len(annotations) != 1 {
+		t.Errorf("want: %d annotations got: %d", 1, len(annotations))
+	}
+
+	v, ok := annotations["prometheus.io.scrape"]
+	if !ok {
+		t.Errorf("missing prometheus.io.scrape key")
+	}
+
+	if v != "true" {
+		t.Errorf("want: %s for annotation prometheus.io.scrape got: %s", "true", v)
+	}
+}
+
 func Test_buildAnnotations_From_CreateRequest(t *testing.T) {
 	request := types.FunctionDeployment{
 		Annotations: &map[string]string{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The prometheus.io.scrape annotation was being overridden in faas-netes
if it was set. This means a user could never set it to true for a
functtion using something like faas-cli store deploy figlet --annotation
prometheus.io.scrape=true



Signed-off-by: Alistair Hey <alistair.hey@form3.tech>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
fixes #621 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested by writing unit tests to validate that the operator did
not do the same thing and writing a new test for faas-netes's deployment
handler to check that if its set, its not overridden.

Then tested on k3d, using:
1) k3d create
2)arkade install openfaas
3) set the faas-netes container to the one created from this commit
4) faas-cli store deploy figlet --annotation prometheus.io.scrape=true
5) validate that the annotation was not overridden (kubectl get deploy
-n openfaas-fn figlet -o yaml)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
