### PR TITLE
Fix IngressOperator install from OpenFaaS Chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -382,7 +382,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `faasnetes.httpProbe` | Use a httpProbe instead of exec | `false` |
 | `ingressOperator.create` | Create the ingress-operator component | `false` |
 | `ingressOperator.replicas` | Replicas of the ingress-operator| `1` |
-| `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.4.0` |
+| `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.6.2` |
 | `ingressOperator.resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi |
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -33,7 +33,6 @@ spec:
         command:
           - ./ingress-operator
           - -logtostderr
-          - -v=2
         env:
         - name: function_namespace
           value: {{ $functionNs | quote }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

There was a rogue `-v=2` in the chart which sopped the ingress-operator
pod starting.

Its been removed and iv tested by:
* Installing using the bundled chart (zip locally)
* Created a FNI using kubectl with TLS
* Verified the cert is created and the DNS all routes correctly

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
(Discussed with Alex on slack)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Installed chart using the bundled chart (zip locally)
* Created a FNI using kubectl with TLS
* Verified the cert is created and the DNS all routes correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
