### PR TITLE
Add cluster role and binding to operator

### DIFF
--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -64,5 +64,57 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-operator
   namespace: {{ .Release.Namespace | quote }}
+{{- if .Values.clusterRole}}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-operator-controller
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Release.Name }}-operator-controller
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+  - apiGroups: ["openfaas.com"]
+    resources: ["functions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "namespaces", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-operator-controller
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-operator-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Adding ClusterRole and ClusterRoleBinding to the
operator-rbac.yaml in order to be able to access
other namespaces and objects in them through the
operator's controller

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Adding cluster role in the operator

## Description
<!--- Describe your changes in detail -->

For multiple namespaces support of the REST controller of the operator cluster role needs to be created in order to list resources from other namespaces across the cluster

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Part of https://github.com/openfaas/faas-netes/issues/616

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested four scenarios:
* operator with cluster role and image which has code which list namespaces in `martindekov/faas-netes:0.15.0-rc2`
* operator without cluster role with default image
* faas-netes with cluster role with default image
* faas-netes without cluster role with default image

Created `staging-ns` with `openfaas: 1` annotation.

Also the testing includes deploying functions depending on the scenario just in case.

operator with cluster role and image which has code which list namespaces in `martindekov/faas-netes:0.15.0-rc2` changed in `values.yaml`:
```
$ helm upgrade --install openfaas ./openfaas --namespace openfaas --set functionNamespace=openfaas-fn --set operator.create=true --set basic_auth=false --set clusterRole=true
$ kubectl port-forward gateway-65d59946fd-jwk6l -n openfaas 8080 &
$ kubectl get sa -n openfaas
NAME                  SECRETS   AGE
default               1         6d13h
openfaas-operator     1         5m4s
openfaas-prometheus   1         5m4s
$ kubectl get clusterrole -n openfaas | grep operator
openfaas-operator-controller                                           11m
$ faas-cli list
Handling connection for 8080
Function                      	Invocations    	Replicas
figlet                        	0              	1    
$ echo "asd" | faas-cli invoke figlet -
Handling connection for 8080
               _ 
  __ _ ___  __| |
 / _` / __|/ _` |
| (_| \__ \ (_| |
 \__,_|___/\__,_|
$ kubectl describe deploy gateway -n openfaas | grep martindekov
    Image:      martindekov/faas-netes:0.15.0-rc2
$ curl -X GET http://localhost:8080/system/namespaces
Handling connection for 8080
["staging-fn","openfaas-fn"]
$ kubectl logs gateway-65d59946fd-jwk6l operator -n openfaas --follow
I0614 09:13:57.971666       1 main.go:153] Starting operator. Version: dev	commit: b14f61f5050d9c6339913588e847945bc4aad49c
W0614 09:13:57.971781       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2020/06/14 09:13:57 Waiting for cache sync in main
2020/06/14 09:13:57 Cache sync done
I0614 09:13:57.972881       1 controller.go:111] Setting up event handlers
I0614 09:13:57.972955       1 server.go:104] Using namespace 'openfaas-fn'
I0614 09:13:57.972977       1 controller.go:154] Waiting for informer caches to sync
I0614 09:13:57.973054       1 server.go:119] Starting HTTP server on port 8081
I0614 09:13:58.073243       1 controller.go:159] Starting workers
I0614 09:13:58.073310       1 controller.go:165] Started workers
I0614 09:16:18.444562       1 apply.go:33] Deployment request for: figlet
I0614 09:16:18.462074       1 controller.go:254] Creating deployment for 'figlet'
I0614 09:16:18.543172       1 controller.go:266] Creating ClusterIP service for 'figlet'
```

operator without cluster role with default image:
```
$ helm upgrade --install openfaas ./openfaas --namespace openfaas --set functionNamespace=openfaas-fn --set operator.create=true --set basic_auth=false --set clusterRole=false
...
$ kubectl port-forward gateway-5d84fcdd9-jfbbn -n openfaas 8080 &
...
$ curl -X GET http://localhost:8080/system/namespaces
Handling connection for 8080
["openfaas-fn"]
$ faas-cli store deploy figlet
...
$ faas-cli list
Handling connection for 8080
Function                      	Invocations    	Replicas
figlet                        	0              	1 
...
$ kubectl logs gateway-5d84fcdd9-jfbbn operator -n openfaas --follow
I0614 08:51:45.994988       1 main.go:153] Starting operator. Version: 0.10.5	commit: 9be50543b372381a505e9e54a1356bb076c8f01f
W0614 08:51:45.995120       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2020/06/14 08:51:45 Waiting for cache sync in main
2020/06/14 08:51:45 Cache sync done
I0614 08:51:45.996421       1 controller.go:111] Setting up event handlers
I0614 08:51:45.996498       1 server.go:104] Using namespace 'openfaas-fn'
I0614 08:51:45.996511       1 controller.go:154] Waiting for informer caches to sync
I0614 08:51:45.996539       1 server.go:119] Starting HTTP server on port 8081
I0614 08:51:46.096637       1 controller.go:159] Starting workers
I0614 08:51:46.096677       1 controller.go:165] Started workers
I0614 08:53:53.803447       1 apply.go:33] Deployment request for: figlet
I0614 08:53:53.825011       1 controller.go:254] Creating deployment for 'figlet'
I0614 08:53:54.830350       1 controller.go:266] Creating ClusterIP service for 'figlet'
$ kubectl get clusterrole -n openfaas  | grep openfaas
openfaas-prometheus                                                    5m53s
$ kubectl get sa -n openfaas
NAME                  SECRETS   AGE
default               1         6d13h
openfaas-operator     1         6m49s
openfaas-prometheus   1         6m49s
```

faas-netes with cluster role with default image

```
$ helm upgrade --install openfaas ./openfaas --namespace openfaas --set functionNamespace=openfaas-fn --set operator.create=false --set basic_auth=false --set clusterRole=true
...
$ kubectl get sa -n openfaas
NAME                  SECRETS   AGE
default               1         6d13h
openfaas-controller   1         9m12s
openfaas-prometheus   1         9m12s
$ kubectl get clusterrole -n openfaas | grep openfaas
openfaas-controller                                                    9m39s
openfaas-prometheus                                                    9m39s
$ curl -X GET http://localhost:8080/system/namespaces
Handling connection for 8080
["staging-fn","openfaas-fn"]
$ faas-cli store deploy figlet -n staging-fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Handling connection for 8080
Handling connection for 8080

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/figlet.staging-fn
$ echo "asdf" | faas-cli invoke figlet -n staging-fn
Handling connection for 8080
               _  __ 
  __ _ ___  __| |/ _|
 / _` / __|/ _` | |_ 
| (_| \__ \ (_| |  _|
 \__,_|___/\__,_|_|  
                     
$ faas-cli list -n staging-fn
Handling connection for 8080
Function                      	Invocations    	Replicas
figlet                        	0              	1    
```
faas-netes without cluster role with default image
```
$ helm upgrade --install openfaas ./openfaas --namespace openfaas --set functionNamespace=openfaas-fn --set operator.create=false --set basic_auth=false --set clusterRole=false
...
$ kubectl get sa -n openfaas
NAME                  SECRETS   AGE
default               1         6d13h
openfaas-controller   1         81s
openfaas-prometheus   1         81s
$ kubectl get clusterrole -n openfaas | grep openfaas
openfaas-prometheus                                                    99s
$ kubectl port-forward gateway-644b56c567-w9wwb 8080 -n openfaas &
$ faas-cli store deploy figlet
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Handling connection for 8080
Handling connection for 8080

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/figlet
$ curl -X GET http://localhost:8080/system/namespaces
Handling connection for 8080
["openfaas-fn"]
$ echo "asdf" | faas-cli invoke figlet -
Handling connection for 8080
               _  __ 
  __ _ ___  __| |/ _|
 / _` / __|/ _` | |_ 
| (_| \__ \ (_| |  _|
 \__,_|___/\__,_|_|  
                     

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
