### PR TITLE
chart: Allow to customize ingress_namespace env var for Ingress Operator

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 5.8.7
+version: 5.8.8
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -37,5 +37,5 @@ spec:
         - name: function_namespace
           value: {{ $functionNs | quote }}
         - name: ingress_namespace
-          value: {{ .Release.Namespace | quote }}
+          value: {{ default .Release.Namespace .Values.ingressOperator.ingressNamespace | quote }}
 {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -173,6 +173,7 @@ ingressOperator:
   image: openfaas/ingress-operator:0.6.2
   replicas: 1
   create: false
+  ingressNamespace: ""
   resources:
     requests:
       memory: "25Mi"


### PR DESCRIPTION
Signed-off-by: Aleksandr Fofanov <avl.fofanov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
The changes in this PR will allow to configure `ingress_namespace` environment variable in Ingress Operator deployment through chart values.

## Description
<!--- Describe your changes in detail -->
`ingress_namespace` in Ingress Operator should be configurable because some users would want to pass traffic from function ingress to the gateway deployed to core services namespace (default behavior) while the others may prefer to pass it directly to the function svc in its namespace (`bypassGateway` option in FunctionIngress object).
Right now the value of this variable is not configurable through chart values. This PR addresses this issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #661
As discussed in #651, this value should be configurable through chart values for different use-cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my local system.
The following verifies that `ingress_namespace` variable is set through chart values and properly passed down to the operator.
```
minikube start
kubectl create ns openfaas
kubectl create ns openfaas-fn
helm upgrade -i openfaas \
--namespace openfaas \
--set basic_auth=false \
--set generateBasicAuth=false \
--set ingressOperator.create=true \
--set ingressOperator.ingressNamespace=openfaas-fn \
./chart/openfaas
kubectl -n openfaas describe pods -l app=ingress-operator | grep -A 2 "Environment"
```
```
    Environment:
      function_namespace:  openfaas-fn
      ingress_namespace:   openfaas-fn
```
By default core services namespace is used as `ingress_namespace`:
```
helm upgrade openfaas \
--namespace openfaas \
--reuse-values \
--set ingressOperator.ingressNamespace="" \
./chart/openfaas
kubectl -n openfaas rollout status deploy/ingress-operator
kubectl -n openfaas describe pods -l app=ingress-operator | grep -A 2 "Environment"
```
```
    Environment:
      function_namespace:  openfaas-fn
      ingress_namespace:   openfaas
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
