### PR TITLE
Add openfaas ingress operator chart

### DIFF
--- a/chart/ingress-operator/.helmignore
+++ b/chart/ingress-operator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/ingress-operator/Chart.yaml
+++ b/chart/ingress-operator/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+description: Get custom domains and TLS for your OpenFaaS Functions through the FunctionIngress CRD
+name: ingress-operator
+version: 0.1.0
+sources:
+  - https://github.com/openfaas-incubator/ingress-operator
+home: https://www.openfaas.com
+icon: https://raw.githubusercontent.com/openfaas/media/master/OpenFaaS_logo_stacked_opaque.png
+keywords:
+  - functions
+  - service
+  - ingress
+  - openfaas
+maintainers:
+  - name: alexellis
+    email: alex@openfaas.com
+  - name: viveksyngh
+    email: vivekkmr45@yahoo.in

--- a/chart/ingress-operator/README.md
+++ b/chart/ingress-operator/README.md
@@ -1,0 +1,54 @@
+# OpenFaaS Ingress Operator
+
+The [Ingress operator](https://github.com/openfaas-incubator/ingress-operator) gets custom domains and TLS for your OpenFaaS Functions through the FunctionIngress CRD
+## Prerequisites
+
+- Install OpenFaaS
+
+  You must have a working OpenFaaS installation. You can find [instructions in the docs](https://docs.openfaas.com/deployment/kubernetes/#pick-helm-or-yaml-files-for-deployment-a-or-b), including instructions to also install OpenFaaS via Helm.
+
+
+## Install the Chart
+
+- Add the OpenFaaS chart repo and deploy the `ingress-operator` chart. We recommend installing it in the same namespace as the rest of OpenFaaS
+
+```sh
+$ helm repo add openfaas https://openfaas.github.io/faas-netes/
+$ helm upgrade ingress-operator openfaas/ingress-operator \
+    --install \
+    --namespace openfaas
+```
+
+> The above command will also update your helm repo to pull in any new releases.
+
+## Configuration
+
+Additional ingress-operator options in `values.yaml`.
+
+| Parameter                | Description                                                                            | Default                        |
+| ------------------------ | -------------------------------------------------------------------------------------- | ------------------------------ |
+| `create` | Create the ingress-operator component | `false` |
+| `replicas` | Replicas of the ingress-operator| `1` |
+| `image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.6.2` |
+| `resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi |
+| `imagePullPolicy` | Image Pull Policy | `Always` |
+| `functionNamespace` | Namespace for functions | `openfaas-fn` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+See values.yaml for detailed configuration.
+
+## Removing the ingress-operator
+
+All control plane components can be cleaned up with helm:
+
+For Helm 2
+
+```sh
+$ helm delete --purge ingress-operator
+```
+
+For Helm 3
+
+```sh
+$ helm uninstall ingress-operator
+```

--- a/chart/ingress-operator/templates/NOTES.txt
+++ b/chart/ingress-operator/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Thanks for installing ingress-operator. Please follow the instructions below to get you started.

--- a/chart/ingress-operator/templates/_helpers.tpl
+++ b/chart/ingress-operator/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openfaas.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "openfaas.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/ingress-operator/templates/ingress-operator-crd.yaml
+++ b/chart/ingress-operator/templates/ingress-operator-crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingressOperator.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -18,23 +17,27 @@ spec:
       description: FunctionIngress describes an OpenFaaS function
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
+          description:
+            "APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
+          description:
+            "Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           type: string
         metadata:
           type: object
         spec:
-          description: FunctionIngressSpec is the spec for a FunctionIngress resource.
+          description:
+            FunctionIngressSpec is the spec for a FunctionIngress resource.
             It must be created in the same namespace as the gateway, i.e. openfaas.
           properties:
             bypassGateway:
-              description: BypassGateway, when true creates an Ingress record directly
+              description:
+                BypassGateway, when true creates an Ingress record directly
                 for the Function name without using the gateway in the hot path
               type: boolean
             domain:
@@ -47,7 +50,8 @@ spec:
               description: IngressType such as "nginx"
               type: string
             path:
-              description: Path such as "/v1/profiles/view/(.*)", or leave empty for
+              description:
+                Path such as "/v1/profiles/view/(.*)", or leave empty for
                 default
               type: string
             tls:
@@ -56,7 +60,8 @@ spec:
                 enabled:
                   type: boolean
                 issuerRef:
-                  description: ObjectReference is a reference to an object with a
+                  description:
+                    ObjectReference is a reference to an object with a
                     given name and kind.
                   properties:
                     kind:
@@ -83,4 +88,3 @@ spec:
     - name: v1alpha2
       served: true
       storage: true
-{{- end }}

--- a/chart/ingress-operator/templates/ingress-operator-dep.yaml
+++ b/chart/ingress-operator/templates/ingress-operator-dep.yaml
@@ -1,5 +1,4 @@
-{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if .Values.ingressOperator.create }}
+{{- if .Values.create }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,7 +11,7 @@ metadata:
   name: ingress-operator
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.ingressOperator.replicas }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: ingress-operator
@@ -27,15 +26,15 @@ spec:
       containers:
       - name: operator
         resources:
-          {{- .Values.ingressOperator.resources | toYaml | nindent 10 }}
-        image: {{ .Values.ingressOperator.image }}
-        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+          {{- .Values.resources | toYaml | nindent 10 }}
+        image: {{ .Values.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
           - ./ingress-operator
           - -logtostderr
         env:
         - name: function_namespace
-          value: {{ $functionNs | quote }}
+          value: {{ .Values.functionNamespace | quote }}
         - name: ingress_namespace
           value: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/chart/ingress-operator/templates/ingress-operator-rbac.yaml
+++ b/chart/ingress-operator/templates/ingress-operator-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressOperator.create }}
+{{- if .Values.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/ingress-operator/values.yaml
+++ b/chart/ingress-operator/values.yaml
@@ -1,0 +1,16 @@
+# https://github.com/openfaas-incubator/ingress-operator
+image: openfaas/ingress-operator:0.6.2
+
+replicas: 1
+
+create: false
+
+imagePullPolicy: "Always"
+
+functionNamespace: "openfaas-fn"
+
+rbac: true
+
+resources:
+  requests:
+    memory: "25Mi"

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -380,10 +380,6 @@ Additional OpenFaaS options in `values.yaml`.
 | `operator.createCRD` | Create the CRD for OpenFaaS Function definition | `true` |
 | `ingress.enabled` | Create ingress resources | `false` |
 | `faasnetes.httpProbe` | Use a httpProbe instead of exec | `false` |
-| `ingressOperator.create` | Create the ingress-operator component | `false` |
-| `ingressOperator.replicas` | Replicas of the ingress-operator| `1` |
-| `ingressOperator.image` | Container image used in ingress-operator| `openfaas/ingress-operator:0.6.2` |
-| `ingressOperator.resources` | Limits and requests for memory and CPU usage | Memory Requests: 25Mi |
 | `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
 | `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
 | `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |

--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -36,9 +36,6 @@ basicAuthPlugin:
   image: openfaas/basic-auth-plugin:0.18.17-arm64
   replicas: 1
 
-ingressOperator:
-  create: false
-
 # Unfortunately the exporter is not multi-arch (yet)
 nats:
   metrics:

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -36,9 +36,6 @@ basicAuthPlugin:
   image: openfaas/basic-auth-plugin:0.18.17-armhf
   replicas: 0
 
-ingressOperator:
-  create: false
-
 # Unfortunately the exporter is not multi-arch (yet)
 nats:
   metrics:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -1,12 +1,12 @@
-functionNamespace: openfaas-fn  # Default namespace for functions
+functionNamespace: openfaas-fn # Default namespace for functions
 
 async: true
 
 exposeServices: true
 serviceType: NodePort
-httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
+httpProbe: true # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
 rbac: true
-clusterRole: false            # Set to true to have OpenFaaS administrate multiple namespaces
+clusterRole: false # Set to true to have OpenFaaS administrate multiple namespaces
 
 # create pod security policies for OpenFaaS control plane
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
@@ -23,9 +23,9 @@ gatewayExternal:
 
 gateway:
   image: openfaas/gateway:0.18.17
-  readTimeout : "65s"
-  writeTimeout : "65s"
-  upstreamTimeout : "60s"  # Must be smaller than read/write_timeout
+  readTimeout: "65s"
+  writeTimeout: "65s"
+  upstreamTimeout: "60s" # Must be smaller than read/write_timeout
   replicas: 1
   scaleFromZero: true
   # change the port when creating multiple releases in the same baremetal cluster
@@ -74,19 +74,19 @@ oauth2Plugin:
 
 faasnetes:
   image: openfaas/faas-netes:0.10.5
-  readTimeout : "60s"
-  writeTimeout : "60s"
-  imagePullPolicy : "Always"    # Image pull policy for deployed functions
-  httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on Pods (incompatible with Istio < 1.1.5)
+  readTimeout: "60s"
+  writeTimeout: "60s"
+  imagePullPolicy: "Always" # Image pull policy for deployed functions
+  httpProbe: true # Setting to true will use HTTP for readiness and liveness probe on Pods (incompatible with Istio < 1.1.5)
   setNonRootUser: false
   readinessProbe:
     initialDelaySeconds: 2
-    timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
-    periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+    timeoutSeconds: 1 # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
+    periodSeconds: 2 # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
   livenessProbe:
     initialDelaySeconds: 2
     timeoutSeconds: 1
-    periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+    periodSeconds: 2 # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
   resources:
     requests:
       memory: "120Mi"
@@ -112,7 +112,7 @@ queueWorker:
   maxInflight: 1
   gatewayInvoke: true
   queueGroup: "faas"
-  ackWait : "60s"
+  ackWait: "60s"
   resources:
     requests:
       memory: "120Mi"
@@ -148,7 +148,7 @@ nats:
   enableMonitoring: false
   metrics:
     enabled: false
-    image: synadia/prometheus-nats-exporter:0.6.2 
+    image: synadia/prometheus-nats-exporter:0.6.2
   resources:
     requests:
       memory: "120Mi"
@@ -158,7 +158,7 @@ ingress:
   enabled: false
   # Used to create Ingress record (should be used with exposeServices: false).
   hosts:
-    - host: gateway.openfaas.local  # Replace with gateway.example.com if public-facing
+    - host: gateway.openfaas.local # Replace with gateway.example.com if public-facing
       serviceName: gateway
       servicePort: 8080
       path: /
@@ -167,24 +167,14 @@ ingress:
   tls:
     # Secrets must be manually created in the namespace.
 
-# ingressOperator (optional) – component to have specific FQDN and TLS for Functions
-# https://github.com/openfaas-incubator/ingress-operator
-ingressOperator:
-  image: openfaas/ingress-operator:0.6.2
-  replicas: 1
-  create: false
-  resources:
-    requests:
-      memory: "25Mi"
-
 # faas-idler configuration
 faasIdler:
   image: openfaas/faas-idler:0.3.0
   replicas: 1
   create: true
-  inactivityDuration: 30m               # If a function is inactive for 15 minutes, it may be scaled to zero
-  reconcileInterval: 2m                 # The interval between each attempt to scale functions to zero
-  dryRun: true                          # Set to false to enable the idler to apply changes and scale to zero
+  inactivityDuration: 30m # If a function is inactive for 15 minutes, it may be scaled to zero
+  reconcileInterval: 2m # The interval between each attempt to scale functions to zero
+  dryRun: true # Set to false to enable the idler to apply changes and scale to zero
   resources:
     requests:
       memory: "64Mi"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This removes ingress operator from the openfaas helm chart and adds a new helm chart for the ingress operator

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#664 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this on Digital Ocean Kubernetes cluster 

```
helm install openfaas openfaas -n openfaas --set basic_auth=true --set functionNamespace=openfaas-fn  --set generateBasicAuth=true --set serviceType=LoadBalancer
NAME: openfaas
LAST DEPLOYED: Sun Jun 28 19:01:37 2020
NAMESPACE: openfaas
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that openfaas has started, run:

  kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"
To retrieve the admin password, run:

  echo $(kubectl -n openfaas get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode)

 kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"
NAME                READY   UP-TO-DATE   AVAILABLE   AGE
alertmanager        1/1     1            1           19s
basic-auth-plugin   1/1     1            1           19s
faas-idler          1/1     1            1           19s
gateway             1/1     1            1           19s
nats                1/1     1            1           19s
prometheus          1/1     1            1           19s
queue-worker        1/1     1            1           19s

helm install nginxingress  stable/nginx-ingress --set rbac.create=true
NAME: nginxingress
LAST DEPLOYED: Sun Jun 28 19:07:25 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The nginx-ingress controller has been installed.
It may take a few minutes for the LoadBalancer IP to be available.
You can watch the status by running 'kubectl --namespace default get services -o wide -w nginxingress-nginx-ingress-controller'

helm install ingress-operator ingress-operator --namespace=openfaas --set create=true
NAME: ingress-operator
LAST DEPLOYED: Sun Jun 28 19:09:36 2020
NAMESPACE: openfaas
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thanks for installing ingress-operator. Please follow the instructions below to get you started.


kubectl get svc
NAME                                         TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)                      AGE
kubernetes                                   ClusterIP      10.245.0.1       <none>           443/TCP                      3h50m
nginxingress-nginx-ingress-controller        LoadBalancer   10.245.148.215   138.197.238.72   80:32177/TCP,443:31267/TCP   5m56s
nginxingress-nginx-ingress-default-backend   ClusterIP      10.245.123.184   <none>           80/TCP                       5m56s

helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "ingress-operator" chart repository
...Successfully got an update from the "nats-connector" chart repository
...Successfully got an update from the "openfaas/nats-connector" chart repository
...Successfully got an update from the "mqtt-connector" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈
➜  chart git:(master) ✗ helm install \
  --name cert-manager \
  --namespace cert-manager \
  --version v0.11.0 \
  jetstack/cert-manager
Error: unknown flag: --name
➜  chart git:(master) ✗ helm install cert-manager \
  --namespace cert-manager \
  --version v0.11.0 \
  jetstack/cert-manager
NAME: cert-manager
LAST DEPLOYED: Sun Jun 28 19:17:37 2020
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
cert-manager has been deployed successfully!

In order to begin issuing certificates, you will need to set up a ClusterIssuer
or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).

More information on the different types of issuers and how to configure them
can be found in our documentation:

https://docs.cert-manager.io/en/latest/reference/issuers.html

For information on how to configure cert-manager to automatically provision
Certificates for Ingress resources, take a look at the `ingress-shim`
documentation:

https://docs.cert-manager.io/en/latest/reference/ingress-shim.html
➜  chart git:(master) ✗ kubectl apply -f ../lets-encrypt-issuer.yml
issuer.cert-manager.io/letsencrypt-staging created
issuer.cert-manager.io/letsencrypt-prod created

 kubectl apply -f ../my-homepage.yml
functioningress.openfaas.com/myhomepagetls created
➜  chart git:(master) ✗ kubectl get ingress -n openfaas
NAME                        HOSTS                        ADDRESS   PORTS     AGE
cm-acme-http-solver-vljkc   my-homepage.viveksyngh.xyz             80        5s
myhomepagetls               my-homepage.viveksyngh.xyz             80, 443   10s

kubectl logs -n openfaas deploy/ingress-operator
I0628 13:39:45.404904       1 main.go:52] Starting FunctionIngress controller version: 0.6.2 commit: d3fc6dedbae581dfe1622f4792992f2b8bb60a7d
W0628 13:39:45.405323       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0628 13:39:45.407450       1 controller.go:122] Setting up event handlers
I0628 13:39:45.407666       1 controller.go:179] Waiting for informer caches to sync
I0628 13:39:45.508025       1 controller.go:184] Starting workers
I0628 13:39:45.508293       1 controller.go:190] Started workers
I0628 14:00:56.414237       1 controller.go:261] FunctionIngress name: myhomepagetls
I0628 14:00:56.414567       1 controller.go:270] fni.Spec.UseTLS() true
I0628 14:00:56.414667       1 controller.go:271] createIngress true

curl https://my-homepage.viveksyngh.xyz/
<html>Hello world</html>
```




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
