### PR TITLE
Add namespaces support for REST

### DIFF
--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -73,7 +73,7 @@ oauth2Plugin:
   securityContext: true
 
 faasnetes:
-  image: openfaas/faas-netes:0.10.5
+  image: martindekov/faas-netes:0.12.0-rc1
   readTimeout : "60s"
   writeTimeout : "60s"
   imagePullPolicy : "Always"    # Image pull policy for deployed functions

--- a/handlers/namespaces.go
+++ b/handlers/namespaces.go
@@ -22,7 +22,7 @@ func MakeNamespacesLister(defaultNamespace string, clientset kubernetes.Interfac
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Query namespaces")
 
-		res := list(defaultNamespace, clientset)
+		res := ListNamespaces(defaultNamespace, clientset)
 
 		out, _ := json.Marshal(res)
 		w.Header().Set("Content-Type", "application/json")
@@ -63,7 +63,7 @@ func NewNamespaceResolver(defaultNamespace string, kube kubernetes.Interface) Na
 			r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 		}
 
-		allowedNamespaces := list(defaultNamespace, kube)
+		allowedNamespaces := ListNamespaces(defaultNamespace, kube)
 		ok := findNamespace(req.Namespace, allowedNamespaces)
 		if !ok {
 			return req.Namespace, fmt.Errorf("unable to manage secrets within the %s namespace", req.Namespace)
@@ -73,7 +73,8 @@ func NewNamespaceResolver(defaultNamespace string, kube kubernetes.Interface) Na
 	}
 }
 
-func list(defaultNamespace string, clientset kubernetes.Interface) []string {
+// ListNamespaces lists all namespaces annotated with openfaas true
+func ListNamespaces(defaultNamespace string, clientset kubernetes.Interface) []string {
 	listOptions := metav1.ListOptions{}
 	namespaces, err := clientset.CoreV1().Namespaces().List(context.TODO(), listOptions)
 

--- a/main.go
+++ b/main.go
@@ -198,7 +198,6 @@ func runOperator(kubeconfig, masterURL string) {
 	}
 
 	factory := controller.NewFunctionFactory(kubeClient, deployConfig)
-
 	functionNamespace := "openfaas-fn"
 	if namespace, exists := os.LookupEnv("function_namespace"); exists {
 		functionNamespace = namespace

--- a/pkg/server/apply.go
+++ b/pkg/server/apply.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog"
 )
 
-func makeApplyHandler(namespace string, client clientset.Interface) http.HandlerFunc {
+func makeApplyHandler(defaultNamespace string, client clientset.Interface) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		if r.Body != nil {
@@ -32,6 +32,11 @@ func makeApplyHandler(namespace string, client clientset.Interface) http.Handler
 			return
 		}
 		klog.Infof("Deployment request for: %s\n", req.Service)
+
+		namespace := defaultNamespace
+		if len(req.Namespace) > 0 {
+			namespace = req.Namespace
+		}
 
 		opts := metav1.GetOptions{}
 		got, err := client.OpenfaasV1().Functions(namespace).Get(context.TODO(), req.Service, opts)

--- a/pkg/server/namespace.go
+++ b/pkg/server/namespace.go
@@ -3,16 +3,19 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/openfaas/faas-netes/handlers"
+	"k8s.io/client-go/kubernetes"
 )
 
-func makeListNamespaceHandler(defaultNamespace string) func(http.ResponseWriter, *http.Request) {
+func makeListNamespaceHandler(defaultNamespace string, clientset kubernetes.Interface) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		res := handlers.ListNamespaces(defaultNamespace, clientset)
 
-		defer r.Body.Close()
-
-		res, _ := json.Marshal([]string{defaultNamespace})
+		out, _ := json.Marshal(res)
 		w.Header().Set("Content-Type", "application/json")
+
 		w.WriteHeader(http.StatusOK)
-		w.Write(res)
+		w.Write(out)
 	}
 }

--- a/pkg/server/secret.go
+++ b/pkg/server/secret.go
@@ -1,19 +1,12 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 
-	faastypes "github.com/openfaas/faas-provider/types"
+	"github.com/openfaas/faas-netes/k8s"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/openfaas/faas-netes/handlers"
 	"k8s.io/client-go/kubernetes"
-	glog "k8s.io/klog"
 )
 
 const (
@@ -23,159 +16,9 @@ const (
 
 // makeSecretHandler provides the secrets CRUD endpoint
 func makeSecretHandler(namespace string, kube kubernetes.Interface) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Body != nil {
-			defer r.Body.Close()
-		}
-
-		switch r.Method {
-		case http.MethodGet:
-			secrets, err := getSecrets(namespace, kube)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secrets query error: %v", err)
-				return
-			}
-
-			secretsBytes, err := json.Marshal(secrets)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secrets json marshal error: %v", err)
-				return
-			}
-
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write(secretsBytes)
-		case http.MethodPost:
-			secret, err := parseSecret(namespace, r.Body)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secret unmarshal error: %v", err)
-				return
-			}
-
-			if err := createSecret(namespace, kube, secret); err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secret create error: %v", err)
-				return
-			}
-
-			glog.Infof("Secret %s created", secret.GetName())
-			w.WriteHeader(http.StatusAccepted)
-		case http.MethodPut:
-			secret, err := parseSecret(namespace, r.Body)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secret unmarshal error: %v", err)
-				return
-			}
-
-			if err := updateSecret(namespace, kube, secret); err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secret update error: %v", err)
-				return
-			}
-
-			glog.Infof("Secret %s updated", secret.GetName())
-			w.WriteHeader(http.StatusAccepted)
-		case http.MethodDelete:
-			secret, err := parseSecret(namespace, r.Body)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secret unmarshal error: %v", err)
-				return
-			}
-
-			if err := deleteSecret(namespace, kube, secret); err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(err.Error()))
-				glog.Errorf("Secret %s delete error: %v", secret.GetName(), err)
-				return
-			}
-
-			glog.Infof("Secret %s deleted", secret.GetName())
-			w.WriteHeader(http.StatusAccepted)
-		default:
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
+	handler := handlers.SecretsHandler{
+		LookupNamespace: handlers.NewNamespaceResolver(namespace, kube),
+		Secrets:         k8s.NewSecretsClient(kube),
 	}
-}
-
-func getSecrets(namespace string, kube kubernetes.Interface) ([]faastypes.Secret, error) {
-	secrets := []faastypes.Secret{}
-	selector := fmt.Sprintf("%s=%s", secretLabel, secretLabelValue)
-
-	res, err := kube.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
-
-	if err != nil {
-		return secrets, err
-	}
-
-	for _, item := range res.Items {
-		secret := faastypes.Secret{
-			Name: item.Name,
-		}
-		secrets = append(secrets, secret)
-	}
-
-	return secrets, nil
-}
-
-func createSecret(namespace string, kube kubernetes.Interface, secret *corev1.Secret) error {
-	_, err := kube.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func updateSecret(namespace string, kube kubernetes.Interface, secret *corev1.Secret) error {
-	s, err := kube.CoreV1().Secrets(namespace).Get(context.TODO(), secret.GetName(), metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	s.StringData = secret.StringData
-	if _, err = kube.CoreV1().Secrets(namespace).Update(context.TODO(), s, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-	return nil
-}
-
-func deleteSecret(namespace string, kube kubernetes.Interface, secret *corev1.Secret) error {
-	if err := kube.CoreV1().Secrets(namespace).Delete(context.TODO(), secret.GetName(), metav1.DeleteOptions{}); err != nil {
-		return err
-	}
-	return nil
-}
-
-func parseSecret(namespace string, r io.Reader) (*corev1.Secret, error) {
-	body, _ := ioutil.ReadAll(r)
-	req := faastypes.Secret{}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, err
-	}
-	secret := &corev1.Secret{
-		Type: corev1.SecretTypeOpaque,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.Name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				secretLabel: secretLabelValue,
-			},
-		},
-		StringData: map[string]string{
-			req.Name: req.Value,
-		},
-	}
-
-	return secret, nil
+	return handler.ServeHTTP
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,7 +91,7 @@ func New(client clientset.Interface,
 		HealthHandler:        makeHealthHandler(),
 		InfoHandler:          makeInfoHandler(),
 		SecretHandler:        makeSecretHandler(functionNamespace, kube),
-		ListNamespaceHandler: makeListNamespaceHandler(functionNamespace),
+		ListNamespaceHandler: makeListNamespaceHandler(functionNamespace, kube),
 		LogHandler:           logs.NewLogHandlerFunc(faasnetesk8s.NewLogRequestor(kube, functionNamespace), bootstrapConfig.WriteTimeout),
 	}
 


### PR DESCRIPTION
Adding namespaces support for the REST endpoints
of the operator. Currently only the function objects
are spawned without the actual pods running the function
themselves

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Add function CRD creation across namespaces for the operator's REST controller

## Description
<!--- Describe your changes in detail -->

Enable rest controller for the operator to spawn function objects across namespaces. The functions yet don't spawn pods, only the function CRD.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Part of #616 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by creating resource, will publish logs once we discuss this draft

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
