### PR TITLE
fix for #675

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -102,8 +102,6 @@ spec:
           value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: function_namespace
           value: {{ $functionNs | quote }}
-        - name: profiles_namespace
-          value: {{ .Release.Namespace | quote }}
         {{- if .Values.nats.external.enabled }}
         - name: faas_nats_address
           value: "{{ .Values.nats.external.host }}"
@@ -215,6 +213,8 @@ spec:
           value: {{ $functionNs | quote }}
         - name: read_timeout
           value: "{{ .Values.faasnetes.readTimeout }}"
+        - name: profiles_namespace
+          value: {{ .Release.Namespace | quote }}
         - name: write_timeout
           value: "{{ .Values.faasnetes.writeTimeout }}"
         - name: image_pull_policy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I moved down "profiles_namespace" env variable to right after line 215 in gateway-dep.yaml within the OpenFaaS templates.

## Motivation and Context
I got an error while installing OpenFaas latest version via Helm Chart and then I asked a question about this situation and @LucasRoesler said this is a bug then I opened this PR to fix that bug.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
