### PR TITLE
Support function resolution in multiple namespaces

### DIFF
--- a/pkg/k8s/proxy_test.go
+++ b/pkg/k8s/proxy_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -30,14 +31,16 @@ func (f FakeNSLister) List(selector labels.Selector) (ret []*corev1.Endpoints, e
 }
 
 func (f FakeNSLister) Get(name string) (*corev1.Endpoints, error) {
+
+	// make sure that we only send the function name to the lister
+	if strings.Contains(name, ".") {
+		return nil, fmt.Errorf("can not look up function name with a dot!")
+	}
+
 	ep := corev1.Endpoints{
-		Subsets: []corev1.EndpointSubset{
-			corev1.EndpointSubset{
-				Addresses: []corev1.EndpointAddress{
-					corev1.EndpointAddress{IP: "127.0.0.1"},
-				},
-			},
-		},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "127.0.0.1"}},
+		}},
 	}
 
 	return &ep, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**What**
- Ensure that the pass only the function name to the Endpoint lister,
  because the namespace is already set when constructing the lister.
  The existing code would always return a 404 because it sent the
  "function_name.namespace" as the function name. This can never be
  found since it is not a valid service name
- Update the error messages to make the component parts of the message 
   easier to read.  It will now be easier to see which part is the error from the 
   k8s api.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves openfaas/faas#1565


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The unit test for the proxy resolver has been updated to catch this case and it now passes.

It has also been tested locally using 


```sh
kind create cluster

# doing this will cause extras and openfaas-fn to show in the UI
kubectl create ns extras
kubectl annotate ns openfaas-fn  openfaas=1
kubectl annotate ns extras  openfaas=1

arkade install openfaas --basic-auth=false --direct-functions=false --operator --clusterrole --set operator.image=theaxer/faas-netes:6802054

# in a separate terminal
kubectl port-forward svc/gateway 8080
```

open http://localhost:8080 and use the UI to deploy and invoke the function 

![image](https://user-images.githubusercontent.com/891889/91644922-0a9c2300-ea41-11ea-8ea9-9b2191893b7d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
