### PR TITLE
Add DNSPolicy and DNSConfig to profiles CRD

### DIFF
--- a/artifacts/crds/openfaas.com_profiles.yaml
+++ b/artifacts/crds/openfaas.com_profiles.yaml
@@ -636,6 +636,53 @@ spec:
                                 any node on which any of the selected pods is running.
                                 Empty topologyKey is not allowed.
                               type: string
+              dnsConfig:
+                description: Specifies the DNS parameters of a pod. Parameters specified
+                  here will be merged to the generated DNS configuration based on
+                  DNSPolicy.
+                type: object
+                properties:
+                  nameservers:
+                    description: A list of DNS name server IP addresses. This will
+                      be appended to the base nameservers generated from DNSPolicy.
+                      Duplicated nameservers will be removed.
+                    type: array
+                    items:
+                      type: string
+                  options:
+                    description: A list of DNS resolver options. This will be merged
+                      with the base options generated from DNSPolicy. Duplicated entries
+                      will be removed. Resolution options given in Options will override
+                      those that appear in the base DNSPolicy.
+                    type: array
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
+                      type: object
+                      properties:
+                        name:
+                          description: Required.
+                          type: string
+                        value:
+                          type: string
+                  searches:
+                    description: A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from
+                      DNSPolicy. Duplicated search paths will be removed.
+                    type: array
+                    items:
+                      type: string
+              dnsPolicy:
+                description: "If specified, the pod's DNS policy. \n Valid values
+                  are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                  DNS parameters given in DNSConfig will be merged with the policy
+                  selected with DNSPolicy. To have DNS options set along with hostNetwork,
+                  you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                  \n copied to the Pod DNSPolicy, this will replace any existing value
+                  or previously applied Profile. \n Note: \"Default\" is not the default
+                  pod DNS policy. If a pod's dnsPolicy is not explicitly specified,
+                  then \"ClusterFirst\" is used."
+                type: string
               podSecurityContext:
                 description: "SecurityContext holds pod-level security attributes
                   and common container settings. Optional: Defaults to empty.  See

--- a/pkg/apis/openfaas/v1/types.go
+++ b/pkg/apis/openfaas/v1/types.go
@@ -111,6 +111,29 @@ type ProfileSpec struct {
 	//
 	// +optional
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+
+	// If specified, the pod's DNS policy.
+	//
+	// Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+	// DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+	// To have DNS options set along with hostNetwork, you have to specify DNS policy
+	// explicitly to 'ClusterFirstWithHostNet'.
+	//
+	// copied to the Pod DNSPolicy, this will replace any existing value or previously
+	// applied Profile.
+	//
+	// Note: "Default" is not the default pod DNS policy. If a pod's dnsPolicy is not explicitly
+	// specified, then "ClusterFirst" is used.
+	//
+	// +optional
+	DNSPolicy *corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// Specifies the DNS parameters of a pod.
+	// Parameters specified here will be merged to the generated DNS
+	// configuration based on DNSPolicy.
+	//
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/openfaas/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/openfaas/v1/zz_generated.deepcopy.go
@@ -245,6 +245,16 @@ func (in *ProfileSpec) DeepCopyInto(out *ProfileSpec) {
 		*out = new(corev1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DNSPolicy != nil {
+		in, out := &in.DNSPolicy, &out.DNSPolicy
+		*out = new(corev1.DNSPolicy)
+		**out = **in
+	}
+	if in.DNSConfig != nil {
+		in, out := &in.DNSConfig, &out.DNSConfig
+		*out = new(corev1.PodDNSConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/k8s/profiles.go
+++ b/pkg/k8s/profiles.go
@@ -175,6 +175,14 @@ func (f FunctionFactory) ApplyProfile(profile Profile, deployment *appsv1.Deploy
 
 		profile.PodSecurityContext.DeepCopyInto(deployment.Spec.Template.Spec.SecurityContext)
 	}
+
+	if profile.DNSPolicy != nil {
+		deployment.Spec.Template.Spec.DNSPolicy = *profile.DNSPolicy
+	}
+
+	if profile.DNSConfig != nil {
+		deployment.Spec.Template.Spec.DNSConfig = profile.DNSConfig
+	}
 }
 
 // RemoveProfile is the inverse of Apply, removing the mutations that the Profile would have applied
@@ -229,6 +237,16 @@ func (f FunctionFactory) RemoveProfile(profile Profile, deployment *appsv1.Deplo
 		if profile.PodSecurityContext.Sysctls != nil {
 			deployment.Spec.Template.Spec.SecurityContext.Sysctls = nil
 		}
+	}
+
+	if profile.DNSPolicy != nil {
+		if deployment.Spec.Template.Spec.DNSPolicy == *profile.DNSPolicy {
+			deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+		}
+	}
+
+	if profile.DNSConfig != nil && reflect.DeepEqual(profile.DNSConfig, deployment.Spec.Template.Spec.DNSConfig) {
+		deployment.Spec.Template.Spec.DNSConfig = nil
 	}
 }
 


### PR DESCRIPTION
## Description

Support function DNS policy configuration by adding DNSPolicy and DNSConfig to the function profiles CRD.

I understood the [Helm instructions](https://github.com/openfaas/faas-netes/blob/master/CONTRIBUTING.md#helm) to mean I should leave updating the Helm charts and yaml files to a maintainer.

## Motivation and Context
Resolves #604
- [x] ~I have~ Someone else raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed custom image to KinD cluster on Ubuntu 18.04 by following the [Local development](https://github.com/openfaas/faas-netes/blob/master/CONTRIBUTING.md#local-development-of-faas-netes) docs, then ran:
```
faas store deploy nslookup
kubectl get deploy -n openfaas-fn nslookup -o jsonpath='{.spec.template.spec.dnsPolicy}'
# ClusterFirst
kubectl get deploy -n openfaas-fn nslookup -o jsonpath='{.spec.template.spec.dnsConfig}'
# empty
curl -H "Content-Type: text/plain" --data "prometheus.openfaas" http://localhost:31112/function/nslookup
# successfully returns service IP address
```
```
cat <<EOF | kubectl apply -f -
kind: Profile
apiVersion: openfaas.com/v1
metadata:
    name: no-cluster-dns
    namespace: openfaas
spec:
    dnsPolicy: Default
EOF

faas store deploy nslookup --annotation com.openfaas.profile=no-cluster-dns
kubectl get deploy -n openfaas-fn nslookup -o jsonpath='{.spec.template.spec.dnsPolicy}'
# Default
kubectl get deploy -n openfaas-fn nslookup -o jsonpath='{.spec.template.spec.dnsConfig}'
# empty
curl -H "Content-Type: text/plain" --data "prometheus.openfaas" http://localhost:31112/function/nslookup
# unable to return IP address
curl -H "Content-Type: text/plain" --data "google.com" http://localhost:31112/function/nslookup
# successfully returns service IP address
```
```
cat <<EOF | kubectl apply -f -
kind: Profile
apiVersion: openfaas.com/v1
metadata:
    name: dns-config
    namespace: openfaas
spec:
    dnsPolicy: None
    dnsConfig:
      nameservers:
        - "8.8.8.8"
EOF

faas store deploy nslookup --annotation com.openfaas.profile=dns-config
kubectl get deploy -n openfaas-fn nslookup -o jsonpath='{.spec.template.spec.dnsPolicy}'
# None
kubectl get deploy -n openfaas-fn nslookup -o jsonpath='{.spec.template.spec.dnsConfig}'
# {"nameservers":["8.8.8.8"]}
curl -H "Content-Type: text/plain" --data "prometheus.openfaas" http://localhost:31112/function/nslookup
# unable to return IP address
curl -H "Content-Type: text/plain" --data "google.com" http://localhost:31112/function/nslookup
# successfully returns service IP address
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. ([Profiles docs page](https://docs.openfaas.com/reference/profiles/#available-options))
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
