### PR TITLE
Add PORT env-var to functions

### DIFF
--- a/pkg/config/ports.go
+++ b/pkg/config/ports.go
@@ -1,0 +1,4 @@
+package config
+
+// WatchdogPort for the OpenFaaS function watchdog
+const WatchdogPort = 8080

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,7 +33,6 @@ import (
 const (
 	controllerAgentName = "openfaas-operator"
 	faasKind            = "Function"
-	functionPort        = 8080
 	LabelMinReplicas    = "com.openfaas.scale.min"
 	// SuccessSynced is used as part of the Event 'reason' when a Function is synced
 	SuccessSynced = "Synced"

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	faasv1 "github.com/openfaas/faas-netes/pkg/apis/openfaas/v1"
+	"github.com/openfaas/faas-netes/pkg/config"
 	"github.com/openfaas/faas-netes/pkg/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -103,7 +105,9 @@ func newDeployment(
 							Name:  function.Spec.Name,
 							Image: function.Spec.Image,
 							Ports: []corev1.ContainerPort{
-								{ContainerPort: int32(functionPort), Protocol: corev1.ProtocolTCP},
+								{
+									ContainerPort: int32(config.WatchdogPort), Protocol: corev1.ProtocolTCP,
+								},
 							},
 							ImagePullPolicy: corev1.PullPolicy(factory.Factory.Config.ImagePullPolicy),
 							Env:             envVars,
@@ -178,12 +182,22 @@ func makeEnvVars(function *faasv1.Function) []corev1.EnvVar {
 		})
 	}
 
+	envVars = append(envVars,
+		corev1.EnvVar{
+			Name:  "PORT",
+			Value: fmt.Sprintf("%d", config.WatchdogPort),
+		})
+
+	reserved := []string{"PORT", "fprocess"}
+
 	if function.Spec.Environment != nil {
 		for k, v := range *function.Spec.Environment {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  k,
-				Value: v,
-			})
+			if findStr(k, reserved) == false {
+				envVars = append(envVars, corev1.EnvVar{
+					Name:  k,
+					Value: v,
+				})
+			}
 		}
 	}
 
@@ -276,4 +290,13 @@ func deploymentNeedsUpdate(function *faasv1.Function, deployment *appsv1.Deploym
 
 func int32p(i int32) *int32 {
 	return &i
+}
+
+func findStr(target string, list []string) bool {
+	for _, t := range list {
+		if target == t {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	faasv1 "github.com/openfaas/faas-netes/pkg/apis/openfaas/v1"
+	"github.com/openfaas/faas-netes/pkg/config"
 )
 
 // newService creates a new ClusterIP Service for a Function resource. It also sets
@@ -33,10 +34,10 @@ func newService(function *faasv1.Function) *corev1.Service {
 				{
 					Name:     "http",
 					Protocol: corev1.ProtocolTCP,
-					Port:     functionPort,
+					Port:     config.WatchdogPort,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
-						IntVal: int32(functionPort),
+						IntVal: int32(config.WatchdogPort),
 					},
 				},
 			},

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openfaas/faas-netes/pkg/config"
 	"github.com/openfaas/faas-netes/pkg/k8s"
 
 	types "github.com/openfaas/faas-provider/types"
@@ -310,11 +311,22 @@ func buildEnvVars(request *types.FunctionDeployment) []corev1.EnvVar {
 		})
 	}
 
-	for k, v := range request.EnvVars {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  k,
-			Value: v,
+	envVars = append(envVars,
+		corev1.EnvVar{
+			Name:  "PORT",
+			Value: fmt.Sprintf("%d", config.WatchdogPort),
 		})
+
+	reserved := []string{"PORT", "fprocess"}
+
+	for k, v := range request.EnvVars {
+		if findStr(k, reserved) == false {
+
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  k,
+				Value: v,
+			})
+		}
 	}
 
 	sort.SliceStable(envVars, func(i, j int) bool {
@@ -398,4 +410,13 @@ func getMinReplicaCount(labels map[string]string) *int32 {
 	}
 
 	return nil
+}
+
+func findStr(target string, list []string) bool {
+	for _, t := range list {
+		if target == t {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -126,8 +126,8 @@ func Test_buildEnvVars_NoSortedKeys(t *testing.T) {
 
 	coreEnvs := buildEnvVars(&function)
 
-	if len(coreEnvs) != 0 {
-		t.Errorf("want: %d env-vars, got: %d", 0, len(coreEnvs))
+	if len(coreEnvs) != 1 {
+		t.Errorf("want: %d env-vars, got: %d", 1, len(coreEnvs))
 		t.Fail()
 	}
 }
@@ -147,7 +147,12 @@ func Test_buildEnvVars_TwoSortedKeys(t *testing.T) {
 
 	coreEnvs := buildEnvVars(&function)
 
-	if coreEnvs[0].Name != firstKey {
+	if coreEnvs[0].Name != "PORT" {
+		t.Errorf("first want: %s, got: %s", "PORT", coreEnvs[0].Name)
+		t.Fail()
+	}
+
+	if coreEnvs[1].Name != firstKey {
 		t.Errorf("first want: %s, got: %s", firstKey, coreEnvs[0].Name)
 		t.Fail()
 	}
@@ -172,22 +177,26 @@ func Test_buildEnvVars_FourSortedKeys(t *testing.T) {
 
 	coreEnvs := buildEnvVars(&function)
 
-	if coreEnvs[0].Name != firstKey {
+	if coreEnvs[0].Name != "PORT" {
+		t.Errorf("first want: %s, got: %s", "PORT", coreEnvs[0].Name)
+		t.Fail()
+	}
+	if coreEnvs[1].Name != firstKey {
 		t.Errorf("first want: %s, got: %s", firstKey, coreEnvs[0].Name)
 		t.Fail()
 	}
 
-	if coreEnvs[1].Name != secondKey {
+	if coreEnvs[2].Name != secondKey {
 		t.Errorf("second want: %s, got: %s", secondKey, coreEnvs[1].Name)
 		t.Fail()
 	}
 
-	if coreEnvs[2].Name != thirdKey {
+	if coreEnvs[3].Name != thirdKey {
 		t.Errorf("third want: %s, got: %s", thirdKey, coreEnvs[2].Name)
 		t.Fail()
 	}
 
-	if coreEnvs[3].Name != lastKey {
+	if coreEnvs[4].Name != lastKey {
 		t.Errorf("last want: %s, got: %s", lastKey, coreEnvs[3].Name)
 		t.Fail()
 	}

--- a/pkg/k8s/proxy.go
+++ b/pkg/k8s/proxy.go
@@ -11,11 +11,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/openfaas/faas-netes/pkg/config"
 	corelister "k8s.io/client-go/listers/core/v1"
 )
-
-// watchdogPort for the OpenFaaS function watchdog
-const watchdogPort = 8080
 
 func NewFunctionLookup(ns string, lister corelister.EndpointsLister) *FunctionLookup {
 	return &FunctionLookup{
@@ -91,7 +89,7 @@ func (l *FunctionLookup) Resolve(name string) (url.URL, error) {
 
 	serviceIP := svc.Subsets[0].Addresses[target].IP
 
-	urlStr := fmt.Sprintf("http://%s:%d", serviceIP, watchdogPort)
+	urlStr := fmt.Sprintf("http://%s:%d", serviceIP, config.WatchdogPort)
 
 	urlRes, err := url.Parse(urlStr)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add PORT env-var to functions

## Motivation and Context
Fixes: #691

The PORT env-var is used by PaaS-like platforms to inform the
underlying code which HTTP port to expose. For OpenFaaS, this
is always port 8080, however this change allows for users
to port their code to OpenFaaS from a PaaS and visa versa.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests updated. Functions will now receive at least one
env-var - PORT=8080.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
