### PR TITLE
Add imagePullSecrets option to helm chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -400,6 +400,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `psp` | Enable [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for OpenFaaS accounts | `false` |
 | `securityContext` | Deploy with a `securityContext` set, this can be disabled for use with Istio sidecar injection | `true` |
 | `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
+| `openfaasImagePullSecrets` | imagePullSecrets for pulling openfaas images from private registries                  | []       |
 | `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |
 | `operator.create` | Use the OpenFaaS operator CRD controller, default uses faas-netes as the Kubernetes controller | `false` |
 | `ingress.enabled` | Create ingress resources | `false` |

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -105,4 +105,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -101,6 +101,12 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 
 {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -60,7 +60,7 @@ spec:
             secretName: basic-auth
 
 {{- end }}
-{{- with .Values.nodeSelector }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -71,5 +71,11 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
-{{- end }}
+    {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -256,3 +256,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -38,4 +38,10 @@ spec:
           value: {{ $functionNs | quote }}
         - name: ingress_namespace
           value: {{ .Release.Namespace | quote }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -79,4 +79,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/oauth2-plugin-dep.yaml
+++ b/chart/openfaas/templates/oauth2-plugin-dep.yaml
@@ -135,5 +135,11 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 
 {{- end }}

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -104,5 +104,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -84,4 +84,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.openfaasImagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -19,6 +19,8 @@ generateBasicAuth: false
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
 openfaasImagePullPolicy: "Always"
 
+openfaasImagePullSecrets: []
+
 gatewayExternal:
   annotations: {}
 


### PR DESCRIPTION
## Description

The `openfaasImagePullSecrets` option has been added to the `values.yaml` file which will add `imagePullSecrets` to all of the deployments in the openfaas helm chart.

I also bumped the chart version patch number.

## Motivation and Context

With DockerHub imposing rate limiting, I need to be able to add image pull secrets to pull these images from our private image registry. It's also more reliable and performant to use our own private registry.

Fixes #702 

## How Has This Been Tested?

I ran the helm chart with `helm template test . --validate` with `openfaasImagePullSecrets` set to an empty array as well as with values, and the chart worked as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
