### PR TITLE
[WIP] Add OPA to the OpenFaaS helm chart for authorization

### DIFF
--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -1,6 +1,6 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 {{- if .Values.basic_auth }}
-{{- if not .Values.oauth2Plugin.enabled }}
+{{- if not .Values.oidc.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -128,7 +128,7 @@ spec:
           value: "/var/secrets"
         {{- if .Values.oidc.enabled }}
         - name: auth_proxy_url
-          value: "http://oauth2-plugin.{{ .Release.Namespace }}:8080/validate"
+          value: "http://oidc.{{ .Release.Namespace }}:8080/validate"
         - name: auth_pass_body
           value: "false"
         {{- else }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -126,7 +126,7 @@ spec:
           value: "true"
         - name: secret_mount_path
           value: "/var/secrets"
-        {{- if .Values.oauth2Plugin.enabled }}
+        {{- if .Values.oidc.enabled }}
         - name: auth_proxy_url
           value: "http://oauth2-plugin.{{ .Release.Namespace }}:8080/validate"
         - name: auth_pass_body

--- a/chart/openfaas/templates/oauth2-plugin-dep.yaml
+++ b/chart/openfaas/templates/oauth2-plugin-dep.yaml
@@ -1,5 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if .Values.oauth2Plugin.enabled }}
+{{- if .Values.oidc.enabled }}
 ---
 
 apiVersion: apps/v1
@@ -14,7 +14,7 @@ metadata:
   name: oauth2-plugin
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  replicas: {{ .Values.oauth2Plugin.replicas }}
+  replicas: {{ .Values.oidc.replicas }}
   selector:
     matchLabels:
       app: oauth2-plugin
@@ -36,8 +36,8 @@ spec:
       containers:
       - name:  oauth2-plugin
         resources:
-          {{- .Values.oauth2Plugin.resources | toYaml | nindent 12 }}
-        image: {{ .Values.oauth2Plugin.image }}
+          {{- .Values.oidc.resources | toYaml | nindent 12 }}
+        image: {{ .Values.oidc.image }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.securityContext }}
         securityContext:
@@ -77,35 +77,35 @@ spec:
           {{- end }}
           timeoutSeconds: 5
         args:
-        - "-license={{- .Values.oauth2Plugin.license}}"
-        - "-provider={{- .Values.oauth2Plugin.provider}}"
+        - "-license={{- .Values.oidc.license}}"
+        - "-provider={{- .Values.oidc.provider}}"
         env:
         - name: client_id
-          value: "{{- .Values.oauth2Plugin.clientID}}"
+          value: "{{- .Values.oidc.clientID}}"
         - name: client_secret
-          value: "{{- .Values.oauth2Plugin.clientSecret}}"
+          value: "{{- .Values.oidc.clientSecret}}"
         - name: cookie_domain
-          value: "{{- .Values.oauth2Plugin.cookieDomain}}"
+          value: "{{- .Values.oidc.cookieDomain}}"
         - name: base_host
-          value: "{{- .Values.oauth2Plugin.baseHost}}"
+          value: "{{- .Values.oidc.baseHost}}"
         - name: port
           value: "8080"
         - name: authorize_url
-          value: "{{- .Values.oauth2Plugin.authorizeURL}}"
+          value: "{{- .Values.oidc.authorizeURL}}"
         - name: welcome_page_url
-          value: "{{- .Values.oauth2Plugin.welcomePageURL}}"
+          value: "{{- .Values.oidc.welcomePageURL}}"
         - name: public_key_path
           value: ""  # leave blank if using jwks
         - name: audience
-          value: "{{- .Values.oauth2Plugin.audience}}"
+          value: "{{- .Values.oidc.audience}}"
         - name: token_url
-          value: "{{- .Values.oauth2Plugin.tokenURL}}"
+          value: "{{- .Values.oidc.tokenURL}}"
         - name: scopes
-          value: "{{- .Values.oauth2Plugin.scopes}}"
+          value: "{{- .Values.oidc.scopes}}"
         - name: jwks_url
-          value: "{{- .Values.oauth2Plugin.jwksURL}}"
+          value: "{{- .Values.oidc.jwksURL}}"
         - name: insecure_tls
-          value: "{{- .Values.oauth2Plugin.insecureTLS}}"
+          value: "{{- .Values.oidc.insecureTLS}}"
         {{- if .Values.basic_auth }}
         - name: secret_mount_path
           value: "/var/secrets"

--- a/chart/openfaas/templates/oidc-dep.yaml
+++ b/chart/openfaas/templates/oidc-dep.yaml
@@ -1,4 +1,3 @@
-{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 {{- if .Values.oidc.enabled }}
 ---
 
@@ -8,25 +7,25 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: oauth2-plugin
+    component: oidc
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: oauth2-plugin
+  name: oidc
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.oidc.replicas }}
   selector:
     matchLabels:
-      app: oauth2-plugin
+      app: oidc
   template:
     metadata:
       annotations:
         prometheus.io.scrape: "false"
       labels:
-        app: oauth2-plugin
+        app: oidc
     spec:
       volumes:
-      - name: oauth2-plugin-temp-volume
+      - name: oidc-temp-volume
         emptyDir: {}
       {{- if .Values.basic_auth }}
       - name: auth
@@ -34,7 +33,7 @@ spec:
           secretName: basic-auth
       {{- end }}
       containers:
-      - name:  oauth2-plugin
+      - name:  oidc
         resources:
           {{- .Values.oidc.resources | toYaml | nindent 12 }}
         image: {{ .Values.oidc.image }}
@@ -111,7 +110,7 @@ spec:
           value: "/var/secrets"
         {{- end }}
         volumeMounts:
-        - name: oauth2-plugin-temp-volume
+        - name: oidc-temp-volume
           mountPath: /tmp
         {{- if .Values.basic_auth }}
         - name: auth

--- a/chart/openfaas/templates/oidc-opa-cfg.yaml
+++ b/chart/openfaas/templates/oidc-opa-cfg.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.oidc.opa.enabled }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: opa-config
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: opa-config
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  openfaas_authz.rego: |
+    package openfaas.authz
+
+    default allow = false
+
+    allow {
+      input.function == "opa-auth"
+      input.user == "alice"
+    }
+{{- end }}

--- a/chart/openfaas/templates/oidc-opa-dep.yaml
+++ b/chart/openfaas/templates/oidc-opa-dep.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.oidc.opa.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: opa
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: opa
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.oidc.replicas }}
+  selector:
+    matchLabels:
+      app: opa
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: opa
+    spec:
+      volumes:
+      - name: opa-temp-volume
+        emptyDir: {}
+      - name: opa-config
+        configMap:
+          name: opa-config
+          items:
+            - key: openfaas_authz.rego
+              path: openfaas_authz.rego
+              mode: 0644
+      containers:
+      - name:  opa
+        resources:
+          {{- .Values.oidc.resources | toYaml | nindent 12 }}
+        image: {{ .Values.oidc.opa.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
+        args:
+          - "run"
+          - "--server"
+          - "--log-level=debug"
+          - "--skip-version-check"
+          - "/policy/openfaas_authz.rego"
+        volumeMounts:
+        - name: opa-temp-volume
+          mountPath: /tmp
+        - name: opa-config
+          readOnly: true
+          mountPath: "/policy/"
+        ports:
+        - name: http
+          containerPort: 8081
+          protocol: TCP
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+{{- end }}

--- a/chart/openfaas/templates/oidc-opa-svc.yaml
+++ b/chart/openfaas/templates/oidc-opa-svc.yaml
@@ -1,26 +1,21 @@
-{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if .Values.oidc.enabled }}
+{{- if .Values.oidc.opa.enabled }}
 ---
-
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: oauth2-plugin
+    component: opa
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: oauth2-plugin
+  name: opa
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: http
+    - port: 8181
       protocol: TCP
-      name: http
   selector:
-    app: oauth2-plugin
-
+    app: opa
 {{- end }}

--- a/chart/openfaas/templates/oidc-svc.yaml
+++ b/chart/openfaas/templates/oidc-svc.yaml
@@ -1,4 +1,3 @@
-{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 {{- if .Values.oidc.enabled }}
 ---
 
@@ -8,10 +7,10 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: oauth2-plugin
+    component: oidc
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: oauth2-plugin
+  name: oidc
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
@@ -21,6 +20,6 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: oauth2-plugin
+    app: oidc
 
 {{- end }}

--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -10,7 +10,7 @@ gateway:
   image: openfaas/gateway:0.20.1-arm64
   directFunctions: true
 
-oauth2Plugin:
+oidc:
   enabled: false
 
 faasnetes:

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -10,7 +10,7 @@ gateway:
   image: openfaas/gateway:0.20.1-armhf
   directFunctions: true
 
-oauth2Plugin:
+oidc:
   enabled: false
 
 faasnetes:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -50,7 +50,9 @@ basicAuthPlugin:
       memory: "50Mi"
       cpu: "20m"
 
-oauth2Plugin:
+## Commercial OIDC authentication and authorization
+## For Premium Subscription customers
+oidc:
   enabled: false
   provider: "" # Leave blank, or put "azure"
   license: "example"
@@ -72,6 +74,11 @@ oauth2Plugin:
   replicas: 1
   image: openfaas/openfaas-oidc-plugin:0.3.7
   securityContext: true
+
+# OPA provides authorization
+  opa:
+    image: openpolicyagent/opa:0.24.0
+    enabled: true
 
 faasnetes:
   image: ghcr.io/openfaas/faas-netes:0.12.8


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add OPA to the OpenFaaS helm chart for authorization

## Motivation and Context

The oidc plugin handles authz with IDps like Okta and Auth0,
but on its own it doesn not add authorization.

This PR renames the oauth2plugin to oidc and adds OPA with
a sample bundle.

## How Has This Been Tested?

Still in active development. This PR is for testing and sharing.