### PR TITLE
Update CRD for IngressOperator

### DIFF
--- a/chart/openfaas/templates/ingress-operator-crd.yaml
+++ b/chart/openfaas/templates/ingress-operator-crd.yaml
@@ -5,7 +5,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
   name: functioningresses.openfaas.com
 spec:
   group: openfaas.com
@@ -15,76 +16,77 @@ spec:
     plural: functioningresses
     singular: functioningress
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: FunctionIngress describes an OpenFaaS function
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: FunctionIngressSpec is the spec for a FunctionIngress resource.
-            It must be created in the same namespace as the gateway, i.e. openfaas.
-          properties:
-            bypassGateway:
-              description: BypassGateway, when true creates an Ingress record directly
-                for the Function name without using the gateway in the hot path
-              type: boolean
-            domain:
-              description: Domain such as "api.example.com"
-              type: string
-            function:
-              description: Function such as "nodeinfo"
-              type: string
-            ingressType:
-              description: IngressType such as "nginx"
-              type: string
-            path:
-              description: Path such as "/v1/profiles/view/(.*)", or leave empty for
-                default
-              type: string
-            tls:
-              description: Enable TLS via cert-manager
-              properties:
-                enabled:
-                  type: boolean
-                issuerRef:
-                  description: ObjectReference is a reference to an object with a
-                    given name and kind.
-                  properties:
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                  required:
-                    - name
-                  type: object
-              required:
-                - enabled
-                - issuerRef
-              type: object
-          required:
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: FunctionIngress describes an OpenFaaS function
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FunctionIngressSpec is the spec for a FunctionIngress resource.
+              It must be created in the same namespace as the gateway, i.e. openfaas.
+            type: object
+            required:
             - domain
             - function
-            - path
-          type: object
-      required:
-        - spec
-      type: object
-  version: v1alpha2
-  versions:
-    - name: v1alpha2
-      served: true
-      storage: true
+            properties:
+              bypassGateway:
+                description: BypassGateway, when true creates an Ingress record directly
+                  for the Function name without using the gateway in the hot path
+                type: boolean
+              domain:
+                description: Domain such as "api.example.com"
+                type: string
+              function:
+                description: Function such as "nodeinfo"
+                type: string
+              ingressType:
+                description: IngressType such as "nginx"
+                type: string
+              path:
+                description: Path such as "/v1/profiles/view/(.*)", or leave empty
+                  for default
+                type: string
+              tls:
+                description: Enable TLS via cert-manager
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  issuerRef:
+                    description: ObjectReference is a reference to an object with
+                      a given name and kind.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update CRD for IngressOperator

## Motivation and Context

Fixes: #718

The CRD doesn't appear to have been synced after merging https://github.com/openfaas/ingress-operator/pull/40

## Testing

```
helm upgrade openfaas --install chart/openfaas \
    --namespace openfaas  \
    --set basic_auth=true \
    --set functionNamespace=openfaas-fn \
    --set ingressOperator=true
```

The CRD applied and worked followed by:

```
kubectl -n openfaas logs deployment/ingress-operator
I1129 15:32:24.947893       1 main.go:52] Starting FunctionIngress controller version: 0.6.6 commit: 01e49ccaa4eafe1bb019803cc485decaca3badbc
W1129 15:32:24.948382       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I1129 15:32:24.950844       1 controller.go:122] Setting up event handlers
I1129 15:32:24.950954       1 controller.go:183] Waiting for informer caches to sync
I1129 15:32:25.051267       1 controller.go:188] Starting workers
I1129 15:32:25.051326       1 controller.go:194] Started workers
```

I then applied a FunctionIngress record and got:

```
NAMESPACE   NAME       CLASS    HOSTS                  ADDRESS      PORTS   AGE
openfaas    nodeinfo   <none>   nodeinfo.myfaas.club   172.18.0.2   80      15s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
