### PR TITLE
Limit the Prometheus role to two namespaces by default

### DIFF
--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -37,7 +37,9 @@ data:
             namespaces:
               names:
                 - {{ .Release.Namespace }}
-                - {{  $functionNs }}
+{{- if ne $functionNs (.Release.Namespace | toString) }}
+                - {{ $functionNs }}
+{{- end }}
         relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)

--- a/chart/openfaas/templates/prometheus-rbac.yaml
+++ b/chart/openfaas/templates/prometheus-rbac.yaml
@@ -1,5 +1,6 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 {{- if .Values.prometheus.create }}
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -13,6 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 ---
+
+{{- if .Values.clusterRole }}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -71,5 +75,88 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-prometheus
   namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+
+{{- else -}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-prometheus
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+{{- if ne $functionNs (.Release.Namespace | toString) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-prometheus-fn
+  namespace: {{ $functionNs | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-prometheus-fn
+  namespace: {{ $functionNs | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-prometheus-fn
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Limit the Prometheus role to two namespaces by default

## Motivation and Context

Limit the Prometheus role to two namespaces

Unless clusterRole is specified, the Prometheus role will be
restricted to scraping from only a single namespace.

This fixes issue: #717 where I user complained that they did 
not want to create a ClusterRole in their cluster.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It has been tested with k3d and K8s 1.19 with and without the 
--set clusterRole=true flag passed into the faas-netes helm 
chart.

The second Role and RoleBinding needed a different name to the 
ones in the primary namespace in order for the RBAC error to 
go away in Prometheus.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

This is likely to break for any users wishing to upgrade, due to the existing `ClusterRole` which they 
will have in their cluster and its mapping.

The upgrade procedure is to delete the roles and bindings and then to run a helm upgrade.
