### PR TITLE
Use an informer for getting replicas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 TAG?=latest
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-all: build-local
+all: build-docker
 
 local:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o faas-netes

--- a/main.go
+++ b/main.go
@@ -155,6 +155,9 @@ func runController(setup serverSetup) {
 
 	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
 
+	deploymentLister := kubeInformerFactory.Apps().V1().
+		Deployments().Lister()
+
 	log.Println("Waiting for openfaas CRD cache sync")
 	faasInformerFactory.WaitForCacheSync(stopCh)
 	setup.profileInformerFactory.WaitForCacheSync(stopCh)
@@ -170,8 +173,8 @@ func runController(setup serverSetup) {
 		FunctionProxy:        proxy.NewHandlerFunc(config.FaaSConfig, functionLookup),
 		DeleteHandler:        handlers.MakeDeleteHandler(config.DefaultFunctionNamespace, kubeClient),
 		DeployHandler:        handlers.MakeDeployHandler(config.DefaultFunctionNamespace, factory),
-		FunctionReader:       handlers.MakeFunctionReader(config.DefaultFunctionNamespace, kubeClient),
-		ReplicaReader:        handlers.MakeReplicaReader(config.DefaultFunctionNamespace, kubeClient),
+		FunctionReader:       handlers.MakeFunctionReader(config.DefaultFunctionNamespace, deploymentLister),
+		ReplicaReader:        handlers.MakeReplicaReader(config.DefaultFunctionNamespace, deploymentLister),
 		ReplicaUpdater:       handlers.MakeReplicaUpdater(config.DefaultFunctionNamespace, kubeClient),
 		UpdateHandler:        handlers.MakeUpdateHandler(config.DefaultFunctionNamespace, factory),
 		HealthHandler:        handlers.MakeHealthHandler(),

--- a/pkg/config/read_config.go
+++ b/pkg/config/read_config.go
@@ -73,39 +73,51 @@ type BootstrapConfig struct {
 	// HTTPProbe when set to true switches readiness and liveness probe to
 	// access /_/health over HTTP instead of accessing /tmp/.lock.
 	HTTPProbe bool
+
 	// SetNonRootUser determines if the Function is deployed with a overridden
 	// non-root user id.  Currently this is preconfigured to the uid 12000.
 	SetNonRootUser bool
+
 	// ReadinessProbeInitialDelaySeconds controls the value of
 	// ReadinessProbeInitialDelaySeconds in the Function  ReadinessProbe
 	ReadinessProbeInitialDelaySeconds int
+
 	// ReadinessProbeTimeoutSeconds controls the value of
 	// ReadinessProbeTimeoutSeconds in the Function  ReadinessProbe
 	ReadinessProbeTimeoutSeconds int
+
 	// ReadinessProbePeriodSeconds controls the value of
 	// ReadinessProbePeriodSeconds in the Function  ReadinessProbe
 	ReadinessProbePeriodSeconds int
+
 	// LivenessProbeInitialDelaySeconds controls the value of
 	// LivenessProbeInitialDelaySeconds in the Function  LivenessProbe
 	LivenessProbeInitialDelaySeconds int
+
 	// LivenessProbeTimeoutSeconds controls the value of
 	// LivenessProbeTimeoutSeconds in the Function  LivenessProbe
 	LivenessProbeTimeoutSeconds int
+
 	// LivenessProbePeriodSeconds controls the value of
 	// LivenessProbePeriodSeconds in the Function  LivenessProbe
 	LivenessProbePeriodSeconds int
+
 	// ImagePullPolicy controls the ImagePullPolicy set on the Function Deployment.
 	ImagePullPolicy string
+
 	// DefaultFunctionNamespace defines which namespace in which Functions are deployed.
 	// Value is set via the function_namespace environment variable. If the
 	// variable is not set, it is set to "default".
 	DefaultFunctionNamespace string
+
 	// ProfilesNamespace defines which namespace is used to look up available Profiles.
 	// Value is set via the profiles_namespace environment variable. If the
 	// variable is not set, then it falls back to DefaultFunctionNamespace.
 	ProfilesNamespace string
+
 	// FaaSConfig contains the configuration for the FaaSProvider
 	FaaSConfig ftypes.FaaSConfig
+
 	// ClusterRole determines whether the operator should have cluster wide access
 	ClusterRole bool
 }

--- a/pkg/handlers/replica_reader.go
+++ b/pkg/handlers/replica_reader.go
@@ -1,0 +1,91 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Copyright 2020 OpenFaaS Author(s)
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/openfaas/faas-netes/pkg/k8s"
+	types "github.com/openfaas/faas-provider/types"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/client-go/listers/apps/v1"
+	glog "k8s.io/klog"
+)
+
+// MakeReplicaReader reads the amount of replicas for a deployment
+func MakeReplicaReader(defaultNamespace string, lister v1.DeploymentLister) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		vars := mux.Vars(r)
+
+		functionName := vars["name"]
+		q := r.URL.Query()
+		namespace := q.Get("namespace")
+
+		lookupNamespace := defaultNamespace
+
+		if len(namespace) > 0 {
+			lookupNamespace = namespace
+		}
+
+		s := time.Now()
+
+		function, err := getService(lookupNamespace, functionName, lister)
+		if err != nil {
+			log.Printf("Unable to fetch service: %s %s\n", functionName, namespace)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if function == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		d := time.Since(s)
+		log.Printf("Replicas: %s.%s, (%d/%d) %dms\n", functionName, lookupNamespace, function.AvailableReplicas, function.Replicas, d.Milliseconds())
+
+		functionBytes, err := json.Marshal(function)
+		if err != nil {
+			glog.Errorf("Failed to marshal function: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Failed to marshal function"))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(functionBytes)
+	}
+}
+
+// getService returns a function/service or nil if not found
+func getService(functionNamespace string, functionName string, lister v1.DeploymentLister) (*types.FunctionStatus, error) {
+
+	item, err := lister.Deployments(functionNamespace).
+		Get(functionName)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	if item != nil {
+		function := k8s.AsFunctionStatus(*item)
+		if function != nil {
+			return function, nil
+		}
+	}
+
+	return nil, fmt.Errorf("function: %s not found", functionName)
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use an informer for getting replicas and functions

## Motivation and Context

Use an informer for getting replicas and functions

This should reduce rate-limiting on the Kubernetes API
server when faas-netes is making many calls. It changes
both the function list handler and the replica status
API.

The API returns much faster than before, so creates more HTTP
calls between the gateway and faas-netes, this value will
need to be tuned in the gateway to be slower between retries.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with k3d and it worked as expected.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
