### PR TITLE
Add NATS Streaming maximum payload option to helm chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -443,6 +443,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `nats.external.enabled` | Whether to use an externally-managed NATS Streaming server | `false` |
 | `nats.external.host` | The host at which the externally-managed NATS Streaming server can be reached | `""` |
 | `nats.external.port` | The port at which the externally-managed NATS Streaming server can be reached | `""` |
+| `nats.maxPayload` | Setup the max payload size for NATS Streaming deployments managed by this chart | `1Mb` |
 | `nats.enableMonitoring` | Enable the NATS monitoring endpoints on port `8222` for NATS Streaming deployments managed by this chart | `false` |
 | `nats.metrics.enabled` | Export Prometheus metrics for NATS, no multi-arch support  | `false` |
 | `nats.metrics.image` | Container image used for the NATS Prometheus exporter, not multi-arch | `synadia/prometheus-nats-exporter:0.6.2` |

--- a/chart/openfaas/templates/nats-cfg.yaml
+++ b/chart/openfaas/templates/nats-cfg.yaml
@@ -1,0 +1,18 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if and .Values.async (not .Values.nats.external.enabled) }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: nats-config
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: nats-config
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  nats-cfg.conf: |
+    {max_payload: {{ .Values.nats.maxPayload }}}
+{{- end }}

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+        checksum/nats-config: {{ include (print $.Template.BasePath "/nats-cfg.yaml") . | sha256sum | quote }}
         prometheus.io.scrape: {{ .Values.nats.metrics.enabled | quote }}
         {{- if .Values.nats.metrics.enabled }}
         prometheus.io.port: "7777"
@@ -39,7 +40,11 @@ spec:
         - containerPort: 8222
           protocol: TCP
         {{- end }}
-        command: ["/nats-streaming-server"]
+        command: ["/nats-streaming-server", "--config=/nats-cfg.conf"]
+        volumeMounts:
+        - mountPath: /nats-cfg.conf
+          name: nats-config
+          subPath: nats-cfg.conf
         args:
           - --store
           - memory
@@ -67,6 +72,14 @@ spec:
         - -serverz
         - http://localhost:8222
       {{- end }}
+      volumes:
+        - name: nats-config
+          configMap:
+            name: nats-config
+            items:
+              - key: nats-cfg.conf
+                path: nats-cfg.conf
+                mode: 0644
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -147,6 +147,7 @@ nats:
     port: ""
   image: nats-streaming:0.17.0
   enableMonitoring: false
+  maxPayload: "1Mb"
   metrics:
     enabled: false
     image: synadia/prometheus-nats-exporter:0.6.2 


### PR DESCRIPTION
Add NATS Streaming maximum payload option to helm chart

## Description
Add NATS Streaming maximum payload option to helm chart. The default is the same as the current one, 1Mb.

## Motivation and Context
It allows people who need to pass a variable to set the nats config max payload size. This allow to potentially do async request of more than 1Mb if configured, or to have a stricter limit.
Fixes https://github.com/openfaas/faas-netes/issues/734
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested on a cluster setup with arkade and no costumisation, then updated with helm upgrade to test different payload size. Sent different payload to verify that the limit was correctly applied.
NB: you have to increase nginx max request size too if you dont want your request to be stopped before reaching nats.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
