### PR TITLE
Really fix profiles RBAC for operator

### DIFF
--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -29,9 +29,6 @@ rules:
 - apiGroups: ["openfaas.com"]
   resources: ["functions"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["openfaas.com"]
-  resources: ["profiles"]
-  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -67,6 +64,42 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-operator
   namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-profiles
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["openfaas.com"]
+  resources: ["profiles"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Release.Name }}-profiles
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-profiles
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-operator
+    namespace: {{ .Release.Namespace | quote }}
 {{- if .Values.clusterRole}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add the required separate Role for the installation namespace with
  permissions to read and watch Profile objects. The previous fix was
  added to a Role with the wrong namespace, so that the Operator still
  could not read the Profiles without enabling the ClusterRole. This
  fix better copies the implementation from the faas-netes controller
  RBAC by creating a specific Role just for Profiles in the installation
  namespace. This means we should now have a Role and a RoleBinding for
  the profiles for the Operator without the full cluster access.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
$ helm template foo  ./chart/openfaas -s templates/operator-rbac.yaml -f ./chart/openfaas/values.yaml --set operator.create=true | grep -B 3 profiles
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: foo-profiles
--
    release: foo
rules:
- apiGroups: ["openfaas.com"]
  resources: ["profiles"]
--
    component: openfaas-operator
    heritage: Helm
    release: foo
  name: foo-profiles
--
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: foo-profiles
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
