### PR TITLE
Fix timeout parsing for operator mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func runOperator(setup serverSetup, cfg config.BootstrapConfig) {
 		factory,
 	)
 
-	srv := server.New(faasClient, kubeClient, endpointsInformer, deploymentInformer, cfg.ClusterRole)
+	srv := server.New(faasClient, kubeClient, endpointsInformer, deploymentInformer, cfg.ClusterRole, cfg)
 
 	go faasInformerFactory.Start(stopCh)
 	go kubeInformerFactory.Start(stopCh)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"strconv"
-	"time"
+
+	"github.com/openfaas/faas-netes/pkg/config"
 
 	clientset "github.com/openfaas/faas-netes/pkg/client/clientset/versioned"
 	"github.com/openfaas/faas-netes/pkg/handlers"
@@ -35,35 +35,12 @@ func New(client clientset.Interface,
 	kube kubernetes.Interface,
 	endpointsInformer coreinformer.EndpointsInformer,
 	deploymentsInformer appsinformer.DeploymentInformer,
-	clusterRole bool) *Server {
+	clusterRole bool,
+	cfg config.BootstrapConfig) *Server {
 
 	functionNamespace := "openfaas-fn"
 	if namespace, exists := os.LookupEnv("function_namespace"); exists {
 		functionNamespace = namespace
-	}
-
-	port := defaultHTTPPort
-	if portVal, exists := os.LookupEnv("port"); exists {
-		parsedVal, parseErr := strconv.Atoi(portVal)
-		if parseErr == nil && parsedVal > 0 {
-			port = parsedVal
-		}
-	}
-
-	readTimeout := defaultReadTimeout
-	if val, exists := os.LookupEnv("read_timeout"); exists {
-		parsedVal, parseErr := strconv.Atoi(val)
-		if parseErr == nil && parsedVal > 0 {
-			readTimeout = parsedVal
-		}
-	}
-
-	writeTimeout := defaultWriteTimeout
-	if val, exists := os.LookupEnv("write_timeout"); exists {
-		parsedVal, parseErr := strconv.Atoi(val)
-		if parseErr == nil && parsedVal > 0 {
-			writeTimeout = parsedVal
-		}
 	}
 
 	pprof := "false"
@@ -76,9 +53,9 @@ func New(client clientset.Interface,
 
 	deploymentLister := deploymentsInformer.Lister()
 	bootstrapConfig := types.FaaSConfig{
-		ReadTimeout:  time.Duration(readTimeout) * time.Second,
-		WriteTimeout: time.Duration(writeTimeout) * time.Second,
-		TCPPort:      &port,
+		ReadTimeout:  cfg.FaaSConfig.ReadTimeout,
+		WriteTimeout: cfg.FaaSConfig.WriteTimeout,
+		TCPPort:      cfg.FaaSConfig.TCPPort,
 		EnableHealth: true,
 	}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix timeout parsing for operator mode

## Motivation and Context

The operator was trying to parse timeouts as ints instead 
of as Golang durations. The fix was to remove the custom 
code and to use the existing "config" code that can 
handle duration format i.e. `20s`.

Fixes #729 #743 

## How Has This Been Tested?

Tested with arkade by installing with:

```
#!/bin/bash

export TIMEOUT=60s
arkade install openfaas   --set gateway.upstreamTimeout=$TIMEOUT  \
 --set gateway.writeTimeout=$TIMEOUT \
 --set gateway.readTimeout=$TIMEOUT  \
 --set faasnetes.writeTimeout=$TIMEOUT  \
 --set faasnetes.readTimeout=$TIMEOUT  \
 --set queueWorker.ackWait=$TIMEOUT \
 --operator \
 --set gateway.directFunctions=false  \
 --set faasnetes.image=my-test-image-here
```

The go-long repo from the docs then worked as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
