### PR TITLE
Update Cron Connector docs to refer to OpenFaaS repository

### DIFF
--- a/chart/cron-connector/README.md
+++ b/chart/cron-connector/README.md
@@ -34,11 +34,11 @@ helm upgrade --namespace openfaas \
 
 cron-connector options in values.yaml
 
-| Parameter     | Description                                      | Default                          |
-|---------------|--------------------------------------------------|----------------------------------|
-| `image`       | The cron-connector image that should be deployed | `zeerorg/cron-connector:v0.2.2`  |
-| `gateway_url` | The URL for the API gateway.                     | `"http://gateway.openfaas:8080"` |
-| `basic_auth`  | Enable or disable basic auth                     | `true`                           |
+| Parameter     | Description                                      | Default                                  |
+|---------------|--------------------------------------------------|------------------------------------------|
+| `image`       | The cron-connector image that should be deployed | `ghcr.io/openfaas/cron-connector:0.3.2`  |
+| `gateway_url` | The URL for the API gateway.                     | `"http://gateway.openfaas:8080"`         |
+| `basic_auth`  | Enable or disable basic auth                     | `true`                                   |
 
 ## Removing the cron-connector
 

--- a/chart/cron-connector/templates/NOTES.txt
+++ b/chart/cron-connector/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Please follow the instructions below to get you started.
 
-https://github.com/zeerorg/cron-connector/blob/master/README.md
+https://github.com/openfaas/cron-connector/blob/master/README.md
 
 You can watch the Connector logs to see it invoke your functions:
 


### PR DESCRIPTION
## Description
Cron Connector development happens in the OpenFaaS repository now, so when installing via helm chart documentation links should refer to appropriate location.

## Motivation and Context
When installing the Cron Connector via the chart, I was provided a link to the original repository, however the image in the chart is built via the OpenFaaS repository. The original link also shows up when installing via arkade (due to it using this helm chart)

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
I clicked on the link to ensure that there were no typos.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
