### PR TITLE
Log and run each informer explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build local push namespaces install charts start-kind stop-kind build-buildx render-charts
 TAG?=latest
+OWNER?=openfaas
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 all: build-docker
@@ -9,7 +10,7 @@ local:
 
 build-docker:
 	docker build \
-	-t ghcr.io/openfaas/faas-netes:$(TAG) .
+	-t ghcr.io/$(OWNER)/faas-netes:$(TAG) .
 
 .PHONY: build-buildx
 build-buildx:
@@ -17,7 +18,7 @@ build-buildx:
 	docker buildx build \
 		--output "type=docker,push=false" \
 		--platform linux/amd64 \
-		--tag ghcr.io/openfaas/faas-netes:$(TAG) \
+		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
 		.
 
 .PHONY: build-buildx-all
@@ -26,11 +27,21 @@ build-buildx-all:
 	docker buildx build \
 		--platform linux/amd64,linux/arm/v7,linux/arm64 \
 		--output "type=image,push=false" \
-		--tag ghcr.io/openfaas/faas-netes:$(TAG) \
+		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
+		.
+
+.PHONY: publish-buildx-all
+publish-buildx-all:
+	@echo  ghcr.io/$(OWNER)/faas-netes:$(TAG) && \
+	docker buildx create --use --name=multiarch --node=multiarch && \
+	docker buildx build \
+		--platform linux/amd64,linux/arm/v7,linux/arm64 \
+		--push=true \
+		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
 		.
 
 push:
-	docker push ghcr.io/openfaas/faas-netes:$(TAG)
+	docker push ghcr.io/$(OWNER)/faas-netes:$(TAG)
 
 namespaces:
 	kubectl apply -f namespaces.yml

--- a/contrib/qemu.sh
+++ b/contrib/qemu.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Support multi-arch builds with buildx on a Linux host.
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,13 +12,13 @@ import (
 	"github.com/openfaas/faas-netes/pkg/k8s"
 	faasnetesk8s "github.com/openfaas/faas-netes/pkg/k8s"
 	bootstrap "github.com/openfaas/faas-provider"
+	v1apps "k8s.io/client-go/listers/apps/v1"
 
 	"github.com/openfaas/faas-provider/logs"
 	"github.com/openfaas/faas-provider/proxy"
 	"github.com/openfaas/faas-provider/types"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	appsinformer "k8s.io/client-go/informers/apps/v1"
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	glog "k8s.io/klog"
@@ -34,7 +34,7 @@ const defaultWriteTimeout = 8
 func New(client clientset.Interface,
 	kube kubernetes.Interface,
 	endpointsInformer coreinformer.EndpointsInformer,
-	deploymentsInformer appsinformer.DeploymentInformer,
+	deploymentLister v1apps.DeploymentLister,
 	clusterRole bool,
 	cfg config.BootstrapConfig) *Server {
 
@@ -51,7 +51,6 @@ func New(client clientset.Interface,
 	lister := endpointsInformer.Lister()
 	functionLookup := k8s.NewFunctionLookup(functionNamespace, lister)
 
-	deploymentLister := deploymentsInformer.Lister()
 	bootstrapConfig := types.FaaSConfig{
 		ReadTimeout:  cfg.FaaSConfig.ReadTimeout,
 		WriteTimeout: cfg.FaaSConfig.WriteTimeout,


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Log and run each informer explicitly

## Motivation and Context

Since adding a wait for the cache to sync for Kubernetes endpoints,
there appears to be conditions where the code waits indefinitely.


The issue can be reproduced by scaling the gateway to zero replicas
and back to 1, some of the time it passes the sync, other times
it gets stuck.

## How Has This Been Tested?

This patch appears to fix the problem and has been tested in
controller and operator mode on an RPi 4x node cluster and
with k3d with hey running a load test into the nodeinfo function
with a minimum of 10 replicas.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

* Moves informer code into one block with more detailed logging
* Increases the rate limits for the controller

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
