### PR TITLE
Add namespace to Prometheus Role

### DIFF
--- a/chart/openfaas/templates/prometheus-rbac.yaml
+++ b/chart/openfaas/templates/prometheus-rbac.yaml
@@ -83,6 +83,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}


### PR DESCRIPTION

## Description
The `helm template` command does not output a Prometheus Role with a namespace, and will cause the prometheus deployment to crash. This PR adds a namespace to the helm template.


## Motivation and Context
See the corresponding [issue](https://github.com/openfaas/faas-netes/issues/766)
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
This has been tested by following the steps in the [issue](https://github.com/openfaas/faas-netes/issues/766).
Namely,
1. ./contrib/create_cluster.sh
2. Create a basic auth secret
3. Apply the template `helm template openfaas ./chart/openfaas --namespace openfaas | kubectl apply -f -`

The old setup also works with `helm upgrade --install`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
This is not testable with the current infrastructure. But could be with the setup referred to in this [ issue](https://github.com/openfaas/faas-netes/issues/710)
Open to discussion here
- [x] All new and existing tests passed.
