### PR TITLE
add createdAt field in the responses for /system/functions and /system/function/FUNCNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can deploy OpenFaaS to any Kubernetes service - whether managed or local, in
 
 [OpenFaaS (Functions as a Service)](https://github.com/openfaas/faas) is a framework for building serverless functions with Docker and Kubernetes which has first class support for metrics. Any process can be packaged as a function enabling you to consume a range of web events without repetitive boiler-plate coding.
 
-<img alt="OpenFaaS workflow" src="https://raw.githubusercontent.com/openfaas/faas/master/docs/of-workflow.png"></img>                                       
+<img alt="OpenFaaS workflow" src="https://raw.githubusercontent.com/openfaas/faas/master/docs/of-workflow.png"></img>
 > Pictured: [OpenFaaS conceptual architecture](https://docs.openfaas.com/architecture/stack/)
 
 ## Highlights

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/onsi/gomega v1.8.1 // indirect
 	github.com/openfaas/faas-provider v0.17.3
-	github.com/openfaas/faas/gateway v0.0.0-20210210182948-7763fa5d6fc0
+	github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
 	google.golang.org/appengine v1.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,11 +293,10 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/openfaas/faas-provider v0.16.2/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/openfaas/faas-provider v0.17.3 h1:LN76lrXUKAx27o5X8l+daKWEzsdiW2E99jMOlI1SO5Q=
 github.com/openfaas/faas-provider v0.17.3/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
-github.com/openfaas/faas/gateway v0.0.0-20210210182948-7763fa5d6fc0 h1:Djl/fZal7NgWeaH7+hPAUSWhMSEVJEGCE9nWoLXrWWw=
-github.com/openfaas/faas/gateway v0.0.0-20210210182948-7763fa5d6fc0/go.mod h1:3owU3zBHBIEBJ8gzqFOJJIzI/Ha3V/QCR4JblgY5bx0=
+github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285 h1:oLrTwALS1EyjvG5AXZQM43CDZPNXoIcjDpeAK3UG/yM=
+github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285/go.mod h1:ZZUyq1Ghd3zvhKvSWfXelAsvbUxWP1TqWtvapP4701Q=
 github.com/openfaas/nats-queue-worker v0.0.0-20200512211843-8e9eefd5a320/go.mod h1:BfT8MB890hbhbtPid+X/oU0HAznGFS581NiG2hkr8Rc=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=

--- a/pkg/k8s/function_status.go
+++ b/pkg/k8s/function_status.go
@@ -32,6 +32,7 @@ func AsFunctionStatus(item appsv1.Deployment) *types.FunctionStatus {
 		Annotations:       &item.Spec.Template.Annotations,
 		Namespace:         item.Namespace,
 		Secrets:           ReadFunctionSecretsSpec(item),
+		CreatedAt:         item.CreationTimestamp.Time,
 	}
 
 	for _, v := range functionContainer.Env {

--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -35,8 +35,6 @@ func makeListHandler(defaultNamespace string,
 			return
 		}
 
-		functions := []types.FunctionStatus{}
-
 		opts := metav1.ListOptions{}
 		res, err := client.OpenfaasV1().Functions(lookupNamespace).List(r.Context(), opts)
 		if err != nil {
@@ -46,8 +44,8 @@ func makeListHandler(defaultNamespace string,
 			return
 		}
 
+		functions := []types.FunctionStatus{}
 		for _, item := range res.Items {
-
 			desiredReplicas, availableReplicas, err := getReplicas(item.Spec.Name, lookupNamespace, deploymentLister)
 			if err != nil {
 				glog.Warningf("Function listing getReplicas error: %v", err)

--- a/pkg/server/replicas.go
+++ b/pkg/server/replicas.go
@@ -139,6 +139,7 @@ func toFunctionStatus(item ofv1.Function) types.FunctionStatus {
 		Secrets:                item.Spec.Secrets,
 		Constraints:            item.Spec.Constraints,
 		ReadOnlyRootFilesystem: item.Spec.ReadOnlyRootFilesystem,
+		CreatedAt:              item.CreationTimestamp.Time,
 	}
 
 	if item.Spec.Environment != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/openfaas/faas-provider/httputil
 github.com/openfaas/faas-provider/logs
 github.com/openfaas/faas-provider/proxy
 github.com/openfaas/faas-provider/types
-# github.com/openfaas/faas/gateway v0.0.0-20210210182948-7763fa5d6fc0
+# github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285
 ## explicit
 github.com/openfaas/faas/gateway/requests
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
## Description
Adds the field `createdAt` in the responses call for `/system/functions` and `/systems/function/FUNCNAME`

examples:

```json
[
    {
        "name": "sleep",
        "image": "ghcr.io/openfaas/sleep:latest",
        "namespace": "openfaas-fn",
        "labels": {
            "faas_function": "sleep"
        },
        "annotations": {
            "prometheus.io.scrape": "false"
        },
        "replicas": 1,
        "availableReplicas": 1,
        "createdAt": "2021-03-17T12:04:05Z"
    },
    {
        "name": "nodeinfo",
        "image": "ghcr.io/openfaas/nodeinfo:latest",
        "namespace": "openfaas-fn",
        "labels": {
            "faas_function": "nodeinfo"
        },
        "annotations": {
            "prometheus.io.scrape": "false"
        },
        "replicas": 1,
        "availableReplicas": 1,
        "createdAt": "2021-03-17T12:04:08Z"
    }
]
```


```json
{
    "name": "nodeinfo",
    "image": "ghcr.io/openfaas/nodeinfo:latest",
    "namespace": "openfaas-fn",
    "labels": {
        "faas_function": "nodeinfo"
    },
    "annotations": {
        "prometheus.io.scrape": "false"
    },
    "replicas": 1,
    "availableReplicas": 1,
    "createdAt": "2021-03-17T12:04:08Z"
}
```

**NOTE**: to this change works it needs a new release of Faas/gateway and update the manifest/values (ie https://github.com/openfaas/faas-netes/blob/master/chart/openfaas/values.yaml#L70)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: https://github.com/openfaas/faas-netes/issues/771


## How Has This Been Tested?
For configuring the environment you can follow this guide: https://blog.alexellis.io/how-i-test-openfaas-with-kubernetes/

but these are the steps:
1. create a Kind cluster
2. deploy the current/stable openfaas with arkade  -> `$arkade install openfaas`
3. deploy one or more functions -> `faas-cli store deploy sleep` / `faas-cli store deploy nodeinfo`
4. Port forward the gateway pod to your host -> `k port-forward -n openfaas gateway-c8646545d-lrdls 8080:8080`
5. get the existing functions by hitting the API endpoint -> ` curl -u admin:YOUR_OPENFAAS_PASWD http://localhost:8080/system/functions | jq .`

It will get something like, and no `createAt` field

```json
[
  {
    "name": "sleep",
    "image": "ghcr.io/openfaas/sleep:latest",
    "namespace": "openfaas-fn",
    "labels": {
      "faas_function": "sleep"
    },
    "annotations": {
      "prometheus.io.scrape": "false"
    },
    "replicas": 1,
    "availableReplicas": 1
  }
]
```

6. deploy this PR change (can the existing image from `ctadeu/faas-netes:GH772`)

```shell
$ arkade install openfaas \
  --set faasnetes.image=ctadeu/faas-netes:GH772 \
  --set gateway.image=ghcr.io/openfaas/gateway:0.20.12
```
need to update the gateway because in the version it supports the new fields


7. get the functions again -> `curl -u admin:YOUR_OPENFAAS_PASWD http://localhost:8080/system/functions | jq .`
note now you can see the `createdAt` field

```json
[
  {
    "name": "sleep",
    "image": "ghcr.io/openfaas/sleep:latest",
    "namespace": "openfaas-fn",
    "labels": {
      "faas_function": "sleep"
    },
    "annotations": {
      "prometheus.io.scrape": "false"
    },
    "replicas": 1,
    "availableReplicas": 1,
    "createdAt": "2021-03-25T12:17:44Z"
  }
]
```

you can do the same now using the operator mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
