### PR TITLE
Feat remove node selectors from helm chart

### DIFF
--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -6,8 +6,7 @@ createCRDs: true
 # See https://www.openfaas.com/support for more
 openfaasPRO: false
 
-nodeSelector:
-  beta.kubernetes.io/arch: arm64
+nodeSelector: {}
 
 gateway:
   directFunctions: true

--- a/chart/openfaas/values-arm64.yaml
+++ b/chart/openfaas/values-arm64.yaml
@@ -1,46 +1,11 @@
-basic_auth: true
-
-clusterRole: false
-createCRDs: true
-
-# See https://www.openfaas.com/support for more
-openfaasPRO: false
-
-nodeSelector: {}
 
 gateway:
   directFunctions: true
 
-oidcAuthPlugin:
-  enabled: false
-
-operator:
-  create: false
-
-queueWorker:
-  image: openfaas/queue-worker:0.11.2
-
 prometheus:
-  image: prom/prometheus:v2.11.0
   resources:
     requests:
       memory: "100Mi"
 
-alertmanager:
-  image: prom/alertmanager:v0.18.0
-
-faasIdler:
-  replicas: 1
-  image: ghcr.io/openfaas/faas-idler-pro:0.5.0
-
 basicAuthPlugin:
   image: openfaas/basic-auth-plugin:0.20.1-arm64
-  replicas: 1
-
-ingressOperator:
-  create: false
-
-# Unfortunately the exporter is not multi-arch (yet)
-nats:
-  metrics:
-    enabled: false

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -1,46 +1,11 @@
-basic_auth: true
-
-clusterRole: false
-createCRDs: true
-
-# See https://www.openfaas.com/support for more
-openfaasPRO: false
-
-nodeSelector: {}
 
 gateway:
   directFunctions: true
 
-oidcAuthPlugin:
-  enabled: false
-
-operator:
-  create: false
-
-queueWorker:
-  image: openfaas/queue-worker:0.11.2
-
 prometheus:
-  image: prom/prometheus:v2.11.0
   resources:
     requests:
       memory: "100Mi"
 
-alertmanager:
-  image: prom/alertmanager:v0.18.0
-
-faasIdler:
-  replicas: 1
-  image: ghcr.io/openfaas/faas-idler-pro:0.5.0
-
 basicAuthPlugin:
   image: openfaas/basic-auth-plugin:0.20.1-armhf
-  replicas: 1
-
-ingressOperator:
-  create: false
-
-# Unfortunately the exporter is not multi-arch (yet)
-nats:
-  metrics:
-    enabled: false

--- a/chart/openfaas/values-armhf.yaml
+++ b/chart/openfaas/values-armhf.yaml
@@ -6,8 +6,7 @@ createCRDs: true
 # See https://www.openfaas.com/support for more
 openfaasPRO: false
 
-nodeSelector:
-  beta.kubernetes.io/arch: arm
+nodeSelector: {}
 
 gateway:
   directFunctions: true

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -54,7 +54,7 @@ oidcAuthPlugin:
 # Requires openfaasPRO=true
 # scale-to-zero feature
 faasIdler:
-  image: ghcr.io/openfaas/faas-idler-pro:0.4.2
+  image: ghcr.io/openfaas/faas-idler-pro:0.5.0
   replicas: 1
   create: true
   inactivityDuration: 30m               # If a function is inactive for 15 minutes, it may be scaled to zero
@@ -171,6 +171,7 @@ nats:
   image: nats-streaming:0.17.0
   enableMonitoring: false
   metrics:
+    # Should stay off by default because the exporter is not multi-arch (yet)
     enabled: false
     image: synadia/prometheus-nats-exporter:0.6.2
   resources:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -172,7 +172,7 @@ nats:
   enableMonitoring: false
   metrics:
     enabled: false
-    image: synadia/prometheus-nats-exporter:0.6.2 
+    image: synadia/prometheus-nats-exporter:0.6.2
   resources:
     requests:
       memory: "120Mi"
@@ -201,8 +201,7 @@ ingressOperator:
     requests:
       memory: "25Mi"
 
-nodeSelector:
-  beta.kubernetes.io/arch: amd64
+nodeSelector: {}
 
 tolerations: []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Remove the nodeSelector value from each of the values files in the
  helm chart. Now that we are using multi-arch builds for all of the
  services, the same configuration (specifically the same image name)
  is valid on any node type (amd64, arm64, and arm). As a result, we
  do not need to specify the node selector to ensure that the image is
  run on a compatible node, the node will automatically pull the correct
  variation of the image.
- This will simplify the integration of the microk8s addon for arm
  systems because the default installation will "just work"
- Reduce duplication of values in the values file for arm and armhf.
  This should make it easier to maintain because these settings are
  valid in any deployment. The values that remain in the arm and armhf
  files are the image name for the basic auth plugin, this one is not
  yet multi-arch, but once it is, we can remove this.
  The prometheus resources also request less memory so that the default
  fits better on a raspberry pi

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#781 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use this command to render the chart on `master` and this branch, then used diff to detect any changes. For each values file, the only difference is the nodeSelector is now removed.  For example:

```sh
$ helm template ./chart/openfaas --values ./chart/openfaas/values.yaml --values ./chart/openfaas/values-arm64.yaml > arm64.yml
$ git checkout master
$ helm template ./chart/openfaas --values ./chart/openfaas/values.yaml --v
alues ./chart/openfaas/values-arm64.yaml > arm64-old.yml
$ diff arm64.yml arm64-old.yml
1378a1379,1380
>       nodeSelector:
>         beta.kubernetes.io/arch: arm64
1441a1444,1445
>       nodeSelector:
>         beta.kubernetes.io/arch: arm64
1585a1590,1591
>       nodeSelector:
>         beta.kubernetes.io/arch: arm64
1627a1634,1635
>       nodeSelector:
>         beta.kubernetes.io/arch: arm64
1699a1708,1709
>       nodeSelector:
>         beta.kubernetes.io/arch: arm64
1761a1772,1773
>       nodeSelector:
>         beta.kubernetes.io/arch: arm64
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
