### PR TITLE
Fix 714 support for istio

### DIFF
--- a/chart/kafka-connector/templates/deployment.yml
+++ b/chart/kafka-connector/templates/deployment.yml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: {{ template "connector.name" . }}
         component: kafka-connector

--- a/chart/mqtt-connector/templates/deployment.yml
+++ b/chart/mqtt-connector/templates/deployment.yml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: {{ template "connector.fullname" . }}
         component: mqtt-connector

--- a/chart/nats-connector/templates/deployment.yml
+++ b/chart/nats-connector/templates/deployment.yml
@@ -23,11 +23,11 @@ spec:
     matchLabels:
       app: {{ template "connector.name" . }}
       component: nats-connector
-  
+
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        /scrape: "false"
       labels:
         app: {{ template "connector.name" . }}
         component: nats-connector

--- a/chart/nats-connector/templates/deployment.yml
+++ b/chart/nats-connector/templates/deployment.yml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        /scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: {{ template "connector.name" . }}
         component: nats-connector

--- a/chart/openfaas/templates/basic-auth-plugin-dep.yaml
+++ b/chart/openfaas/templates/basic-auth-plugin-dep.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: basic-auth-plugin
     spec:

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: faas-idler
     spec:

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -18,8 +18,8 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "true"
-        prometheus.io.port: "8082"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8082"
       labels:
         app: gateway
     spec:

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "true"
+        prometheus.io/scrape: "true"
       labels:
         app: ingress-operator
     spec:

--- a/chart/openfaas/templates/istio-mtls.yaml
+++ b/chart/openfaas/templates/istio-mtls.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   mtls:
     mode: STRICT
+{{- if ne .Release.Namespace $functionNs }}
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
@@ -17,60 +18,5 @@ metadata:
 spec:
   mtls:
     mode: STRICT
----
-# enforce mTLS to openfaas control plane
-apiVersion: authentication.istio.io/v1alpha1
-kind: Policy
-metadata:
-    name: default
-    namespace: {{ .Release.Namespace }}
-spec:
-    peers:
-        - mtls: {}
----
-# enforce mTLS to openfaas control plane
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-    name: default
-    namespace: {{ .Release.Namespace }}
-spec:
-    host: "*.{{ .Release.Namespace }}.svc.cluster.local"
-    trafficPolicy:
-        tls:
-            mode: ISTIO_MUTUAL
----
-# enforce mTLS to functions
-apiVersion: authentication.istio.io/v1alpha1
-kind: Policy
-metadata:
-    name: default
-    namespace: {{ $functionNs }}
-spec:
-    peers:
-        - mtls: {}
----
-# enforce mTLS to functions
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-    name: default
-    namespace: {{ $functionNs | quote }}
-spec:
-    host: "*.{{ $functionNs }}.svc.cluster.local"
-    trafficPolicy:
-        tls:
-            mode: ISTIO_MUTUAL
----
-# disable mTLS to nats, the nats protocol is not supported by Istio
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-    name: "nats-no-mtls"
-    namespace: {{ .Release.Namespace }}
-spec:
-    host: "nats.{{ .Release.Namespace }}.svc.cluster.local"
-    trafficPolicy:
-        tls:
-            mode: DISABLE
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/chart/openfaas/templates/istio-mtls.yaml
+++ b/chart/openfaas/templates/istio-mtls.yaml
@@ -1,5 +1,23 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 {{- if .Values.istio.mtls -}}
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: {{ .Release.Namespace }}
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace:  {{ $functionNs }}
+spec:
+  mtls:
+    mode: STRICT
+---
 # enforce mTLS to openfaas control plane
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -18,7 +18,6 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "false"
         prometheus.io/scrape: {{ .Values.nats.metrics.enabled | quote }}
         {{- if .Values.nats.metrics.enabled }}
         prometheus.io/port: "7777"

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -19,10 +19,10 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        prometheus.io.scrape: {{ .Values.nats.metrics.enabled | quote }}
+        prometheus.io/scrape: {{ .Values.nats.metrics.enabled | quote }}
         {{- if .Values.nats.metrics.enabled }}
-        prometheus.io.port: "7777"
-        {{- end }} 
+        prometheus.io/port: "7777"
+        {{- end }}
       labels:
         app: nats
     spec:

--- a/chart/openfaas/templates/nats-svc.yaml
+++ b/chart/openfaas/templates/nats-svc.yaml
@@ -16,7 +16,7 @@ spec:
   ports:
     - port: 4222
       protocol: TCP
-      name: clients
+      name: tcp
     {{- if .Values.nats.enableMonitoring }}
     - port: 8222
       protocol: TCP

--- a/chart/openfaas/templates/oauth2-plugin-dep.yaml
+++ b/chart/openfaas/templates/oauth2-plugin-dep.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: oauth2-plugin
     spec:

--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -57,6 +57,11 @@ data:
           regex: ([^:]+)(?::\d+)?;(\d+)
           replacement: $1:$2
           target_label: __address__
+        - action: replace
+          regex: (.+)
+          source_labels:
+          - __meta_kubernetes_pod_annotation_prometheus_io_path
+          target_label: __metrics_path__
 
     alerting:
       alertmanagers:

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io.scrape: "false"
+        prometheus.io/scrape: "false"
       labels:
         app: queue-worker
     spec:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apply the suggested patches from #714 to the helm chart

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #714

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See the comments from #714, specifically https://github.com/openfaas/faas-netes/issues/714#issuecomment-817277705

```sh
$ kind create cluster
$ istioctl install -y
$ kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
$ kubectl label namespace openfaas istio-injection=enabled --overwrite
$ kubectl label namespace openfaas-fn istio-injection=enabled --overwrite
$ helm upgrade openfaas --install ./chart/openfaas \
    --namespace openfaas \
    --set functionNamespace=openfaas-fn \
    --set generateBasicAuth=true \
    --set gateway.directFunctions=true \
    --set openfaasPRO=false \
    --wait

$ kubectl port-forward -n openfaas svc/gateway 8080:8080 &

$ faas-cli login \
    -u admin \
    -p  (kubectl -n openfaas get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode)

$ faas-cli store deploy nodeinfofaa
$ faas-cli invoke nodeinfo
Reading from STDIN - hit (Control + D) to stop.
Hostname: nodeinfo-857d9c469b-5x2f2

Arch: x64
CPUs: 8
Total mem: 15702MB
Platform: linux
Uptime: 181475

$ faas-cli logs nodeinfo
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Version: 0.8.4	SHA: bbd2e96214264d6b87cc97745ee9f604776dd80f
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Forking: node, arguments: [index.js]
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Started logging: stderr from function.
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Started logging: stdout from function.
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Watchdog mode: http
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Timeouts: read: 15s, write: 15s hard: 10s.
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Listening on port: 8080
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Writing lock-file to: /tmp/.lock
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Metrics listening on port: 8081
2021-05-15T12:39:56Z node12 listening on port: 3000
2021-05-15T12:40:17Z 2021/05/15 12:40:17 POST / - 200 OK - ContentLength: 105

$ faas-cli invoke nodeinfo -a
$ faas-cli logs nodeinfo
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Version: 0.8.4	SHA: bbd2e96214264d6b87cc97745ee9f604776dd80f
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Forking: node, arguments: [index.js]
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Started logging: stderr from function.
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Started logging: stdout from function.
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Watchdog mode: http
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Timeouts: read: 15s, write: 15s hard: 10s.
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Listening on port: 8080
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Writing lock-file to: /tmp/.lock
2021-05-15T12:39:56Z 2021/05/15 12:39:56 Metrics listening on port: 8081
2021-05-15T12:39:56Z node12 listening on port: 3000
2021-05-15T12:40:17Z 2021/05/15 12:40:17 POST / - 200 OK - ContentLength: 105
2021-05-15T12:41:52Z 2021/05/15 12:41:52 POST / - 200 OK - ContentLength: 105
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
