### PR TITLE
fix: Improve the error behavior in make start-kind

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,6 @@ You can use `OF_DEV_ENV` to set a custom name for the cluster. The default value
 As you are developing on `faas-netes`, you will want to build and test your own local images.  This can easily be done using the following commands
 
 ```sh
-export KUBECONFIG="$(kind get kubeconfig-path --name="${OF_DEV_ENV:-kind}")"
-
 make build
 
 kind load docker-image --name="${OF_DEV_ENV:-kind}" openfaas/faas-netes:latest

--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,7 @@ render-charts:
 	./contrib/create-static-manifest.sh ./chart/openfaas ./yaml_armhf ./chart/openfaas/values-armhf.yaml
 
 start-kind: ## attempt to start a new dev environment
-	@./contrib/create_dev.sh \
-		&& echo "" \
-		&& printf '%-15s:\t %s\n' 'Web UI' 'http://localhost:31112/ui' \
-		&& printf '%-15s:\t %s\n' 'User' 'admin' \
-		&& printf '%-15s:\t %s\n' 'Password' $(shell cat password.txt) \
-		&& printf '%-15s:\t %s\n' 'CLI Login' "faas-cli login --username admin --password $(shell cat password.txt)"
+	@./contrib/create_dev.sh
 
 stop-kind: ## attempt to stop the dev environment
 	@./contrib/stop_dev.sh

--- a/contrib/create_cluster.sh
+++ b/contrib/create_cluster.sh
@@ -3,9 +3,25 @@
 DEVENV=${OF_DEV_ENV:-kind}
 KUBE_VERSION=v1.18.8
 
-echo ">>> Creating Kubernetes ${KUBE_VERSION} cluster ${DEVENV}"
+EXISTS=$(kind get clusters | grep "$DEVENV")
 
-kind create cluster --wait 5m --image kindest/node:${KUBE_VERSION} --name "$DEVENV" -v 1
+if [ "$EXISTS" = "$DEVENV" ]; then
+    while true; do
+    read -p "Kind cluster '$DEVENV' already exists, do you want to continue with this cluster? (yes/no) " yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit 1;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+fi
+
+
+if [ "$EXISTS" != "$DEVENV" ]; then
+    echo ">>> Creating Kubernetes ${KUBE_VERSION} cluster ${DEVENV}"
+
+    kind create cluster --wait 5m --image kindest/node:${KUBE_VERSION} --name "$DEVENV" -v 1
+fi
 
 echo ">>> Waiting for CoreDNS"
 kubectl --context "kind-$DEVENV" -n kube-system rollout status deployment/coredns

--- a/contrib/create_dev.sh
+++ b/contrib/create_dev.sh
@@ -2,6 +2,16 @@
 
 # Creates an installation of OpenFaaS in kind for development
 
-contrib/create_cluster.sh
+set -e
+contrib/create_cluster.sh || exit 0;
 contrib/deploy.sh
 contrib/run_function.sh
+
+cd "$(git rev-parse --show-toplevel)"
+echo ""
+echo ""
+echo "Local dev cluster details:"
+printf '%-10s:\t %s\n' 'Web UI' 'http://localhost:8080/ui'
+printf '%-10s:\t %s\n' 'User' 'admin'
+printf '%-10s:\t %s\n' 'Password' "$(cat password.txt)"
+printf '%-10s:\t %s\n' 'CLI Login' "faas-cli login --username admin --password $(cat password.txt)"

--- a/contrib/deploy.sh
+++ b/contrib/deploy.sh
@@ -5,6 +5,7 @@ set -e
 DEVENV=${OF_DEV_ENV:-kind}
 OPERATOR=${OPERATOR:-0}
 
+echo ""
 echo "Applying namespaces"
 kubectl --context "kind-$DEVENV" apply -f ./namespaces.yml
 
@@ -17,18 +18,25 @@ if [ -x "$(command -v $sha_cmd)" ]; then
     sha_cmd="shasum"
 fi
 
-PASSWORD=$(head -c 16 /dev/urandom| $sha_cmd | cut -d " " -f 1)
-echo -n $PASSWORD > password.txt
+PASSWORD_EXISTS=$(kubectl get secret -n openfaas basic-auth | wc -c)
+if [ $PASSWORD_EXISTS -eq 0 ]; then
+    PASSWORD=$(head -c 16 /dev/urandom| $sha_cmd | cut -d " " -f 1)
+    echo -n $PASSWORD > password.txt
 
-kubectl --context "kind-$DEVENV" -n openfaas create secret generic basic-auth \
---from-literal=basic-auth-user=admin \
---from-literal=basic-auth-password="$PASSWORD"
+    kubectl --context "kind-$DEVENV" -n openfaas create secret generic basic-auth \
+    --from-literal=basic-auth-user=admin \
+    --from-literal=basic-auth-password="$PASSWORD"
+else
+    PASSWORD=$(kubectl get secret -n openfaas basic-auth -o=go-template='{{index .data "basic-auth-password"}}' | base64 --decode)
+    echo -n $PASSWORD > password.txt
+fi
 
 CREATE_OPERATOR=false
 if [ "${OPERATOR}" == "1" ]; then
     CREATE_OPERATOR="true"
 fi
 
+echo ""
 echo "Waiting for helm install to complete."
 
 helm upgrade \

--- a/contrib/run_function.sh
+++ b/contrib/run_function.sh
@@ -13,21 +13,30 @@ then
 fi
 
 if [ -f "of_${DEVENV}_portforward.pid" ]; then
-    kill $(<of_${DEVENV}_portforward.pid)
+    kill "$(<of_${DEVENV}_portforward.pid)" > /dev/null 2> /dev/null || :
 fi
 
 # quietly start portforward and put it in the background, it will not
 # print every connection handled
-kubectl --context "kind-$DEVENV" port-forward deploy/gateway -n openfaas 31112:8080 &>/dev/null & \
+kubectl --context "kind-$DEVENV" port-forward deploy/gateway -n openfaas 8080:8080 &>/dev/null & \
     echo -n "$!" > "of_${DEVENV}_portforward.pid"
 
 # port-forward needs some time to start
 sleep 10
 
-export OPENFAAS_URL=http://127.0.0.1:31112
+export OPENFAAS_URL=http://127.0.0.1:8080
 
 # Login into the gateway
+echo ""
+echo "Login to the gateway..."
 cat ./password.txt | faas-cli login --username admin --password-stdin
+
+IS_DEPLOYED=$(faas-cli list | grep echo | wc -c)
+if [ $IS_DEPLOYED -gt 0 ];then
+    echo ""
+    echo "test function 'echo' already deployed"
+    exit;
+fi
 
 # Deploy via the REST API which can test either the controller or operator
 faas-cli deploy --image=functions/alpine:latest --fprocess=cat --name "echo"


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Add various checks for existing data and ask for user input before
continuing during the cluster creation.

Ignore certain errors, such as killing the port-forward, it is ok for
this command to fail because it indicates that the background task is
already stopped.

Improve the formatting of the output to make it easier to read.

Change the port-forward to 8080 instead of 31112 so that the default faas-cli behavior works as expected, meaning the default gateway value (localhots:8080) will work.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #797

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run the `make start-kind` command locally, if a cluster already exists (for example you run the command twice) the output will look like 

```sh
Kind cluster 'kind' already exists, do you want to continue with this cluster? (yes/no) yes
>>> Waiting for CoreDNS
deployment "coredns" successfully rolled out

Applying namespaces
namespace/openfaas unchanged
namespace/openfaas-fn unchanged
Waiting for helm install to complete.
Release "openfaas" has been upgraded. Happy Helming!
NAME: openfaas
LAST DEPLOYED: Sat May 22 10:00:08 2021
NAMESPACE: openfaas
STATUS: deployed
REVISION: 10
TEST SUITE: None
NOTES:
To verify that openfaas has started, run:

  kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"
deployment "prometheus" successfully rolled out
deployment "gateway" successfully rolled out
deployment "gateway" successfully rolled out

Login to the gateway...
Calling the OpenFaaS server to validate the credentials...
credentials saved for admin http://127.0.0.1:8080

test function 'echo' already deployed


Local dev cluster details:
Web UI    :	 http://localhost:8080/ui
User      :	 admin
Password  :	 30e9489a6570f440a8da0ad87fd375cdc082f7e8
CLI Login :	 faas-cli login --username admin --password 30e9489a6570f440a8da0ad87fd375cdc082f7e8
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
