### PR TITLE
Add support for binary data in secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ build-docker:
 
 .PHONY: build-buildx
 build-buildx:
-	@docker buildx create --use --name=multiarch --node=multiarch && \
+	@echo ghcr.io/$(OWNER)/faas-netes:$(TAG) && \
+	docker buildx create --use --name=multiarch --node=multiarch && \
 	docker buildx build \
-		--output "type=docker,push=false" \
+		--push \
 		--platform linux/amd64 \
 		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
 		.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/onsi/gomega v1.8.1 // indirect
-	github.com/openfaas/faas-provider v0.17.3
+	github.com/openfaas/faas-provider v0.18.5
 	github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/openfaas/faas-provider v0.17.3 h1:LN76lrXUKAx27o5X8l+daKWEzsdiW2E99jMOlI1SO5Q=
 github.com/openfaas/faas-provider v0.17.3/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
+github.com/openfaas/faas-provider v0.18.5 h1:y7CCkbh0dW9aWpRisXbjgG9MTZVrdiDKLNt7qqo8M5c=
+github.com/openfaas/faas-provider v0.18.5/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285 h1:oLrTwALS1EyjvG5AXZQM43CDZPNXoIcjDpeAK3UG/yM=
 github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285/go.mod h1:ZZUyq1Ghd3zvhKvSWfXelAsvbUxWP1TqWtvapP4701Q=
 github.com/openfaas/nats-queue-worker v0.0.0-20200512211843-8e9eefd5a320/go.mod h1:BfT8MB890hbhbtPid+X/oU0HAznGFS581NiG2hkr8Rc=

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -97,9 +97,16 @@ func (c secretClient) Create(secret types.Secret) error {
 				secretLabel: secretLabelValue,
 			},
 		},
-		StringData: map[string]string{
-			secret.Name: secret.Value,
-		},
+	}
+
+	if len(secret.RawValue) > 0 {
+		req.Data = map[string][]byte{
+			secret.Name: secret.RawValue,
+		}
+	} else {
+		req.Data = map[string][]byte{
+			secret.Name: []byte(secret.Value),
+		}
 	}
 
 	_, err = c.kube.Secrets(secret.Namespace).Create(context.TODO(), req, metav1.CreateOptions{})

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -2,6 +2,22 @@ package types
 
 import "time"
 
+// Secret for underlying orchestrator
+type Secret struct {
+	// Name of the secret
+	Name string `json:"name"`
+
+	// Namespace if applicable for the secret
+	Namespace string `json:"namespace,omitempty"`
+
+	// Value is a string representing the string's value
+	Value string `json:"value,omitempty"`
+
+	// RawValue can be used to provide binary data when
+	// Value is not set
+	RawValue []byte `json:"rawValue,omitempty"`
+}
+
 // FunctionDeployment represents a request to create or update a Function.
 type FunctionDeployment struct {
 
@@ -44,13 +60,6 @@ type FunctionDeployment struct {
 	// ReadOnlyRootFilesystem removes write-access from the root filesystem
 	// mount-point.
 	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem,omitempty"`
-}
-
-// Secret for underlying orchestrator
-type Secret struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace,omitempty"`
-	Value     string `json:"value,omitempty"`
 }
 
 // FunctionResources Memory and CPU

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/onsi/gomega v1.8.1
 ## explicit
-# github.com/openfaas/faas-provider v0.17.3
+# github.com/openfaas/faas-provider v0.18.5
 ## explicit
 github.com/openfaas/faas-provider
 github.com/openfaas/faas-provider/auth


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for binary data in secrets

## Motivation and Context

Through the RawValue field in the latest version of the
faas-provider, users can now input raw binary data when
creating secrets.

Previously, we attempted to solve this problem by adding a 
`--trim=false` flag to faas-cli, but as @LucasRoesler pointed out, 
this isn't sufficient because of the use of StringData on the 
Kubernetes API.

This is not a breaking change in that:

* RawValue is a new and optional field
* StringData was only a helper method used by Kubernetes to populate its own Data field which is of type []byte

## How Has This Been Tested?

Unit tests updated.

```bash
arkade install openfaas --set faasnetes.image=ghcr.io/alexellis/faas-netes:binary-secrets-1 --set openfaasImagePullPolicy=Always
```

Followed by:

```bash
faas-cli secret create alex --from-literal is-here

kubectl get secret -n openfaas-fn alex -o jsonpath='{.data.alex}' | base64 --decode;echo

is-here
```

For binary data:

```bash
echo raw-data |base64
cmF3LWRhdGEK

curl -i -X POST http://admin:$PASSWORD@127.0.0.1:8080/system/secrets --data-binary '{"name": "binary1", "rawValue": "cmF3LWRhdGEK", "namespace": "openfaas-fn"}'

kubectl get secret -n openfaas-fn binary1 -o jsonpath='{.data.binary1}' | base64 --decode

raw-data
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.

Once released, a change to the `faas-cli secret create` command will be needed to add a `--raw` flag.