### PR TITLE
Add support for Kafka authentication and TLS to helm chart

### DIFF
--- a/chart/kafka-connector/.gitignore
+++ b/chart/kafka-connector/.gitignore
@@ -1,0 +1,1 @@
+/ae-values.yaml

--- a/chart/kafka-connector/Chart.yaml
+++ b/chart/kafka-connector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Connect OpenFaaS functions to Kafka topics
 name: kafka-connector
-version: 0.5.1
+version: 0.6.0
 sources:
 - https://github.com/openfaas/kafka-connector
 home: https://www.openfaas.com

--- a/chart/kafka-connector/README.md
+++ b/chart/kafka-connector/README.md
@@ -14,17 +14,19 @@ The [Kafka connector](https://github.com/openfaas-incubator/kafka-connector) bri
 
 - Install OpenFaaS
 
-  You must have a working OpenFaaS installation. You can find [instructions in the docs](https://docs.openfaas.com/deployment/kubernetes/#pick-helm-or-yaml-files-for-deployment-a-or-b), including instructions to also install OpenFaaS via Helm.
+  You must have a working OpenFaaS installed.
 
-- Install Kafka for dev/testing
+- Self-hosted Kafka with Helm
 
-  You can install [Apache Kafka](https://kafka.apache.org/) using the [development instructions](development.md) for testing purposes.
+  For development and testing, you can install [Apache Kafka](https://kafka.apache.org/) using Confluent's [chart](https://github.com/confluentinc/cp-helm-charts). Find out additional options here: [available here](https://github.com/helm/charts/tree/master/incubator/kafka#installing-the-chart)
 
-- Install Kafka for production use
+- Hosted Kafka
 
-  You may already have a working Kafka installation, but if not you can provision it using Confluent's [chart](https://github.com/confluentinc/cp-helm-charts).
-  
-  Instructions for installing Apache Kafka via Helm are [available here](https://github.com/helm/charts/tree/master/incubator/kafka#installing-the-chart).
+  [Aiven](https://aiven.io/) and [Confluent Cloud](https://confluent.cloud/) have both been tested with the Kafka Connector.
+
+## Complete walk-through guide
+
+  You can continue with this guide, or start the [walk-through](development.md) for testing purposes.
 
 ## Install the Chart
 
@@ -56,6 +58,17 @@ $ helm upgrade kafka-connector ./chart/kafka-connector \
     --namespace openfaas
 ```
 
+## Encryption options
+
+1) TLS off (default)
+2) TLS on
+
+## Authentication options
+
+1) TLS with SASL using CA from the default trust store
+3) TLS with SASL using a custom CA
+4) TLS with client certificates
+
 ## Configuration
 
 Additional kafka-connector options in `values.yaml`.
@@ -64,13 +77,19 @@ Additional kafka-connector options in `values.yaml`.
 | ------------------------ | -------------------------------------------------------------------------------------- | ------------------------------ |
 | `topics`                 | Topics to which the connector will bind, provide as a comma-separated list.            | `faas-request`                 |
 | `brokerHost`             | location of the Kafka brokers.                                                         | `kafka`                        |
-| `asyncInvocation`        | For long running or slow functions, offload to asychronous function invocations and carry on processing the stream |
-| `upstreamTimeout`       | Maximum timeout for upstream function call, must be a Go formatted duration string.    | `30s`                          |
+| `asyncInvocation`        | For long running or slow functions, offload to asychronous function invocations and carry on processing the stream | `false`   |
+| `upstreamTimeout`        | Maximum timeout for upstream function call, must be a Go formatted duration string.    | `30s`                          |
 | `rebuildInterval`        | Interval for rebuilding function to topic map, must be a Go formatted duration string. | `3s`                           |
 | `gatewayURL`             | The URL for the API gateway.                                                           | `http://gateway.openfaas:8080` |
 | `printResponse`          | Output the response of calling a function in the logs.                                 | `true`                         |
-| `printResponseBody`      | Output to the logs the response body when calling a function.                                 | `false`                         |
+| `printResponseBody`      | Output to the logs the response body when calling a function.                          | `false`                        |
 | `fullnameOverride`       | Override the name value used for the Connector Deployment object.                      | ``                             |
+| `sasl`                   | Enable auth with a SASL username/password                                              | `false`                        |
+| `brokerPasswordSecret`   | Name of secret for SASL password                                                       | `kafka-broker-password`        |
+| `brokerUsernameSecret`   | Name of secret for SASL username                                                       | `kafka-broker-username`        |
+| `caSecret`               | Name secret for TLS CA - leave empty to disable                                        | `kafka-broker-ca`              |
+| `certSecret`             | Name secret for TLS client certificate cert - leave empty to disable                   | `kafka-broker-cert`            |
+| `keySecret`              | Name secret for TLS client certificate private key - leave empty to disable            | `kafka-broker-key`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. See `values.yaml` for the default configuration.
 

--- a/chart/kafka-connector/quickstart.md
+++ b/chart/kafka-connector/quickstart.md
@@ -1,4 +1,4 @@
-# Testing the Chart locally
+# Kafka PRO connector quickstart
 
 1.  Install Kafka in a separate namespace
 
@@ -55,36 +55,73 @@
   arkade install openfaas
   ```
 
-  Or
+  Or use helm
+
+3) Create any secrets required
+
+  Secrets are required for SASL or client certificate authentication, see the comments in the values.yaml file
+
+4) Install the connector:
+
+  Create `overrides.yaml` and configure as per comments in values.yaml
+
+  Example for Kafka helm chart:
+
+  ```yaml
+  brokerHost: kf-kafka:9092
+  tls: false
+  saslAuth: false
+
+  caSecret: ""
+  certSecret: ""
+  keySecret: ""
+  ```
+
+  Example for Aiven cloud with client certificates:
+
+  ```yaml
+  brokerHost: kafka-202504b5-openfaas-910b.aivencloud.com:10905
+  tls: true
+  saslAuth: false
+  
+  caSecret: kafka-broker-ca
+  certSecret: kafka-broker-cert
+  keySecret: kafka-broker-key
+  ```
+
+  Example for Confluent Cloud with Let's Encrypt and SASL auth:
+
+  ```yaml
+  brokerHost: pkc-4r297.europe-west1.gcp.confluent.cloud:9092
+  tls: true
+  saslAuth: true
+  
+  caSecret: ""
+  certSecret: ""
+  keySecret: ""
+  ```
+
+  Use the helm chart:
 
    ```sh
-   helm upgrade openfaas --install openfaas/openfaas \
-   --namespace openfaas  \
-   --set basic_auth=true \
-   --set functionNamespace=openfaas-fn
+   cd faas-netes/charts
+   
+   helm upgrade kafka-connector ./kafka-connector \
+       --install \
+       --namespace openfaas \
+       --values ./overrides.yaml
    ```
 
-3) Install the connector using the arkade app:
+  Or install with arkade:
 
    ```sh
    arkade install kafka-connector \
    --broker-host=kf-kafka:9092 \
    --license-file $HOME/.openfaas/LICENSE \
-   --topics faas-request \
-   --set image=alexellis/kafka-connector-pro:0.4.1-5-g551d268-dirty-amd64
-  ```
-
-4) Or install the connector from the faas-netes repo:
-
-   ```sh
-   cd charts
-   helm upgrade kafka-connector . \
-       --install \
-       --namespace openfaas \
-       --set broker_host=kf-kafka.kafka
+   --topics faas-request
    ```
 
-4) Trigger a function from a topic:
+5) Trigger a function from a topic:
 
    a. Deploy figlet
 
@@ -104,7 +141,7 @@
    kubectl -n openfaas logs deploy/kafka-connector -f
    ```
 
-5. If you need to reset your environment:
+6. If you need to reset your environment:
 
    ```sh
    faas remove figlet --gateway $GATEWAY

--- a/chart/kafka-connector/templates/deployment.yml
+++ b/chart/kafka-connector/templates/deployment.yml
@@ -31,21 +31,60 @@ spec:
         app: {{ template "connector.name" . }}
         component: kafka-connector
     spec:
-      {{- if .Values.basic_auth }}
       volumes:
-        - name: auth
-          secret:
-            secretName: basic-auth
         - name: openfaas-license
           secret:
             secretName: openfaas-license
+      {{- if .Values.basic_auth }}
+        - name: auth
+          secret:
+            secretName: basic-auth
       {{- end }}
+      {{- if.Values.saslAuth }}
+        - name: broker-username
+          secret:
+            secretName: {{ .Values.brokerUsernameSecret }}
+        - name: broker-password
+          secret:
+            secretName: {{ .Values.brokerPasswordSecret }}
+      {{- end }}
+      {{- if .Values.caSecret }}
+        - name: broker-ca
+          secret:
+            secretName: {{ .Values.caSecret }}
+      {{- end}}
+      {{- if .Values.certSecret }}
+        - name: broker-cert
+          secret:
+            secretName: {{ .Values.certSecret }}
+      {{- end}}
+      {{- if .Values.keySecret }}
+        - name: broker-key
+          secret:
+            secretName: {{ .Values.keySecret }}
+      {{- end}}
       containers:
         - name: connector
           image: {{ .Values.image }}
           command:
            - "/usr/bin/kafka-connector"
            - "-license-file=/var/secrets/license/license"
+           {{- if.Values.saslAuth }}
+           - "-username-file=/var/secrets/broker-username/broker-username"
+           - "-password-file=/var/secrets/broker-password/broker-password"
+           {{- end }}
+           {{- if .Values.tls }}
+           - "-tls"
+           {{- end }}
+           {{- if .Values.caSecret }}
+           - "-ca-file=/var/secrets/broker-ca/broker-ca"
+           {{- end }}
+          {{- if .Values.certSecret }}
+           - "-cert-file=/var/secrets/broker-cert/broker-cert"
+          {{- end }}
+          {{- if .Values.keySecret }}
+           - "-key-file=/var/secrets/broker-key/broker-key"
+          {{- end }}
           env:
             - name: gateway_url
               value: {{ .Values.gatewayURL | quote }}
@@ -73,14 +112,40 @@ spec:
             - name: rebuild_interval
               value: {{ .Values.rebuildInterval | quote }}
             {{- end }}
-          {{- if .Values.basic_auth }}
           volumeMounts:
-            - name: auth
-              readOnly: true
-              mountPath: "/var/secrets"
             - name: openfaas-license
               readOnly: true
               mountPath: "/var/secrets/license"
+          {{- if .Values.basic_auth }}
+            - name: auth
+              readOnly: true
+              mountPath: "/var/secrets"
+          {{- if.Values.saslAuth }}
+            - name: broker-username
+              readOnly: true
+              mountPath: "/var/secrets/broker-username"
+            - name: broker-password
+              readOnly: true
+              mountPath: "/var/secrets/broker-password"
+          {{- end }}
+
+          {{- if .Values.caSecret }}
+            - name: broker-ca
+              readOnly: true
+              mountPath: "/var/secrets/broker-ca"
+          {{- end}}
+
+          {{- if .Values.certSecret }}
+            - name: broker-cert
+              readOnly: true
+              mountPath: "/var/secrets/broker-cert"
+          {{- end }}
+          {{- if .Values.keySecret }}
+            - name: broker-key
+              readOnly: true
+              mountPath: "/var/secrets/broker-key"
+          {{- end }}
+
           {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/kafka-connector/values.yaml
+++ b/chart/kafka-connector/values.yaml
@@ -1,7 +1,7 @@
 # You will need to create a license named "openfaas-license" - see the 
-# chart README for more.
+# chart README for detailed instructions.
 
-image: ghcr.io/openfaas/kafka-connector-pro:0.5.0
+image: ghcr.io/openfaas/kafka-pro-connector:0.6.0-rc1
 
 replicas: 1
 
@@ -15,7 +15,7 @@ asyncInvocation: false
 topics: faas-request
 
 # Your Kafka broker
-brokerHost: kafka:9092
+# brokerHost: kf-kafka:9092
 
 printResponse: true
 printResponseBody: false
@@ -31,3 +31,56 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Encryption
+tls: false
+
+# Authentication
+
+## When set to true, create secrets: "kafka-broker-username" and "kafka-broker-password"
+saslAuth: false
+
+# kubectl create secret generic \
+# kafka-broker-username \
+# -n openfaas \
+# --from-file broker-username=./broker-username.txt
+
+# kubectl create secret generic \
+# kafka-broker-password \
+# -n openfaas \
+# --from-file broker-password=./broker-password.txt
+
+brokerPasswordSecret: kafka-broker-password
+brokerUsernameSecret: kafka-broker-username
+
+## When using a custom CA:
+
+# kubectl create secret generic \
+# kafka-broker-ca \
+# -n openfaas \
+# --from-file broker-ca=./broker-ca.pem
+
+# When using client certs
+
+# kubectl create secret generic \
+# kafka-broker-cert \
+# -n openfaas \
+# --from-file broker-cert=./broker-cert.txt
+
+# kubectl create secret generic \
+# kafka-broker-key \
+# -n openfaas \
+# --from-file broker-key=./broker-key.txt
+
+# Set to empty to disable:
+
+caSecret: ""
+certSecret: ""
+keySecret: ""
+
+# Or give a name to each to enable
+
+# caSecret: kafka-broker-ca
+# certSecret: kafka-broker-cert
+# keySecret: kafka-broker-key
+


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for Kafka authentication and TLS to helm chart

## Motivation and Context

Part of OpenFaaS PRO, from customer trials where users need auth or TLS for their self-hosted or managed Kafka brokers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with:

TLS no auth
No TLS no auth

TLS with Confluent Cloud and SASL auth
TLS with Aiven and SASL auth with custom CA
TLS with Aiven and client certs with custom CA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
