### PR TITLE
Update single v1beta to v1 in order to support k8s >= 1.22

### DIFF
--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -102,7 +102,7 @@ subjects:
     namespace: {{ .Release.Namespace | quote }}
 {{- if .Values.clusterRole}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-operator-controller


### PR DESCRIPTION
Signed-off-by: Philip Marc Schwartz <Philip.Schwartz1@T-Mobile.com>


## Description
This change fixes a clusterRole creation using v1beta to v1 in order to support K8s >= 1.22.

This change works with > 1.15, meets the deprecation from 1.17 and the removal in 1.22.

## Motivation and Context
Fix cluster role creation for operator prior to 1.22 release.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) #826 


## How Has This Been Tested?
yes, locally on k3d+k3s with 1.21

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
