### PR TITLE
Added basicAuthPassword as an alternative to password generation

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -416,6 +416,7 @@ Additional OpenFaaS options in `values.yaml`.
 | `exposeServices` | Expose `NodePorts/LoadBalancer`  | `true` |
 | `serviceType` | Type of external service to use `NodePort/LoadBalancer` | `NodePort` |
 | `generateBasicAuth` | Generate admin password for basic authentication | `false` |
+| `basicAuthPassword` | Set basic password manually instead of generating it | `` |
 | `rbac` | Enable RBAC | `true` |
 | `httpProbe` | Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (compatible with Istio >= 1.1.5) | `true` |
 | `psp` | Enable [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for OpenFaaS accounts | `false` |

--- a/chart/openfaas/templates/secret.yaml
+++ b/chart/openfaas/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.generateBasicAuth }}
+{{- if (or .Values.generateBasicAuth .Values.basicAuthPassword) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,5 +15,5 @@ metadata:
 data:
   basic-auth-user: {{ "admin" | b64enc | quote }}
   # kubectl -n openfaas get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode
-  basic-auth-password: {{ randAlphaNum 12 | b64enc | quote }}
+  basic-auth-password: {{ default (randAlphaNum 12) (.Values.basicAuthPassword) | b64enc | quote }}
 {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -11,6 +11,7 @@ clusterRole: false            # Set to true to have OpenFaaS administrate multip
 createCRDs: true
 basic_auth: true
 generateBasicAuth: false
+basicAuthPassword: ''   # Set password explicated if you set generateBasicAuth to false
 
 securityContext: true
 # create pod security policies for OpenFaaS control plane


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a new option to openfaas chart: `basicAuthPassword`.
It's an alternative to `generateBasicAuth` that allows to set a password instead of generating one.

## Motivation and Context
When testing integration with openfaas as part of an automated test case it's absolutely more convinient to have access credentials (password) that can be shared with other components before openfaas is deployed.

## How Has This Been Tested?
It's been deployed hundreds of times as part of our CI/CD pipeline.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
