### PR TITLE
Migrate OIDC 0.5.0

### DIFF
--- a/chart/kafka-connector/README.md
+++ b/chart/kafka-connector/README.md
@@ -36,7 +36,7 @@ The [Kafka connector](https://github.com/openfaas-incubator/kafka-connector) bri
 $ kubectl create secret generic \
     -n openfaas \
     openfaas-license \
-    --from-file license=$HOME/OPENFAAS_LICENSE
+    --from-file license=$HOME/.openfaas/LICENSE
 ```
 
 - Add the OpenFaaS chart repo and deploy the `kafka-connector` PRO chart. We recommend installing it in the same namespace as the rest of OpenFaaS

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -128,7 +128,7 @@ spec:
           value: "/var/secrets"
         {{- if .Values.oidcAuthPlugin.enabled }}
         - name: auth_proxy_url
-          value: "http://oauth2-plugin.{{ .Release.Namespace }}:8080/validate"
+          value: "http://oidc-plugin.{{ .Release.Namespace }}:8080/validate"
         - name: auth_pass_body
           value: "false"
         {{- else }}

--- a/chart/openfaas/templates/oidc-plugin-dep.yaml
+++ b/chart/openfaas/templates/oidc-plugin-dep.yaml
@@ -8,33 +8,36 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: oauth2-plugin
+    component: oidc-plugin
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: oauth2-plugin
+  name: oidc-plugin
   namespace: {{ .Release.Namespace | quote }}
 spec:
   replicas: {{ .Values.oidcAuthPlugin.replicas }}
   selector:
     matchLabels:
-      app: oauth2-plugin
+      app: oidc-plugin
   template:
     metadata:
       annotations:
         prometheus.io/scrape: "false"
       labels:
-        app: oauth2-plugin
+        app: oidc-plugin
     spec:
       volumes:
-      - name: oauth2-plugin-temp-volume
+      - name: oidc-plugin-temp-volume
         emptyDir: {}
       {{- if .Values.basic_auth }}
       - name: auth
         secret:
           secretName: basic-auth
       {{- end }}
+      - name: license
+        secret:
+          secretName: openfaas-license
       containers:
-      - name:  oauth2-plugin
+      - name:  oidc-plugin
         resources:
           {{- .Values.oidcAuthPlugin.resources | toYaml | nindent 12 }}
         image: {{ .Values.oidcAuthPlugin.image }}
@@ -77,7 +80,7 @@ spec:
           {{- end }}
           timeoutSeconds: 5
         args:
-        - "-license={{- .Values.oidcAuthPlugin.license}}"
+        - "-license-file=/var/secrets/license/license"
         - "-provider={{- .Values.oidcAuthPlugin.provider}}"
         env:
         - name: client_id
@@ -90,34 +93,33 @@ spec:
           value: "{{- .Values.oidcAuthPlugin.baseHost}}"
         - name: port
           value: "8080"
-        - name: authorize_url
-          value: "{{- .Values.oidcAuthPlugin.authorizeURL}}"
+        - name: openid_url
+          value: "{{- .Values.oidcAuthPlugin.openidURL}}"
         - name: welcome_page_url
           value: "{{- .Values.oidcAuthPlugin.welcomePageURL}}"
         - name: public_key_path
-          value: ""  # leave blank if using jwks
+          value: ""
         - name: audience
           value: "{{- .Values.oidcAuthPlugin.audience}}"
-        - name: token_url
-          value: "{{- .Values.oidcAuthPlugin.tokenURL}}"
         - name: scopes
           value: "{{- .Values.oidcAuthPlugin.scopes}}"
-        - name: jwks_url
-          value: "{{- .Values.oidcAuthPlugin.jwksURL}}"
         - name: insecure_tls
           value: "{{- .Values.oidcAuthPlugin.insecureTLS}}"
         {{- if .Values.basic_auth }}
         - name: secret_mount_path
-          value: "/var/secrets"
+          value: "/var/secrets/gateway"
         {{- end }}
         volumeMounts:
-        - name: oauth2-plugin-temp-volume
+        - name: oidc-plugin-temp-volume
           mountPath: /tmp
         {{- if .Values.basic_auth }}
         - name: auth
           readOnly: true
-          mountPath: "/var/secrets"
+          mountPath: "/var/secrets/gateway"
         {{- end }}
+        - name: license
+          readOnly: true
+          mountPath: "/var/secrets/license"
         ports:
         - name: http
           containerPort: 8080

--- a/chart/openfaas/templates/oidc-plugin-svc.yaml
+++ b/chart/openfaas/templates/oidc-plugin-svc.yaml
@@ -8,10 +8,10 @@ metadata:
   labels:
     app: {{ template "openfaas.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: oauth2-plugin
+    component: oidc-plugin
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: oauth2-plugin
+  name: oidc-plugin
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
@@ -21,6 +21,6 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: oauth2-plugin
+    app: oidc-plugin
 
 {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -24,24 +24,22 @@ openfaasImagePullPolicy: "Always"
 oidcAuthPlugin:
   enabled: false
   provider: "" # Leave blank, or put "azure"
-  license: "example"
+  license: ""
   insecureTLS: false
   scopes: "openid profile email"
-  jwksURL: https://example.eu.auth0.com/.well-known/jwks.json
-  tokenURL: https://example.eu.auth0.com/oauth/token
+  openidURL: "https://example.eu.auth0.com/.well-known/openid-configuration"
   audience: https://example.eu.auth0.com/api/v2/
-  authorizeURL: https://example.eu.auth0.com/authorize
-  welcomePageURL: https://gw.oauth.example.com
-  cookieDomain: ".oauth.example.com"
-  baseHost: "http://auth.oauth.example.com"
-  clientSecret: SECRET
-  clientID: ID
+  welcomePageURL: https://gateway.openfaas.example.com
+  cookieDomain: ".openfaas.example.com"
+  baseHost: "https://auth.openfaas.example.com"
+  clientSecret: ""
+  clientID: ""
   resources:
     requests:
       memory: "120Mi"
       cpu: "50m"
   replicas: 1
-  image: ghcr.io/openfaas/openfaas-oidc-plugin:0.4.1
+  image: ghcr.io/openfaas/openfaas-oidc-plugin:0.5.0
   securityContext: true
 
 # Requires openfaasPRO=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Migrate to OIDC plugin 0.5.0

## Motivation and Context

    * Renames the deployment for the plugin to match its name
    better (oidc plugin, not oauth2-plugin)
    * Removes the need for separate token/autorization URLs
    by adding an openid discovery URL
    * Updates to version 0.5.0 of the component
    * Reads license from a secret in the cluster instead of a literal
       value. Thanks @dirien for the suggestion
   
## How Has This Been Tested?

    Tested e2e with the code grant flow and Auth0/Google as the
    sign-on provider.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Existing users will need to redeploy the helm chart if they are using the SSO capability.