### PR TITLE
Add OpenFaaS Pro queue-worker to faas-netes helm chart

### DIFF
--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -28,7 +28,7 @@ spec:
         secret:
           secretName: basic-auth
       {{- end }}
-      {{- if .Values.queueWorker.pro }}
+      {{- if .Values.queueWorkerPro.enabled }}
       - name: license
         secret:
           secretName: openfaas-license
@@ -37,15 +37,15 @@ spec:
       - name:  queue-worker
         resources:
           {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
-      {{- if .Values.queueWorker.pro }}
+      {{- if .Values.queueWorkerPro.enabled }}
         image: {{ .Values.queueWorkerPro.image }}
       {{- else }}
         image: {{ .Values.queueWorker.image }}
       {{- end }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.queueWorkerPro.enabled }}
         command:
           - "/worker"
-        {{- if .Values.queueWorker.pro }}
           - "-license-file=/var/secrets/license/license"
         {{- end }}
         env:
@@ -76,22 +76,22 @@ spec:
           value: "{{ .Values.queueWorker.ackWait }}"
         - name: max_inflight
           value: "{{ .Values.queueWorker.maxInflight }}"
-        # OpenFaaS PRO image required
+        # OpenFaaS PRO license required
         - name: "max_retry_attempts"
-          value: "{{ .Values.queueWorker.maxRetryAttempts }}"
+          value: "{{ .Values.queueWorkerPro.maxRetryAttempts }}"
         - name: "max_retry_wait"
-          value: "{{ .Values.queueWorker.maxRetryWait }}"
+          value: "{{ .Values.queueWorkerPro.maxRetryWait }}"
         - name: "initial_retry_wait"
-          value: "{{ .Values.queueWorker.initialRetryWait }}"
+          value: "{{ .Values.queueWorkerPro.initialRetryWait }}"
         - name: "retry_http_codes"
-          value: "{{ .Values.queueWorker.httpRetryCodes }}"
+          value: "{{ .Values.queueWorkerPro.httpRetryCodes }}"
         {{- if .Values.basic_auth }}
         - name: secret_mount_path
           value: "/var/secrets/gateway"
         - name: basic_auth
           value: "{{ .Values.basic_auth }}"
         volumeMounts:
-        {{- if .Values.queueWorker.pro }}
+        {{- if .Values.queueWorkerPro.enabled }}
         - name: license
           readOnly: true
           mountPath: "/var/secrets/license"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -115,11 +115,16 @@ operator:
       memory: "120Mi"
       cpu: "50m"
 
+# Requires openfaas PRO subscription
 queueWorkerPro:
   image: ghcr.io/openfaas/queue-worker-pro:0.1.0-rc4
+  enabled: false
+  maxRetryAttempts: "10"
+  maxRetryWait: "120s"
+  initialRetryWait: "10s"
+  httpRetryCodes: "429,502,500,504,408"
 
 queueWorker:
-  pro: true
   image: ghcr.io/openfaas/queue-worker:0.12.2
   # Control HA of queue-worker
   replicas: 1
@@ -132,11 +137,6 @@ queueWorker:
     requests:
       memory: "120Mi"
       cpu: "50m"
-# Requires openfaas PRO subscription
-  maxRetryAttempts: "10"
-  maxRetryWait: "120s"
-  initialRetryWait: "10s"
-  httpRetryCodes: "429,502,500,504,408"
 
 # monitoring and auto-scaling components
 # both components


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add OpenFaaS Pro queue-worker to faas-netes helm chart

This PR enables retries and backoff for Pro customers through an enhanced queue-worker.

See, the per-queue-worker configuration:

```bash
  maxRetryAttempts: "10"
  maxRetryWait: "120s"
  initialRetryWait: "10s"
  httpRetryCodes: "429,502,500,504,408"
```

To enable it, set `queueWorkerPro.enabled=true` with helm or arkade

## Motivation and Context

The OpenFaaS Pro queue-worker is a new feature for paying customers

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running `kubectl logs -n openfaas deploy/queue-worker` showed the new worker taking over when installed with helm, then I was able to run an async invocation against nodeinfo and see its response executing. I also confirmed that the existing queue-worker carried on workign when the pro version was disabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
