### PR TITLE
add chart prom rules to template

### DIFF
--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -73,6 +73,7 @@ data:
     groups:
       - name: openfaas
         rules:
+{{- if .Values.prometheus.config.alertRules.includeDefaults }}
         - alert: service_down
           expr: up == 0
         - alert: APIHighInvocationRate
@@ -84,4 +85,8 @@ data:
           annotations:
             description: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
             summary: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
+{{- end }}
+{{- if or (gt (len .Values.prometheus.config.alertRules.rules) 0) (eq .Values.prometheus.config.alertRules.includeDefaults false) }}
+        {{- .Values.prometheus.config.alertRules.rules | toYaml | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -147,6 +147,12 @@ prometheus:
     requests:
       memory: "512Mi"
   annotations: {}
+  config:
+    alertRules:
+      # whether or not to include the default alert rules
+      includeDefaults: true
+      # list of rules to add
+      rules: []
 
 alertmanager:
   image: prom/alertmanager:v0.18.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

this commit exposes up the prometheus alert rules as configurable on the faas-netes/openfaas chart.

you may specify a list of rules, which by default are added as additional rules following the default rules. you may optionally set `includeDefaults` to `false` in order to override the existing defaults.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`helm template` and looking at the output `yaml` files for each of the 4 cases:
- [x] include defaults, no rules
- [x] include defaults, rules
- [x] do not include defaults, rules 
- [x] do not include defaults, no rules. this just outputs a `[]`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
