### PR TITLE
 Set Termination Grace Period to write_timeout for functions to allow them to complete during a scale down event.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build local push namespaces install charts start-kind stop-kind build-buildx render-charts
 TAG?=latest
 OWNER?=openfaas
+SERVER?=ghcr.io
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 TOOLS_DIR := .tools
@@ -24,16 +25,16 @@ local:
 
 build-docker:
 	docker build \
-	-t ghcr.io/$(OWNER)/faas-netes:$(TAG) .
+	-t $(SERVER)/$(OWNER)/faas-netes:$(TAG) .
 
 .PHONY: build-buildx
 build-buildx:
-	@echo ghcr.io/$(OWNER)/faas-netes:$(TAG) && \
+	@echo $(SERVER)/$(OWNER)/faas-netes:$(TAG) && \
 	docker buildx create --use --name=multiarch --node=multiarch && \
 	docker buildx build \
 		--push \
 		--platform linux/amd64 \
-		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
+		--tag $(SERVER)/$(OWNER)/faas-netes:$(TAG) \
 		.
 
 .PHONY: build-buildx-all
@@ -42,21 +43,21 @@ build-buildx-all:
 	docker buildx build \
 		--platform linux/amd64,linux/arm/v7,linux/arm64 \
 		--output "type=image,push=false" \
-		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
+		--tag $(SERVER)/$(OWNER)/faas-netes:$(TAG) \
 		.
 
 .PHONY: publish-buildx-all
 publish-buildx-all:
-	@echo  ghcr.io/$(OWNER)/faas-netes:$(TAG) && \
+	@echo  $(SERVER)/$(OWNER)/faas-netes:$(TAG) && \
 	docker buildx create --use --name=multiarch --node=multiarch && \
 	docker buildx build \
 		--platform linux/amd64,linux/arm/v7,linux/arm64 \
 		--push=true \
-		--tag ghcr.io/$(OWNER)/faas-netes:$(TAG) \
+		--tag $(SERVER)/$(OWNER)/faas-netes:$(TAG) \
 		.
 
 push:
-	docker push ghcr.io/$(OWNER)/faas-netes:$(TAG)
+	docker push $(SERVER)/$(OWNER)/faas-netes:$(TAG)
 
 charts:
 	cd chart && helm package openfaas/ && helm package kafka-connector/ && helm package cron-connector/ && helm package nats-connector/ && helm package mqtt-connector/ && helm package pro-builder/

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -13,18 +13,18 @@ import (
 func Test_GracePeriodFromWriteTimeout(t *testing.T) {
 
 	scenarios := []struct {
-		name    string
-		seconds int64
-		envs    map[string]string
+		name        string
+		wantSeconds int64
+		envs        map[string]string
 	}{
-		{"grace period is the default", 30, map[string]string{}},
-		{"grace period is set from write_timeout", 60, map[string]string{"write_timeout": "60s"}},
+		{"grace period is the default", 32, map[string]string{}},
+		{"grace period is set from write_timeout", 62, map[string]string{"write_timeout": "60s"}},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
 
-			want := int64(s.seconds)
+			want := int64(s.wantSeconds)
 			function := &faasv1.Function{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "alpine",

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -13,6 +13,46 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 )
 
+func Test_GracePeriodFromWriteTimeout(t *testing.T) {
+
+	scenarios := []struct {
+		name    string
+		seconds int64
+		envs    map[string]string
+	}{
+		{"grace period is the default", 30, map[string]string{}},
+		{"grace period is set from write_timeout", 60, map[string]string{"write_timeout": "60s"}},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			request := types.FunctionDeployment{Service: "testfunc", Image: "ghcr.io/openfaas/alpine:latest"}
+			factory := k8s.NewFunctionFactory(fake.NewSimpleClientset(), k8s.DeploymentConfig{
+				LivenessProbe:  &k8s.ProbeConfig{},
+				ReadinessProbe: &k8s.ProbeConfig{},
+				SetNonRootUser: false,
+			}, nil)
+
+			request.EnvVars = s.envs
+			deployment, err := makeDeploymentSpec(request, map[string]*apiv1.Secret{}, factory)
+			if err != nil {
+				t.Errorf("unexpected makeDeploymentSpec error: %s", err.Error())
+			}
+			want := s.seconds
+			got := deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
+
+			if got == nil {
+				t.Fatalf("want: %d, got: nil", want)
+			}
+
+			if *got != want {
+				t.Errorf("TerminationGracePeriodSeconds want: %d, got: %d", want, *got)
+			}
+
+		})
+	}
+}
+
 func Test_buildAnnotations_Empty_In_CreateRequest(t *testing.T) {
 	request := types.FunctionDeployment{}
 
@@ -113,7 +153,6 @@ func Test_SetNonRootUser(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_buildEnvVars_NoSortedKeys(t *testing.T) {

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -16,12 +16,12 @@ import (
 func Test_GracePeriodFromWriteTimeout(t *testing.T) {
 
 	scenarios := []struct {
-		name    string
-		seconds int64
-		envs    map[string]string
+		name        string
+		wantSeconds int64
+		envs        map[string]string
 	}{
-		{"grace period is the default", 30, map[string]string{}},
-		{"grace period is set from write_timeout", 60, map[string]string{"write_timeout": "60s"}},
+		{"grace period is the default", 32, map[string]string{}},
+		{"grace period is set from write_timeout", 62, map[string]string{"write_timeout": "60s"}},
 	}
 
 	for _, s := range scenarios {
@@ -38,7 +38,7 @@ func Test_GracePeriodFromWriteTimeout(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected makeDeploymentSpec error: %s", err.Error())
 			}
-			want := s.seconds
+			want := s.wantSeconds
 			got := deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
 
 			if got == nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Set Termination Grace Period to `write_timeout` for functions to allow them to complete during a scale down event.

## Motivation and Context

Prior to this change, a function could only drain for 30 seconds, then Kubernetes would forcibly kill it. After this change, in--flight function invocations can drain according to the write_timeout environment variable.

For example, this function would have failed to complete in-flight requests that ran for `1m30s`.

```yaml
functions:
  go-long:
    lang: golang-middleware
    handler: ./go-long
    image: alexellis2/graceful:0.2.1-newest
    environment:
      write_timeout: 2m
      read_timeout: 2m
      exec_timeout: 2m
      handler_wait_duration: 1m30s
      healthcheck_interval: 5s
    annotations:
      topic: "pipeline.subscription"
    labels:
      com.openfaas.scale.min: 1
      com.openfaas.scale.max: 1
```

Fixes #853 #637 

## How Has This Been Tested?

I deployed openfaas with global timeouts of 2m as per the "Extended timeout" tutorial in the docs.

Then I deployed the go-long function with a 1m wait and 2m max write_timeout/exec_timeout.

Then I used hey and an extended `-t` (timeout flag) to schedule 5 requests.

At this point I scale down the function with `kubectl scale` and monitored the logs.

![image (9)](https://user-images.githubusercontent.com/6358735/140304579-011c779b-61b1-4457-852f-d5a905b50540.png)

Normally, the default of 30 seconds would have caused the functions to exit, but instead they stayed running and the pod remained in a terminating status.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Also related to this change is a watchdog update to allow the Pod to exit early, if all in-flight requests have completed:

https://github.com/openfaas/of-watchdog/commit/31e1d320714ccc2e49cb3fa72563d162b54581f9