### PR TITLE
Set termination grace period upon function updates

### DIFF
--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -168,6 +168,11 @@ func updateDeploymentSpec(
 		deployment.Spec.Template.Spec.Containers[0].LivenessProbe = probes.Liveness
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = probes.Readiness
 
+		terminationGracePeriodSeconds :=
+			getTerminationGracePeriodSeconds(request.EnvVars, request.Service)
+
+		deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
+
 		// compare the annotations from args to the cache copy of the deployment annotations
 		// at this point we have already updated the annotations to the new value, if we
 		// compare to that it will produce an empty list


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Set termination grace period upon function updates

## Motivation and Context

This was missed from #869 and fixes the controller so that
it updates the termination grace period for functions.

The problem would be that if a user updated the
write_timeout variable used to compute the grace
period, it would be ignored.

The operator uses common code for deploy/update, so does
not need a separate change.

Thanks to @kevin-lindsay-1 for doing exploratory testing
to find this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
# write_timeout = 2m

kubectl get deploy/go-long -n openfaas-fn -o yaml|grep term

terminationGracePeriodSeconds: 122

# write_timeout = 2m30s

kubectl get deploy/go-long -n openfaas-fn -o yaml|grep terminationGracePeriodSeconds

terminationGracePeriodSeconds: 152
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
