### PR TITLE
ci: use locally built image in the e2e tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ '*' ]
+    branches: ["*"]
   pull_request:
-    branches: [ '*' ]
+    branches: ["*"]
 
 jobs:
   build:
@@ -48,17 +48,19 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: |
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
- # Todo - load the image into Kind before running tests
- # otherwise, this just tests the chart with images that
- # have already been built and pushed in an earlier job
       - name: get tools
         run: ./contrib/get_tools.sh
       - name: lint chart
         run: ./contrib/lint_chart.sh
       - name: create cluster
         run: ./contrib/create_cluster.sh
+      - name: load CI image into kind
+        run: kind load docker-image ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
       - name: deploy function
-        run: OPERATOR=0 ./contrib/deploy.sh
+        run: |
+          export OPERATOR=0
+          export IMAGE=ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
+          ./contrib/deploy.sh
       - name: run function
         run: OPERATOR=0 ./contrib/run_function.sh
       - name: stop dev cluster
@@ -67,12 +69,16 @@ jobs:
         run: sleep 10
       - name: create cluster
         run: ./contrib/create_cluster.sh
+      - name: load CI image into kind
+        run: kind load docker-image ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
       - name: deploy function
-        run: OPERATOR=1 ./contrib/deploy.sh
+        run: |
+          export OPERATOR=1
+          export IMAGE=ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
+          ./contrib/deploy.sh
       - name: run function
         run: OPERATOR=1 ./contrib/run_function.sh
       - name: stop dev cluster
         run: ./contrib/stop_dev.sh
-
 # The certifier should also be run here
 #

--- a/contrib/deploy.sh
+++ b/contrib/deploy.sh
@@ -4,6 +4,7 @@ set -e
 
 DEVENV=${OF_DEV_ENV:-kind}
 OPERATOR=${OPERATOR:-0}
+IMAGE=${IMAGE:-""}
 
 echo ""
 echo "Applying namespaces"
@@ -20,15 +21,15 @@ fi
 
 PASSWORD_EXISTS=$(kubectl get secret -n openfaas basic-auth | wc -c)
 if [ $PASSWORD_EXISTS -eq 0 ]; then
-    PASSWORD=$(head -c 16 /dev/urandom| $sha_cmd | cut -d " " -f 1)
-    echo -n $PASSWORD > password.txt
+    PASSWORD=$(head -c 16 /dev/urandom | $sha_cmd | cut -d " " -f 1)
+    echo -n $PASSWORD >password.txt
 
     kubectl --context "kind-$DEVENV" -n openfaas create secret generic basic-auth \
-    --from-literal=basic-auth-user=admin \
-    --from-literal=basic-auth-password="$PASSWORD"
+        --from-literal=basic-auth-user=admin \
+        --from-literal=basic-auth-password="$PASSWORD"
 else
     PASSWORD=$(kubectl get secret -n openfaas basic-auth -o=go-template='{{index .data "basic-auth-password"}}' | base64 --decode)
-    echo -n $PASSWORD > password.txt
+    echo -n $PASSWORD >password.txt
 fi
 
 CREATE_OPERATOR=false
@@ -39,20 +40,35 @@ fi
 echo ""
 echo "Waiting for helm install to complete."
 
-helm upgrade \
-    --kube-context "kind-$DEVENV" \
-    --install \
-    openfaas \
-    ./chart/openfaas \
-    --namespace openfaas  \
-    --set basic_auth=true \
-    --set functionNamespace=openfaas-fn \
-    --set operator.create=$CREATE_OPERATOR
+if [ "z${IMAGE}" == "z" ]; then
+    helm upgrade \
+        --kube-context "kind-$DEVENV" \
+        --install \
+        openfaas \
+        ./chart/openfaas \
+        --namespace openfaas \
+        --set basic_auth=true \
+        --set functionNamespace=openfaas-fn \
+        --set operator.create=$CREATE_OPERATOR
+else
+    helm upgrade \
+        --kube-context "kind-$DEVENV" \
+        --install \
+        openfaas \
+        ./chart/openfaas \
+        --namespace openfaas \
+        --set basic_auth=true \
+        --set functionNamespace=openfaas-fn \
+        --set openfaasImagePullPolicy=IfNotPresent \
+        --set operator.create=$CREATE_OPERATOR \
+        --set operator.image=$IMAGE \
+        --set faasnetes.image=$IMAGE
+fi
 
 if [ "${OPERATOR}" == "1" ]; then
 
     kubectl --context "kind-$DEVENV" patch -n openfaas deploy/gateway \
-      -p='[{"op": "add", "path": "/spec/template/spec/containers/1/command", "value": ["./faas-netes", "-operator=true"]} ]' --type=json
+        -p='[{"op": "add", "path": "/spec/template/spec/containers/1/command", "value": ["./faas-netes", "-operator=true"]} ]' --type=json
 fi
 
 kubectl --context "kind-$DEVENV" rollout status deploy/prometheus -n openfaas


### PR DESCRIPTION
Load the just built image into the kind cluster before running the e2e
tests. This ensure we are testing the changes on the branch before we
publish them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #710 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Github will do this for us

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
