### PR TITLE
fix: improve error messages when teh profile crd is missing

### DIFF
--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -126,6 +126,16 @@ func updateDeploymentSpec(
 		// store the current annotations so that we can diff the annotations
 		// and determine which profiles need to be removed
 		currentAnnotations := deployment.Annotations
+
+		hasProfiles, err := k8s.ProfilesEnabled(factory.Client)
+		if err != nil {
+			return fmt.Errorf("can not verify the Profile CRD exists: %w", err), http.StatusInternalServerError
+		}
+
+		if !hasProfiles && (len(k8s.ParseProfileNames(annotations)) > 0 || len(k8s.ParseProfileNames(currentAnnotations)) > 0) {
+			return fmt.Errorf("Profiles CRD is missing, can not safely deploy a function while this is missing"), http.StatusInternalServerError
+		}
+
 		deployment.Annotations = annotations
 		deployment.Spec.Template.Annotations = annotations
 		deployment.Spec.Template.ObjectMeta.Annotations = annotations

--- a/pkg/k8s/capabilities.go
+++ b/pkg/k8s/capabilities.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// Capabilities is a map of kuberenetes api resources
+type Capabilities map[string]bool
+
+// Has returns true if the api resource is supported
+func (c Capabilities) Has(wanted string) bool {
+	return c[wanted]
+}
+
+// String implements the Stringer interface
+func (c Capabilities) String() string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
+}
+
+// getPreferredAvailableAPIs queries the cluster for the preferred resources information and returns a Capabilities
+// instance containing those api groups that support the specified kind.
+//
+// kind should be the title case singular name of the kind. For example, "Ingress" is the kind for a resource "ingress".
+func GetPreferredAvailableAPIs(client kubernetes.Interface, kind string) (Capabilities, error) {
+	discoveryclient := client.Discovery()
+	lists, err := discoveryclient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+
+	caps := Capabilities{}
+	for _, list := range lists {
+		if len(list.APIResources) == 0 {
+			continue
+		}
+		for _, resource := range list.APIResources {
+			if len(resource.Verbs) == 0 {
+				continue
+			}
+			if resource.Kind == kind {
+				caps[list.GroupVersion] = true
+			}
+		}
+	}
+
+	return caps, nil
+}
+
+// ProfilesEnabled returns if the Profile CRD is installed in the cluster.
+func ProfilesEnabled(client kubernetes.Interface) (bool, error) {
+	capabilities, err := GetPreferredAvailableAPIs(client, "Profile")
+
+	return capabilities.Has("openfaas.com/v1"), err
+}
+
+// FunctionEnabled returns if the Function CRD is installed in the cluster.
+func FunctionEnabled(client kubernetes.Interface) (bool, error) {
+	capabilities, err := GetPreferredAvailableAPIs(client, "Function")
+
+	return capabilities.Has("openfaas.com/v1"), err
+}


### PR DESCRIPTION
Add explicit errors during startup and during deploy when the Profiles
CRD is missing. This will not prevent deployment and invocation of functions that don't require Profiles but it will block functions that use the feature.

This improves the error behavior and makes the errors more explicit so that it is easier for the cluster operator to fix it.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Relates to #868

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

WIP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
