### PR TITLE
Handle ingressClassName

### DIFF
--- a/chart/openfaas/templates/ingress.yaml
+++ b/chart/openfaas/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host.host }}


### PR DESCRIPTION
## Description
Allows the usage of `ingressClassname`  setting, which replaces the deprecated annotation: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
