### PR TITLE
chore: Extend configuration for production

### DIFF
--- a/chart/pro-builder/templates/deployment.yml
+++ b/chart/pro-builder/templates/deployment.yml
@@ -108,9 +108,19 @@ spec:
         ports:
         - containerPort: 1234
           protocol: TCP
+        {{- with .Values.securityContext }}
         securityContext:
-          privileged: true
+          {{- . | toYaml | nindent 12 }}
+        {{- end }}
         volumeMounts:
         - name: daemon-certs
           readOnly: true
           mountPath: /var/secrets/certs
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/pro-builder/templates/service.yml
+++ b/chart/pro-builder/templates/service.yml
@@ -18,4 +18,4 @@ spec:
       protocol: TCP
       targetPort: 8080
   selector:
-    app: pro-builder
+    app: {{ template "builder.name" . }}

--- a/chart/pro-builder/values.yaml
+++ b/chart/pro-builder/values.yaml
@@ -23,3 +23,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+securityContext: {}


### PR DESCRIPTION
## Description
We are adopters of the Probuilder middleware to build images which in turn are run as functions via Openfaas. 

Extending the probuilder chart with some production ready configuration requirements: 
- nodeSelector
- tolerations
- affinity

Fix for the service label selector, to reuse the templated values. This avoids any misconfiguration on the service and routing to pods. 

## Motivation and Context
This was required for us to deploy this application to production. 

## How Has This Been Tested?
Tested on our staging environment. 

## Checklist:
- [x] My code follows the code style of this project.
not sure if it applies for Helm charts
- [x] My change requires a change to the documentation.
Don't think this applies
- [x] I have updated the documentation accordingly.
Don't think this applies
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
Did not, if it is a problem let me know
- [x] I have added tests to cover my changes.
Don't think this applies
- [x] All new and existing tests passed.
Don't think this applies
