### PR TITLE
Add support for Pro scaler and metrics in helm chart

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: OpenFaaS - Serverless Functions Made Simple
 name: openfaas
-version: 9.0.2
+version: 10.0.0
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes
@@ -18,6 +18,3 @@ maintainers:
   email: alex@openfaas.com
 - name: lucasroesler
   email: roesler.lucas@gmail.com
-- name: Waterdrips
-  email: alistair.hey@gmail.com
-

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -107,7 +107,7 @@ echo "OpenFaaS admin password: $PASSWORD"
 kubectl create secret generic \
     -n openfaas \
     openfaas-license \
-    --from-file license=$HOME/OPENFAAS_LICENSE
+    --from-file license=$HOME/.openfaas/LICENSE
 ```
 
 Now deploy OpenFaaS from the helm chart repo:
@@ -118,10 +118,10 @@ helm repo update \
     --namespace openfaas  \
     --set functionNamespace=openfaas-fn \
     --set generateBasicAuth=true \
-    --set openfaasPRO=true
+    --set openfaasPro=true
 ```
 
-The main change here is to add: `--set openfaasPRO=true`
+The main change here is to add: `--set openfaasPro=true`
 
 See also:
 * Scale-down to zero (in this document)

--- a/chart/openfaas/templates/faas-idler-dep.yaml
+++ b/chart/openfaas/templates/faas-idler-dep.yaml
@@ -1,7 +1,7 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
-{{- if .Values.openfaasPRO }}
+{{- if .Values.openfaasPro }}
 
-{{- if .Values.faasIdler.create }}
+{{- if .Values.faasIdler.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -1,4 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+
 {{- if .Values.prometheus.create }}
 ---
 kind: ConfigMap
@@ -22,10 +23,19 @@ data:
 
     rule_files:
         - 'alert.rules.yml'
+{{- if .Values.openfaasPro }}
+        - 'prometheus-rules.yml'
+{{- end }}
+
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager:9093
 
     scrape_configs:
       - job_name: 'prometheus'
-        scrape_interval: 5s
+        scrape_interval: 10s
         static_configs:
           - targets: ['localhost:9090']
 
@@ -63,11 +73,54 @@ data:
           - __meta_kubernetes_pod_annotation_prometheus_io_path
           target_label: __metrics_path__
 
-    alerting:
-      alertmanagers:
-      - static_configs:
-        - targets:
-          - alertmanager:9093
+{{- if .Values.openfaasPro }}
+
+      - job_name: 'kubernetes-resource-metrics'
+        scrape_interval: 10s
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+        metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: (pod)_(cpu|memory)_(.+)
+          action: keep
+        # Exclude container metrics
+        - source_labels: [__name__]
+          regex: container_(.+)
+          action: drop
+        - action: replace
+          source_labels:
+          - namespace
+          regex: '(.*)'
+          replacement: '$1'
+          target_label: kubernetes_namespace
+        # Output deployment name from Pod
+        - action: replace
+          source_labels:
+          - pod
+          regex: '^([0-9a-zA-Z-]+)+(-[0-9a-zA-Z]+-[0-9a-zA-Z]+)$'
+          replacement: '$1'
+          target_label: deployment_name
+        # Output fully-qualified function name fn.ns
+        - source_labels: [deployment_name, kubernetes_namespace]
+          separator: ";"
+          regex: '(.*);(.*)'
+          replacement: '${1}.${2}'
+          target_label: "function_name"
+{{- end }}
 
   alert.rules.yml: |
     groups:
@@ -75,6 +128,7 @@ data:
         rules:
         - alert: service_down
           expr: up == 0
+{{- if eq .Values.openfaasPro false }}
         - alert: APIHighInvocationRate
           expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
           for: 5s
@@ -84,4 +138,35 @@ data:
           annotations:
             description: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
             summary: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
+{{- end }}
+
+{{- if .Values.openfaasPro }}
+
+  prometheus-rules.yml: |
+    groups:
+    - name: load
+      rules:
+      - record: job:function_current_load:sum
+        expr: sum by (function_name) ( rate( gateway_function_invocation_total{}[30s] ) )  and avg by (function_name) (gateway_service_target_load{scaling_type="rps"}) > 1
+        labels:
+          scaling_type: rps
+
+      - record: job:function_current_load:sum
+        expr: sum by (function_name) (gateway_function_invocation_started{}) - sum by (function_name) ( gateway_function_invocation_total{}) and avg by (function_name) (gateway_service_target_load{scaling_type="capacity"}) > 1
+        labels:
+          scaling_type: capacity
+
+      - record: job:function_current_load:sum
+        expr: sum(irate ( pod_cpu_usage_seconds_total{}[1m])*1000) by (function_name) * on (function_name) avg by (function_name) (gateway_service_target_load{scaling_type="cpu"}  > bool 1 )
+        labels:
+          scaling_type: cpu
+
+    - name: recently_started_1m
+      interval: 10s
+      rules:
+      - record: job:function_current_started:max_sum
+        expr: max_over_time(sum by (function_name) (rate( gateway_function_invocation_started{}[1m]))[1m:5s]) > 0
+
+{{- end }}
+
 {{- end }}

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -77,6 +77,11 @@ spec:
         - mountPath: /etc/prometheus/prometheus.yml
           name: prometheus-config
           subPath: prometheus.yml
+{{- if .Values.openfaasPro }}
+        - mountPath: /etc/prometheus/prometheus-rules.yml
+          name: prometheus-config
+          subPath: prometheus-rules.yml
+{{- end }}
         - mountPath: /etc/prometheus/alert.rules.yml
           name: prometheus-config
           subPath: alert.rules.yml
@@ -93,6 +98,11 @@ spec:
               - key: alert.rules.yml
                 path: alert.rules.yml
                 mode: 0644
+{{- if .Values.openfaasPro }}
+              - key: prometheus-rules.yml
+                path: prometheus-rules.yml
+                mode: 0644
+{{- end }}
         - name: prom-data
           emptyDir: {}
     {{- with .Values.nodeSelector }}

--- a/chart/openfaas/templates/prometheus-rbac.yaml
+++ b/chart/openfaas/templates/prometheus-rbac.yaml
@@ -33,7 +33,31 @@ rules:
     - services
     - endpoints
     - pods
+    - nodes
+    - nodes/proxy
   verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+# Cluster binding for node discovery and node-level metrics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-nodemetrics-prometheus
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-prometheus
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/openfaas/templates/prometheus-rbac.yaml
+++ b/chart/openfaas/templates/prometheus-rbac.yaml
@@ -39,6 +39,8 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
+
+{{- if .Values.openfaasPro }}
 # Cluster binding for node discovery and node-level metrics
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -58,6 +60,8 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-prometheus
   namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/openfaas/templates/scaler-dep.yaml
+++ b/chart/openfaas/templates/scaler-dep.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.async }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: scaler
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: scaler
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.proScaler.replicas }}
+  selector:
+    matchLabels:
+      app: scaler
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "false"
+      labels:
+        app: scaler
+    spec:
+      volumes:
+      {{- if .Values.basic_auth }}
+      - name: auth
+        secret:
+          secretName: basic-auth
+      {{- end }}
+      {{- if .Values.proScaler.enabled }}
+      - name: license
+        secret:
+          secretName: openfaas-license
+      {{- end }}
+      containers:
+      - name:  scaler
+        resources:
+          {{- .Values.proScaler.resources | toYaml | nindent 12 }}
+      {{- if .Values.proScaler.enabled }}
+        image: {{ .Values.proScaler.image }}
+      {{- else }}
+        image: {{ .Values.proScaler.image }}
+      {{- end }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.proScaler.enabled }}
+        command:
+          - "/usr/bin/scaler"
+          - "-license-file=/var/secrets/license/license"
+        {{- end }}
+        env:
+        - name: gateway_url
+          value: "http://gateway.{{ .Release.Namespace }}:8080/"
+        - name: prometheus_host
+          value: "prometheus.{{ .Release.Namespace }}"
+        - name: prometheus_port
+          value: "9090"
+          
+        {{- if .Values.functionNamespace }}
+        - name: faas_function_suffix
+          value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        {{- end }}
+
+        {{- if .Values.basic_auth }}
+        - name: secret_mount_path
+          value: "/var/secrets/scaler"
+        - name: basic_auth
+          value: "{{ .Values.basic_auth }}"
+        volumeMounts:
+        {{- if .Values.proScaler.enabled }}
+        - name: license
+          readOnly: true
+          mountPath: "/var/secrets/license"
+        {{- end }}
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets/scaler"
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -1,19 +1,20 @@
 functionNamespace: openfaas-fn  # Default namespace for functions
 
 # See https://www.openfaas.com/support for more
-openfaasPRO: false
+openfaasPro: false
 
 serviceType: NodePort
 exposeServices: true
 async: true
 httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
 rbac: true
-clusterRole: false            # Set to true to have OpenFaaS administrate multiple namespaces
+clusterRole: false            # Set to true for multiple namespaces
 createCRDs: true
 basic_auth: true
 generateBasicAuth: false
 
 securityContext: true
+
 # create pod security policies for OpenFaaS control plane
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 psp: false
@@ -21,7 +22,35 @@ psp: false
 # image pull policy for openfaas components, can change to `IfNotPresent` in offline env
 openfaasImagePullPolicy: "Always"
 
-# openfaasPRO components, which requires openfaasPRO=true
+# openfaasPro components, which require openfaasPro=true
+# clusterRole is also recommended for collecting CPU/RAM metrics for Pro add-ons
+
+# advanced scaling on concurrency and CPU
+proScaler:
+  image: alexellis2/openfaas-pro-scaler:0.1.1-dirty
+  replicas: 1
+  enabled: true
+  resources:
+    requests:
+      memory: "128Mi"
+    limits:
+      memory: "256Mi"
+
+# Not required if using proScaler
+# scale-to-zero feature
+faasIdler:
+  image: ghcr.io/openfaas/faas-idler-pro:0.4.4
+  replicas: 1
+  enabled: false
+  inactivityDuration: 3m               # If a function is inactive for 15 minutes, it may be scaled to zero
+  reconcileInterval: 2m                 # The interval between each attempt to scale functions to zero
+  readOnly: false                       # When set to true, no functions are scaled to zero
+  writeDebug: false                     # Write additional debug information
+  resources:
+    requests:
+      memory: "64Mi"
+
+# OIDC plugin for authentication on the OpenFaaS REST API
 oidcAuthPlugin:
   enabled: false
   verbose: false # debug setting
@@ -42,20 +71,6 @@ oidcAuthPlugin:
   replicas: 1
   image: ghcr.io/openfaas/openfaas-oidc-plugin:0.5.1
   securityContext: true
-
-# Requires openfaasPRO=true
-# scale-to-zero feature
-faasIdler:
-  image: ghcr.io/openfaas/faas-idler-pro:0.4.4
-  replicas: 1
-  create: true
-  inactivityDuration: 3m               # If a function is inactive for 15 minutes, it may be scaled to zero
-  reconcileInterval: 2m                 # The interval between each attempt to scale functions to zero
-  readOnly: false                       # When set to true, no functions are scaled to zero
-  writeDebug: false                     # Write additional debug information
-  resources:
-    requests:
-      memory: "64Mi"
 
 gateway:
   image: ghcr.io/openfaas/gateway:0.21.3


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for Pro scaler and metrics in helm chart

## Motivation and Context

* Enables CPU/RAM usage collection for Pro users which also
requires the cluster role to be set to scrape the kubelet
* Enables new auto-scaler for Pro users, and disables alert
manager rule for those users
* openfaasPRO => openfaasPro in the values.yaml file

If using the new Pro scaler, disable the faas-idler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New usage data being populated in the API / CLI:

```bash
~/go/src/github.com/openfaas/faas-cli/faas-cli describe figlet
Handling connection for 8080

Name:                figlet
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               ghcr.io/openfaas/figlet:latest
Function process:    figlet
URL:                 http://127.0.0.1:8080/function/figlet
Async URL:           http://127.0.0.1:8080/async-function/figlet
Labels               com.openfaas.scale.max : 10
                     com.openfaas.scale.target : 100
                     com.openfaas.scale.target-proportion : 0.7
                     com.openfaas.scale.type : cpu
                     faas_function : figlet
                     uid : 501963057
Annotations          prometheus.io.scrape : false
RAM:                 6.27 MB
CPU:                 1 Mi
```

Auto-scaler working on new load metrics:

![load-test](https://user-images.githubusercontent.com/6358735/152149564-11b3aae7-8580-42b6-b6c9-4e7233877392.png)

Testing OpenFaaS Pro with pre-release faas-netes Pro:

```bash
helm upgrade openfaas --install chart/openfaas     \
  --namespace openfaas     \
  --set functionNamespace=openfaas-fn     \
  --set generateBasicAuth=true     \
  --set clusterRole=true     \
  --set openfaasPro=true \
  --set faasnetes.image=docker.io/alexellis2/faas-netes:0.15-rc1
```

Testing w/o Pro:

```bash
helm upgrade openfaas --install chart/openfaas     \
  --namespace openfaas     \
  --set functionNamespace=openfaas-fn     \
  --set generateBasicAuth=true     \
  --set clusterRole=true     \
  --set openfaasPro=false
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This will break by not deploying Pro components for anyone who is setting `openfaasPRO=true`, you should now set: `openfaasPro=true` since the variable was renamed.

The auto-scaling docs have been updated: 

https://docs.openfaas.com/architecture/autoscaling/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
