### PR TITLE
Resolve version from GitHub Action and move to Go 1.17

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 /artifacts
 /hack
 /docs
+/.git

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
@@ -28,6 +28,9 @@ jobs:
       - name: Get Repo Owner
         id: get_repo_owner
         run: echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
+      - name: Get git commit
+        id: get_git_commit
+        run: echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Build x86_64 container into library
         uses: docker/build-push-action@v2
@@ -36,6 +39,9 @@ jobs:
           file: ./Dockerfile
           outputs: "type=docker,push=false"
           platforms: linux/amd64
+          build-args: |
+            GIT_COMMIT=dev-${{env.GIT_COMMIT}}
+            VERSION=dev-${{env.GIT_COMMIT}}
           tags: |
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
 
@@ -46,6 +52,9 @@ jobs:
           file: ./Dockerfile
           outputs: "type=image,push=false"
           platforms: linux/amd64,linux/arm/v7,linux/arm64
+          build-args: |
+            GIT_COMMIT=dev-${{env.GIT_COMMIT}}
+            VERSION=dev-${{env.GIT_COMMIT}}
           tags: |
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
  # Todo - load the image into Kind before running tests

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -43,6 +43,12 @@ jobs:
       - name: Get Repo Owner
         id: get_repo_owner
         run: echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
+      - name: Get git commit
+        id: get_git_commit
+        run: echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=$(git describe --tags --dirty)" >> $GITHUB_ENV
 
       - name: Push containers
         uses: docker/build-push-action@v2
@@ -51,6 +57,9 @@ jobs:
           file: ./Dockerfile
           outputs: "type=registry,push=true"
           platforms: linux/amd64,linux/arm/v7,linux/arm64
+          build-args: |
+            GIT_COMMIT=${{env.GIT_COMMIT}}
+            VERSION=${{env.VERSION}}
           tags: |
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ github.sha }}
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/faas-netes:${{ steps.get_tag.outputs.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM teamserverless/license-check:0.3.9 as license-check
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17 as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+
+ARG VERSION
+ARG GIT_COMMIT
 
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
@@ -20,9 +23,7 @@ RUN license-check -path /go/src/github.com/openfaas/faas-netes/ --verbose=false 
 RUN gofmt -l -d $(find . -type f -name '*.go' -not -path "./vendor/*")
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go test -v ./...
 
-RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
-    && GIT_COMMIT=$(git rev-list -1 HEAD) \
-    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=${CGO_ENABLED} go build \
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
         --ldflags "-s -w \
         -X github.com/openfaas/faas-netes/version.GitCommit=${GIT_COMMIT}\
         -X github.com/openfaas/faas-netes/version.Version=${VERSION}" \


### PR DESCRIPTION
Resolve version from GitHub Action and move to Go 1.17

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* As per other projects, the version is determined from the
execution environment, and not from within the Docker build
stage. This means there's no need to copy the .git folder
into the build context.
* Moves to Go 1.17 for building the operator/controller.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing during CI

## Types of changes

Technical debt & no-harm updates
