### PR TITLE
ci: reduce number of jobs while validating helm charts

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -11,42 +11,17 @@ on:
 jobs:
   lint-chart:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        chartName:
-          - openfaas
-          - cron-connector
-          - kafka-connector
-          - mqtt-connector
-          - nats-connector
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - uses: azure/setup-helm@v1
       - name: Helm Lint
-        working-directory: chart
-        run: helm lint ${{ matrix.chartName }}
+        run: ./contrib/lint_chart.sh
 
   kubeval-chart:
     runs-on: ubuntu-latest
     needs:
       - lint-chart
-    strategy:
-      matrix:
-        k8s:
-          - v1.16.8
-          - v1.17.4
-          - v1.17.17
-          - v1.18.6
-          - v1.18.9
-          - v1.20.4
-          - v1.21.1
-        chartName:
-          - openfaas
-          - cron-connector
-          - kafak-connector
-          - mqtt-connector
-          - nats-connector
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,7 +31,6 @@ jobs:
       - name: Run kubeval
         env:
           KUBEVAL_SCHEMA_LOCATION: "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
-          KUBERNETES_VERSION: ${{ matrix.k8s }}
+          KUBERNETES_VERSION: v1.16.8 v1.17.4 v1.17.17 v1.18.6 v1.18.9 v1.20.4 v1.21.1
         working-directory: chart
-        run: |
-          helm template ${{ matrix.chartName }} -f ${{ matrix.chartName }}/values.yaml -n openfaas | kubeval -n openfaas --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}"
+        run: ./contrib/lint_chart.sh

--- a/contrib/lint_chart.sh
+++ b/contrib/lint_chart.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
+ROOT=$(git rev-parse --show-toplevel)
 
-for chart in `ls ./chart`; do
-  helm lint ./chart/${chart}
+status=0
+msg=''
+
+for chart in $ROOT/chart/*; do
+  name=$(basename $chart)
+  echo -e "\n\nLinting $name"
+  helm lint "$chart"
   if [ $? != 0 ]; then
-    exit 1
+    status=1
+    msg="$msg\n$name"
   fi
 done
 
+if [ $status != 0 ]; then
+  echo -e "Failures:\n$msg"
+fi
+
+exit $status

--- a/contrib/validate_chart.sh
+++ b/contrib/validate_chart.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+export KUBEVAL_SCHEMA_LOCATION=${KUBEVAL_SCHEMA_LOCATION:-"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"}
+
+ROOT=$(git rev-parse --show-toplevel)
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-'v1.21.1'}
+
+status=0
+msg=''
+
+for version in $KUBERNETES_VERSION; do
+    echo -e "\n#####################################"
+    echo "Validating Kubernetes $version"
+    echo "######################################"
+    for chart in $ROOT/chart/*; do
+        name=$(basename $chart)
+        echo -e "\n\nValidating $name"
+        helm template $chart -f $chart/values.yaml -n openfaas |
+            kubeval -n openfaas --strict --ignore-missing-schemas --kubernetes-version "${version#v}" |
+            grep -v 'WARN - Set to ignore missing schemas' |
+            grep -v 'PASS'
+        if [ $? != 0 ]; then
+            status=1
+            msg="$msg\n$name ($version)"
+        fi
+    done
+done
+
+if [ $status != 0 ]; then
+    echo -e "Failures:\n$msg"
+fi
+
+exit $status


### PR DESCRIPTION
Use a bash script instead of the matrix strategy for linting and
validating the helm charts, to reduce the number of jobs it creates, this
will use only 2 jobs instead of 56 it was generating.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#934 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

WIP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
