### PR TITLE
ci: add more paths to trigger the helm CI flow

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -3,10 +3,16 @@ name: Validate Chart
 on:
   push:
     paths:
-      - "chart/**"
+      - chart/**
+      - contrib/validate_chart.sh
+      - contrib/lint_chart.sh
+      - .github/workflows/helm.yaml
   pull_request:
     paths:
-      - "chart/**"
+      - chart/**
+      - contrib/validate_chart.sh
+      - contrib/lint_chart.sh
+      - .github/workflows/helm.yaml
 
 jobs:
   lint-chart:


### PR DESCRIPTION
Add the chart tools and the helm workflow itself to the triggers that
cause the helm validation workflow to run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Issue was mentioned on Discord

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR should verify it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
