### PR TITLE
Allow override of http port and loadBalancerIP with new helm values

### DIFF
--- a/chart/openfaas/templates/gateway-external-svc.yaml
+++ b/chart/openfaas/templates/gateway-external-svc.yaml
@@ -16,9 +16,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.serviceType }}
+{{- if and (contains "LoadBalancer" .Values.serviceType) .Values.gatewayExternal.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.gatewayExternal.loadBalancerIP }}
+{{- end }}
   ports:
     - name: http
-      port: 8080
+      port: {{ .Values.gatewayExternal.port | default 8080 }}
       protocol: TCP
       targetPort: 8080
       {{- if contains "NodePort" .Values.serviceType }}


### PR DESCRIPTION
Signed-off-by: Levi Trammell <davidltrammell@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

I've added a couple of new helm values :

`.Values.gatewayExternal.loadBalancerIP`
`.Values.gatewayExternal.port`

If the `gatewayExternal.loadBalancerIP` is set and the service is of type `LoadBalancer`, one can explicitly set which IP the external gateway service uses. This is not an uncommon practice with people of the homelab community using MetalLB or kube-vip.

If the `gatewayExternal.port` is set, the gateway service can use whatever port it wants (say port 80), and continue using the target port of 8080. If `gatewayExternal.port` is not set it falls back to the default port 8080. 

These changes will make it super simple for someone to set these value using helm or arkade.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

[https://github.com/openfaas/faas-netes/issues/941](https://github.com/openfaas/faas-netes/issues/941)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested as described in documentation. 

```
helm upgrade openfaas --install ~/Developer/faas-netes/chart/openfaas \
    --namespace openfaas \
    --set functionNamespace=openfaas-fn \
    --set generateBasicAuth=true \
    -f ~/Developer/faas-netes/chart/openfaas/values.yaml \
    -f ~/Developer/faas-netes/chart/openfaas/values-arm64.yaml \
    -f ./values.yaml
```

Here is the values.yaml that I used
```
serviceType: LoadBalancer

gatewayExternal:
  port: 80
  loadBalancerIP: 10.49.0.9
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
