### PR TITLE
Improve validation for POST/PUT requests to /system/functions

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -5,12 +5,13 @@
 package handlers
 
 import (
+	"fmt"
 	"testing"
 
 	types "github.com/openfaas/faas-provider/types"
 )
 
-func Test_ValidateDeployRequest_ValidCharacters(t *testing.T) {
+func Test_validateService_ValidCharacters(t *testing.T) {
 	cases := []struct {
 		scenario string
 		value    string
@@ -26,7 +27,7 @@ func Test_ValidateDeployRequest_ValidCharacters(t *testing.T) {
 			Service: testCase.value,
 		}
 
-		err := ValidateDeployRequest(&request)
+		err := validateService(request.Service)
 		if err != nil {
 			t.Errorf("Scenario: %s with value: %s, got: %s", testCase.scenario, testCase.value, err.Error())
 		}
@@ -34,7 +35,7 @@ func Test_ValidateDeployRequest_ValidCharacters(t *testing.T) {
 	}
 }
 
-func Test_ValidateDeployRequest_InvalidCharacters(t *testing.T) {
+func Test_validateService_InvalidCharacters(t *testing.T) {
 	cases := []struct {
 		scenario string
 		value    string
@@ -52,9 +53,66 @@ func Test_ValidateDeployRequest_InvalidCharacters(t *testing.T) {
 			Service: testCase.value,
 		}
 
-		err := ValidateDeployRequest(&request)
+		err := validateService(request.Service)
 		if err == nil {
 			t.Errorf("Expected error for scenario: %s with value: %s, got: %s", testCase.scenario, testCase.value, err.Error())
 		}
+	}
+}
+
+func Test_ValidateDeployRequest_InvalidRequest(t *testing.T) {
+	cases := []struct {
+		scenario    string
+		serviceName string
+		imageName   string
+		err         error
+	}{
+		{"empty service with valid image",
+			"",
+			"test-image",
+			fmt.Errorf("service: is required")},
+		{"empty service with empty image",
+			"",
+			"",
+			fmt.Errorf("service: is required")},
+		{"invalid service with valid image",
+			"test_function",
+			"test-image",
+			fmt.Errorf("service: (test_function) is invalid, must be a valid DNS entry")},
+		{"invalid service with empty image",
+			"test_function",
+			"",
+			fmt.Errorf("service: (test_function) is invalid, must be a valid DNS entry")},
+		{"valid service with empty image",
+			"test-function",
+			"",
+			fmt.Errorf("image: is required")},
+	}
+
+	for _, testCase := range cases {
+		request := types.FunctionDeployment{
+			Service: testCase.serviceName,
+			Image:   testCase.imageName,
+		}
+
+		err := ValidateDeployRequest(&request)
+		if err == nil {
+			t.Fatalf("Expected error for scenario: %s", testCase.scenario)
+		}
+		if err.Error() != testCase.err.Error() {
+			t.Fatalf("Scenario: %s, want: %s, but got: %s", testCase.scenario, testCase.err.Error(), err.Error())
+		}
+	}
+}
+
+func Test_ValidateDeploymentRequest_ValidRequest(t *testing.T) {
+	request := types.FunctionDeployment{
+		Service: "test-function",
+		Image:   "test-image",
+	}
+
+	err := ValidateDeployRequest(&request)
+	if err != nil {
+		t.Errorf("unexpected ValidateDeploymentRequest error: %s", err.Error())
 	}
 }

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -36,6 +36,12 @@ func MakeUpdateHandler(defaultNamespace string, factory k8s.FunctionFactory) htt
 			return
 		}
 
+		if err := ValidateDeployRequest(&request); err != nil {
+			wrappedErr := fmt.Errorf("validation failed: %s", err.Error())
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
 		lookupNamespace := defaultNamespace
 		if len(request.Namespace) > 0 {
 			lookupNamespace = request.Namespace

--- a/pkg/handlers/validate.go
+++ b/pkg/handlers/validate.go
@@ -15,12 +15,31 @@ import (
 // 	k8s.io/kubernetes/pkg/util/validation/validation.go
 var validDNS = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
-// ValidateDeployRequest validates that the service name is valid for Kubernetes
-func ValidateDeployRequest(request *types.FunctionDeployment) error {
-	matched := validDNS.MatchString(request.Service)
+// validates that the service name is valid for Kubernetes
+func validateService(service string) error {
+	matched := validDNS.MatchString(service)
 	if matched {
 		return nil
 	}
 
-	return fmt.Errorf("(%s) must be a valid DNS entry for service name", request.Service)
+	return fmt.Errorf("service: (%s) is invalid, must be a valid DNS entry", service)
+}
+
+// ValidateDeployRequest validates that the service name is valid for Kubernetes
+func ValidateDeployRequest(request *types.FunctionDeployment) error {
+
+	if request.Service == "" {
+		return fmt.Errorf("service: is required")
+	}
+
+	err := validateService(request.Service)
+	if err != nil {
+		return err
+	}
+
+	if request.Image == "" {
+		return fmt.Errorf("image: is required")
+	}
+
+	return nil
 }

--- a/pkg/server/apply.go
+++ b/pkg/server/apply.go
@@ -8,6 +8,7 @@ import (
 
 	faasv1 "github.com/openfaas/faas-netes/pkg/apis/openfaas/v1"
 	clientset "github.com/openfaas/faas-netes/pkg/client/clientset/versioned"
+	"github.com/openfaas/faas-netes/pkg/handlers"
 	"github.com/openfaas/faas-provider/types"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +31,13 @@ func makeApplyHandler(defaultNamespace string, client clientset.Interface) http.
 			w.Write([]byte(err.Error()))
 			return
 		}
+
+		if err := handlers.ValidateDeployRequest(&req); err != nil {
+			wrappedErr := fmt.Errorf("validation failed: %s", err.Error())
+			http.Error(w, wrappedErr.Error(), http.StatusBadRequest)
+			return
+		}
+
 		klog.Infof("Deployment request for: %s\n", req.Service)
 
 		namespace := defaultNamespace


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve validation of POST/PUT requests to /system/functions
- Verify required fields `service` and `image` are not empty
- Improve error messages for invalid requests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Solves part of #958

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on KinD with controller
```
kind delete cluster; kind create cluster
arkade install openfaas \
  --set faasnetes.image=welteki/faas-netes:request-validation 

PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
```

Verified responses
```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": null,
  "image": null
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 60
Content-Type: text/plain; charset=utf-8
Date: Tue, 24 May 2022 15:15:49 GMT
X-Content-Type-Options: nosniff

validation failed: service: is required; image: is required
```

```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": "welteki-fn",
  "image": null
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 38
Content-Type: text/plain; charset=utf-8
Date: Tue, 24 May 2022 15:17:09 GMT
X-Content-Type-Options: nosniff

validation failed: image: is required
```

```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": "invalid_fn",
  "image": ""                       
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 99
Content-Type: text/plain; charset=utf-8
Date: Tue, 24 May 2022 15:54:33 GMT
X-Content-Type-Options: nosniff

validation failed: service: (invalid_fn) is invalid, must be a valid DNS entry; image: is required
```

```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": "invalid_fn", 
  "image": "ghcr.io/openfaas/figlet"
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 79
Content-Type: text/plain; charset=utf-8
Date: Tue, 24 May 2022 15:41:56 GMT
X-Content-Type-Options: nosniff

validation failed: service: (invalid_fn) is invalid, must be a valid DNS entry
```

```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": "figlet",    
  "image": "ghcr.io/openfaas/figlet"
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 202 Accepted
Content-Length: 0
Date: Tue, 24 May 2022 15:44:21 GMT
```

Tested on KinD with operator
```
kind delete cluster; kind create cluster
arkade install openfaas \
  --set operator.create=true
  --set operator.image=welteki/faas-netes:request-validation

PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
```

Verified responses
```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": null,
  "image": null
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 40
Content-Type: text/plain; charset=utf-8
Date: Wed, 25 May 2022 13:10:12 GMT
X-Content-Type-Options: nosniff

validation failed: service: is required
```

```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": "welteki-fn",
  "image": null
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 38
Content-Type: text/plain; charset=utf-8
Date: Wed, 25 May 2022 13:12:33 GMT
X-Content-Type-Options: nosniff

validation failed: image: is required
```

```
curl -i -u "admin:$PASSWORD" -X POST --data-binary '{
  "service": "invalid_fn", 
  "image": "ghcr.io/openfaas/figlet"
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 79
Content-Type: text/plain; charset=utf-8
Date: Wed, 25 May 2022 13:13:29 GMT
X-Content-Type-Options: nosniff

validation failed: service: (invalid_fn) is invalid, must be a valid DNS entry
```

```
curl -i -u "admin:$PASSWORD" -X PUT --data-binary '{
  "service": "",          
  "image": "ghcr.io/openfaas/figlet"
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 40
Content-Type: text/plain; charset=utf-8
Date: Wed, 25 May 2022 13:14:30 GMT
X-Content-Type-Options: nosniff

validation failed: service: is required
```

```
curl -i -u "admin:$PASSWORD" -X PUT --data-binary '{
  "service": "figlet",    
  "image": null                     
}' http://127.0.0.1:8080/system/functions
HTTP/1.1 400 Bad Request
Content-Length: 38
Content-Type: text/plain; charset=utf-8
Date: Wed, 25 May 2022 13:15:30 GMT
X-Content-Type-Options: nosniff

validation failed: image: is required
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
