### PR TITLE
Enable Prometheus scraping for pro-builder

### DIFF
--- a/chart/pro-builder/Chart.yaml
+++ b/chart/pro-builder/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Build OpenFaaS functions via a REST API
 name: pro-builder
-version: 0.3.0
+version: 0.3.1
 sources:
 - https://github.com/openfaas/faas-netes
 home: https://www.openfaas.com

--- a/chart/pro-builder/templates/deployment.yml
+++ b/chart/pro-builder/templates/deployment.yml
@@ -29,7 +29,8 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "false"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8081"
       labels:
         app: {{ template "builder.name" . }}
         component: pro-builder

--- a/chart/pro-builder/values.yaml
+++ b/chart/pro-builder/values.yaml
@@ -3,7 +3,7 @@
 
 # image is for the pro-builder API
 proBuilder:
-  image: ghcr.io/openfaasltd/pro-builder:0.2.0
+  image: ghcr.io/openfaasltd/pro-builder:0.3.0
   securityContext: {}
 
 # buildkit.image is for the buildkit daemon


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The latest pro-builder now has Prometheus metrics available.
Enable Prometheus scraping for the pro-builder metrics.
- Bump pro-builder image 0.2.0 -> 0.3.0
- Enable Prometheus scraping

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified that the pro-builder pods appear in the Prometheus targets and that metrics from the builder are available.
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
