### PR TITLE
Passing extra env variables to gateway

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -129,7 +129,7 @@ spec:
         {{- if .Values.gateway.extraEnv }}
         {{- range $k, $v := .Values.gateway.extraEnv }}
         - name: {{ $v.name }}
-          value: {{ $v.value }}
+          value: "{{ $v.value }}"
         {{- end }}
         {{- end }}
         {{- if .Values.basic_auth }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -126,6 +126,12 @@ spec:
           value: "{{ .Values.nats.channel }}"
         {{- end }}
         {{- end }}
+        {{- if .Values.gateway.extraEnv }}
+        {{- range $k, $v := .Values.gateway.extraEnv }}
+        - name: {{ $v.name }}
+          value: {{ $v.value }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.basic_auth }}
         - name: basic_auth
           value: "true"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -109,6 +109,12 @@ gateway:
   upstreamTimeout: "60s"  # Must be smaller than read/write_timeout
   replicas: 1
   scaleFromZero: true
+  # You can pass extra environment variables to gateway application e.g
+  # extraEnv:
+  #   - name: faas_prometheus_host
+  #     value: "prometheus.monitoring.svc.cluster.local"
+  #   - name: faas_prometheus_port
+  #     value: "9090"
   # change the port when creating multiple releases in the same baremetal cluster
   nodePort: 31112
   maxIdleConns: 1024


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Passing down extra environment variables to `gateway` Deployment
## Description
<!--- Describe your changes in detail -->
There should be option to pass extra environment variables/config to gateway application.
So I've added `extraEnv` in `gateway` object and updated the `gateway-dep.yml` template.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I needed to use my own prometheus and there is no way to pass down `faas_prometheus_host` and `faas_prometheus_port` to `gateway` application so I added new object in `.Values.gateway.extraEnv` that can contain any environment variables that can passed down to `gateway`
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
