### PR TITLE
Add insecureTLS config for queue-worker to chart

### DIFF
--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -91,6 +91,10 @@ spec:
           value: "{{ .Values.queueWorkerPro.printRequestBody }}"
         - name: print_response_body
           value: "{{ .Values.queueWorkerPro.printResponseBody }}"
+        {{- if .Values.openfaasPro }}
+        - name: tls_insecure
+          value: "{{ .Values.queueWorkerPro.insecureTLS }}"
+        {{- end }}
 
         {{- if .Values.basic_auth }}
         - name: secret_mount_path

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -67,8 +67,6 @@ spec:
           value: "{{ .Values.queueWorker.queueGroup }}"
         - name: faas_gateway_address
           value: "gateway.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
-        - name: "gateway_invoke"
-          value: "{{ .Values.queueWorker.gatewayInvoke }}"
         {{- if .Values.functionNamespace }}
         - name: faas_function_suffix
           value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -192,6 +192,7 @@ queueWorkerPro:
   # 503 Service Unavailable
   # 504 Gateway Timeout
   httpRetryCodes: "408,429,500,502,503,504"
+  insecureTLS: false
   printRequestBody: false
   printResponseBody: false
 

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -202,7 +202,6 @@ queueWorker:
   replicas: 1
   # Control the concurrent invocations
   maxInflight: 1
-  gatewayInvoke: true
   queueGroup: "faas"
   ackWait: "60s"
   resources:


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a config value to enable insecure tls on the queue-worker.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The queue-worker supports enabling insecure tls using an env variable. Make this configuration available in the OpenFaaS Chart.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Install OpenFaaS Pro with the updated chart and `--set queueWorkerPro.insecureTLS=true`
```bash
helm upgrade openfaas --install chart/openfaas \                    
    --namespace openfaas  \
    --set functionNamespace=openfaas-fn \
    --set generateBasicAuth=true \
    --set openfaasPro=true \
    --set autoscaler.enabled=true \
    --set queueWorkerPro.insecureTLS=true
```

2. Verify the deploy was successful and the `tls_insecure` env variable set correctly.
```
kubectl describe deploy/queue-worker -n openfaas | grep tls_insecure
       tls_insecure:           true
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
