### PR TITLE
Simplify faas-netes timeout configuration for the openfaas chart

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -1,4 +1,6 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- $providerReadTimeout :=  default .Values.gateway.readTimeout .Values.faasnetes.readTimeout }}
+{{- $providerWriteTimeout :=  default .Values.gateway.writeTimeout .Values.faasnetes.writeTimeout }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -188,9 +190,9 @@ spec:
           - name: profiles_namespace
             value: {{ .Release.Namespace | quote }}
           - name: read_timeout
-            value: "{{ .Values.faasnetes.readTimeout }}"
+            value: "{{ $providerReadTimeout }}"
           - name: write_timeout
-            value: "{{ .Values.faasnetes.writeTimeout }}"
+            value: "{{ $providerWriteTimeout }}"
           - name: image_pull_policy
             value: {{ .Values.faasnetes.imagePullPolicy | quote }}
           - name: http_probe
@@ -250,11 +252,11 @@ spec:
         - name: function_namespace
           value: {{ $functionNs | quote }}
         - name: read_timeout
-          value: "{{ .Values.faasnetes.readTimeout }}"
+          value: "{{ $providerReadTimeout }}"
         - name: profiles_namespace
           value: {{ .Release.Namespace | quote }}
         - name: write_timeout
-          value: "{{ .Values.faasnetes.writeTimeout }}"
+          value: "{{ $providerWriteTimeout }}"
         - name: image_pull_policy
           value: {{ .Values.faasnetes.imagePullPolicy | quote }}
         - name: http_probe

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -145,8 +145,6 @@ operatorPro:
 
 faasnetes:
   image: ghcr.io/openfaas/faas-netes:0.15.1
-  readTimeout: "60s"
-  writeTimeout: "60s"
   imagePullPolicy: "Always"    # Image pull policy for deployed functions
   httpProbe: true              # Setting to true will use HTTP for readiness and liveness probe on function pods
   setNonRootUser: false        # It's recommended to set this to "true", but test your images before committing to it


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Simplify faas-netes timeouts in the openfaas chart

Use the geteway readTimeout and writeTimeout values as default if
faasnetes.readTimeout or faasnetes.writeTimeout is not set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OpenFaaS has a many different timeouts to keep track of. In most cases timeouts for the gateway and faas-netes are set to the same value. To simplify configuration the values set for the gateway can be used as defaults for faas-netes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deployed OpenFaaS Pro with this updated chart and set some small timeouts for testing.
```
helm upgrade openfaas --install chart/openfaas \
    --namespace openfaas  \
    --set functionNamespace=openfaas-fn \
    --set generateBasicAuth=true \
    --set openfaasPro=true \
    --set autoscaler.enabled=true \
    --set gateway.readTimeout=5s \
    --set gateway.writeTimeout=5s \
    --set gateway.upstreamTimeout=4s
```

Verified the correct env values are set in the deployment by running
```
kubectl describe deploy/gateway -n openfaas
```
2. Deployed the sleep function
```
faas-cli store deploy sleep
```
3. Invoked the function using hey
```
hey -n 200 -c 4 -H "X-Sleep: 3900ms" http://127.0.0.1:8080/function/sleep

Summary:
  Total:        195.1964 secs
  Slowest:      3.9062 secs
  Fastest:      3.9034 secs
  Average:      3.9039 secs
  Requests/sec: 1.0246
  
  Total data:   22800 bytes
  Size/request: 114 bytes

Response time histogram:
  3.903 [1]     |
  3.904 [46]    |■■■■■■■■■■■■■■■■■■■
  3.904 [97]    |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  3.904 [42]    |■■■■■■■■■■■■■■■■■
  3.905 [10]    |■■■■
  3.905 [0]     |
  3.905 [0]     |
  3.905 [0]     |
  3.906 [0]     |
  3.906 [0]     |
  3.906 [4]     |■■


Latency distribution:
  10% in 3.9036 secs
  25% in 3.9037 secs
  50% in 3.9038 secs
  75% in 3.9040 secs
  90% in 3.9042 secs
  95% in 3.9044 secs
  99% in 3.9062 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.0000 secs, 0.0002 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:    0.0000 secs, 0.0000 secs, 0.0001 secs
  resp wait:    3.9038 secs, 3.9033 secs, 3.9060 secs
  resp read:    0.0000 secs, 0.0000 secs, 0.0001 secs

Status code distribution:
  [200] 200 responses
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
