### PR TITLE
Tune capacity mode autoscaling metric

### DIFF
--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -184,7 +184,7 @@ data:
           scaling_type: rps
 
       - record: job:function_current_load:sum
-        expr: sum by(function_name) (gateway_function_invocation_started) - sum by(function_name) (gateway_function_invocation_total) and avg by(function_name) (gateway_service_target_load{scaling_type="capacity"}) > bool 1
+        expr: sum by (function_name) ( max_over_time( gateway_function_invocation_inflight[45s:5s])) and on (function_name) avg by(function_name) (gateway_service_target_load{scaling_type="capacity"}) > bool 1
         labels:
           scaling_type: capacity
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Tune capacity mode autoscaling metric

## Motivation and Context

I noticed some unexpected osculation between replicas due to the way metrics are scraped and calculated with a delay in Prometheus. 

Updates the way that job:function_current_load:sum is calculated for capacity-mode autoscaling in OpenFaaS Pro.

* Uses the new gateway_function_invocation_inflight metric with a 45 second smoothing window applied over the top to counter osculation
* Applies a sum over gateway_function_invocation_inflight for when there are multiple gateway replicas being scraped

```
#!/bin/bash

export HOST=127.0.0.1:8080

hey -c 6 -z 30s http://${HOST}/function/sleep

sleep 10

hey -c 4 -z 30s http://${HOST}/function/sleep

sleep 30

hey -c 3 -z 60s http://${HOST}/function/sleep
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with hey, which created some premature scaling down with the old version, which remained stable in the new version

Here is a before/after for the input data into the auto-scaler for the current load in capacity mode:

![Screenshot from 2022-08-31 11-00-37](https://user-images.githubusercontent.com/6358735/187657637-44777174-538b-4bbf-8dca-595fdb532b2d.png)
