### PR TITLE
Add max_inflight configuration to pro-builder

### DIFF
--- a/chart/pro-builder/.gitignore
+++ b/chart/pro-builder/.gitignore
@@ -1,1 +1,4 @@
 /ae-values.yaml
+/out/**
+/payload.txt
+

--- a/chart/pro-builder/Chart.yaml
+++ b/chart/pro-builder/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Build OpenFaaS functions via a REST API
 name: pro-builder
-version: 0.3.3
+version: 0.3.4
 sources:
 - https://github.com/openfaas/faas-netes
 home: https://www.openfaas.com

--- a/chart/pro-builder/templates/deployment.yml
+++ b/chart/pro-builder/templates/deployment.yml
@@ -85,9 +85,25 @@ spec:
             value: "tcp://127.0.0.1:1234"
           - name: "disable_hmac"
             value: {{ .Values.disableHmac | quote }}
+          - name: "max_inflight"
+            value: {{ or .Values.proBuilder.maxInflight 0  | quote }}
         ports:
         - containerPort: 8080
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          failureThreshold: 1
         {{- with .Values.proBuilder.securityContext }}
         securityContext:
           {{- . | toYaml | nindent 12 }}

--- a/chart/pro-builder/values.yaml
+++ b/chart/pro-builder/values.yaml
@@ -4,11 +4,30 @@
 # image is for the pro-builder API
 proBuilder:
   image: ghcr.io/openfaasltd/pro-builder:0.3.2
+
+  # Set to 0 for unlimited, or some non-zero value for a hard limit
+  # the builder will return a HTTP 429 status code, then the client 
+  # must retry the request. If it's helpful to you, the OpenFaaS Pro 
+  # queue-worker supports retrying failed requests. 
+  maxInflight: 0
+
   securityContext: {}
 
 # buildkit.image is for the buildkit daemon
 # Check for the latest release on GitHub: https://github.com/moby/buildkit/releases
+#
+# Both configurations are "rootless", however the rootless: true mode does not
+# require Buildkit to run as a privileged container and is preferred.
+
+ 
 buildkit:
+  # A configuration which uses a privileged container for when 
+  # your nodes have issues running in rootless mode
+  #
+  # Use rootless if possible, and if not, set up a dedicated 
+  # nodepool for the function builder pods, which is recycled often
+  # through the use of spot instances or preemptive VMs.
+  #
   # image: moby/buildkit:v0.10.3
   # rootless: false
   # securityContext:
@@ -16,7 +35,9 @@ buildkit:
   #   runAsGroup: 0
   #   privileged: true
 
-  # For a rootless configuration
+  # For a rootless configuration, preferred, if the configuration
+  # and Kernel version of your Kubernetes nodes supports it
+  # 
   image: moby/buildkit:master-rootless
   rootless: true
   securityContext:


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add max_inflight configuration to pro-builder

## Motivation and Context

This setting will limit concurrent builds in the pro-builder including marking pods as "unready" and removing their endpoints from the Kubernetes services for the pro-builder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See below, when I set a max_inflight to 1 and started a second build:

```bash
kubectl get endpoints -n openfaas pro-builder -w
NAME          ENDPOINTS          AGE
pro-builder   10.42.3.161:8080   42m
pro-builder                      43m
pro-builder   10.42.3.161:8080   44m
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.

Docs updated at: https://docs.openfaas.com/openfaas-pro/builder/#limiting-the-amount-of-concurrent-requests