### PR TITLE
Added retention period in prometheus configmap

### DIFF
--- a/chart/openfaas/templates/prometheus-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-cfg.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 data:
   prometheus.yml: |
+{{- if .Values.prometheus.retentionPeriod }}
+    storage:
+      tsdb:
+        retention:
+          time: {{ .Values.prometheus.retentionPeriod }}
+{{- end }}
     global:
       scrape_interval:     15s
       evaluation_interval: 15s

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -239,6 +239,8 @@ queueWorker:
 prometheus:
   image: prom/prometheus:v2.38.0
   create: true
+  # Retention period can be configured if the disk space is limited
+  retentionPeriod: 10d
   resources:
     requests:
       memory: "512Mi"


### PR DESCRIPTION
Data retention period for `prometheus` should be configureable.
## Description
Added optional parameter `retentionPeriod` in `.Values.prometheus` object 

## Motivation and Context
As disk space is used for prometheus storage and default retention period is 15 days. If one has limited disk space then the retention period should be configureable.
- [ No] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested this in minikube

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
