### PR TITLE
Fix config parameter name in postgres-connector README

### DIFF
--- a/chart/postgres-connector/README.md
+++ b/chart/postgres-connector/README.md
@@ -43,7 +43,7 @@ $ kubectl create secret generic -n openfaas \
 Create a `pgconnector.yaml` file with the following custom contents:
 
 ```yaml
-connectionFileSecret: "postgres-connection-file"
+connectionSecret: "postgresql-connection"
 
 publication: "ofltd"
 
@@ -83,7 +83,7 @@ Additional postgres-connector options in `values.yaml`.
 
 | Parameter                | Description                                                                            | Default                        |
 | ------------------------ | -------------------------------------------------------------------------------------- | ------------------------------ |
-| `connectionFileSecret`  | The name of the secret containing the connection string                                | `postgresql-connection`        |
+| `connectionSecret`       | The name of the secret containing the connection string                                | `postgresql-connection`        |
 | `publication`           | The name of the publication to be created in Postgres, we do not recommend changing this value. | `ofltd`                        |
 | `filters`                | A comma separated list of filters to apply to the stream i.e. `TABLENAME:ACTION`, action can be: `insert`, `delete` or `update`, multiple items can be comma separated such as `T1:insert,T2:delete,T3:insert`  | `""`                           |
 | `upstreamTimeout`        | Maximum timeout for upstream function call, must be a Go formatted duration string.    | `2m`                          |


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update the README to use the correct Helm parameter for the connection secret name.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Ensure the correct parameters are mentioned in the README.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the parameter is named `connectionSecret` in the templetes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
