### PR TITLE
Fix invalid port flag in sns-connector command

### DIFF
--- a/chart/sns-connector/templates/deployment.yml
+++ b/chart/sns-connector/templates/deployment.yml
@@ -53,7 +53,7 @@ spec:
             - "-license-file=/var/secrets/license/license"
             - "-callback-url={{ .Values.callbackURL }}/"
             - "-arn={{.Values.topicARN }}"
-            - "-port 8080"
+            - "-port=8080"
           env:
             - name: gateway_url
               value: {{ .Values.gatewayURL | quote }}


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the command for the connector container in the `deployment.yaml` of the SNS connector. The port flag was not used correctly.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Starting the sns-connector fails because the command was not valid.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified deploying the chart works and the sns-connector starts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
