### PR TITLE
Fix callback-url and add confirm-timeout flag

### DIFF
--- a/chart/sns-connector/Chart.yaml
+++ b/chart/sns-connector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Invoke functions from an AWS SNS messages.
 name: sns-connector
-version: 0.1.0
+version: 0.1.1
 sources:
 - https://github.com/openfaas/faas-netes
 home: https://www.openfaas.com

--- a/chart/sns-connector/templates/deployment.yml
+++ b/chart/sns-connector/templates/deployment.yml
@@ -51,9 +51,10 @@ spec:
           command:
             - "/usr/bin/connector"
             - "-license-file=/var/secrets/license/license"
-            - "-callback-url={{ .Values.callbackURL }}/"
+            - "-callback-url={{ .Values.callbackURL }}"
             - "-arn={{.Values.topicARN }}"
             - "-port=8080"
+            - "-confirm-timeout=30s"
           env:
             - name: gateway_url
               value: {{ .Values.gatewayURL | quote }}

--- a/chart/sns-connector/values.yaml
+++ b/chart/sns-connector/values.yaml
@@ -5,7 +5,7 @@
 # You will need to create a license named "openfaas-license" - see the
 # chart README for detailed instructions.
 
-image: ghcr.io/openfaasltd/sns-connector:0.0.1
+image: ghcr.io/openfaasltd/sns-connector:0.0.2
 
 replicas: 1
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Remove a slash appended to the end of the callback-url
- Bump the image to 0.0.2
- set `confirm-timeout` to default of 30s

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes issue where subscription could not be confirmed because the wrong callback-url was used.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with Ingress in debugging session together with Alex.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
