### PR TITLE
Add maxWaiting parameter for jetstream-queue-worker

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -508,6 +508,7 @@ yaml) |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `jetstreamQueueWorker.durableName` | Durable name used by JetStream consumers | `faas-workers` |
 | `jetstreamQueueWorker.image` | Container image used for the queue-worker when the `queueMode` is `jetstream` | See [values.yaml](./values.yaml) |
+| `jetstreamQueueWorker.maxWaiting` | Configure the max waiting pulls for the queue-worker JetStream consumer. The value should be at least max_inflight * queue_worker.replicas. Note that this value can not be updated once the consumer is created. | `512` |
 | `jetstreamQueueWorker.logs.debug` | Log debug messages | `false` |
 | `jetstreamQueueWorker.logs.format` | Set the log format, supports `console` or `json` | `console` |
 | `nats.channel` | The name of the NATS Streaming channel or NATS JetStream stream to use for asynchronous function invocations | `faas-request` |

--- a/chart/openfaas/templates/jetstream-queueworker-dep.yaml
+++ b/chart/openfaas/templates/jetstream-queueworker-dep.yaml
@@ -62,6 +62,8 @@ spec:
           value: "{{ .Values.queueWorker.ackWait }}"
         - name: max_inflight
           value: "{{ .Values.queueWorkerPro.maxInflight }}"
+        - name: max_waiting
+          value: "{{ .Values.jetstreamQueueWorker.maxWaiting }}"
         - name: "debug"
           value: "{{ .Values.jetstreamQueueWorker.logs.debug }}"
         - name: "log_encoding"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -182,8 +182,12 @@ operator:
 #  
 # Enable automatically when nats.queueMode is set to "jetstream"
 jetstreamQueueWorker:
-  image: ghcr.io/openfaasltd/jetstream-queue-worker:0.3.5
+  image: ghcr.io/openfaasltd/jetstream-queue-worker:0.3.6
   durableName: "faas-workers"
+  # Configure the max waiting pulls for the queue-worker JetStream consumer. 
+  # The value should be at least max_inflight * replicas.
+  # Note that this value can not be updated once the consumer is created.
+  maxWaiting: 512
   logs:
     debug: false
     format: "console"
@@ -264,7 +268,7 @@ nats:
     host: ""
     port: ""
   # The version of NATS Core used with OpenFaaS Pro and JetStream
-  image: nats:2.9.14
+  image: nats:2.9.15
   enableMonitoring: false
   metrics:
     # Should stay off by default because the exporter is not multi-arch (yet)

--- a/chart/queue-worker/Chart.yaml
+++ b/chart/queue-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: queue-worker
 description: JetStream for OpenFaaS queue-worker
 type: application
-version: 0.1.4
+version: 0.1.5
 keywords:
 - openfaas
 - jetstream

--- a/chart/queue-worker/README.md
+++ b/chart/queue-worker/README.md
@@ -33,6 +33,8 @@ helm upgrade slow-queue chart/queue-worker \
 |-----------|-------------|---------|
 | `image` | The jetstream-queue-worker image that should be deployed | See values.yaml |
 | `replicas` | Number of queue-worker replicas to create | `1` |
+| `maxInflight` | Control the concurrent invocations | `1` |
+| `maxWaiting` | Configure the max waiting pulls for the queue-worker JetStream consumer. The value should be at least max_inflight * queue_worker.replicas. Note that this value can not be updated once the consumer is created. | `512` |
 | `upstreamTimeout` | Maximum duration of upstream function call | `1m` |
 | `maxRetryAttempts` | The amount of times to try sending a message to a function before discarding it |`10` |
 | `maxRetryWait` | The maximum amount of time to wait between retries | `120s` |

--- a/chart/queue-worker/templates/deployment.yaml
+++ b/chart/queue-worker/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
               value: "{{ .Values.gateway.host }}:{{ .Values.gateway.port }}"
             - name: "max_inflight"
               value: "{{ .Values.maxInflight }}"
+            - name: max_waiting
+              value: "{{ .Values.maxWaiting }}"
             - name: "upstream_timeout"
               value: "{{ .Values.upstreamTimeout }}"
             - name: "tls_insecure"

--- a/chart/queue-worker/values.yaml
+++ b/chart/queue-worker/values.yaml
@@ -1,8 +1,13 @@
-image: ghcr.io/openfaasltd/jetstream-queue-worker:0.3.5
+image: ghcr.io/openfaasltd/jetstream-queue-worker:0.3.6
 
 replicas: 1
 
 maxInflight: 1
+
+# Configure the max waiting pulls for the queue-worker JetStream consumer. 
+# The value should be at least max_inflight * replicas.
+# Note that this value can not be updated once the consumer is created.
+maxWaiting: 512
 
 upstreamTimeout: "1m"
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add `maxWaiting` parameter for the JetStream queue-worker. Allows users to configure the max waiting pulls for the queue-worker JetStream consumer.

WIP: the JetStream queue-worker needs a new release and the image needs to be updated in this PR.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allow users to set the MaxWaiting configuration for a consumer without having to create the consumer manually.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the generated templates and checked the `max_waiting` environment variable is included in the deployment:

```bash
helm template chart/openfaas \
  --set openfaasPro=true \
  --set queueMode=jetstream
```

```bash
helm template chart/queue-worker 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
