### PR TITLE
Add parameter for signing key secret used by dashboard

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -546,6 +546,7 @@ yaml) |
 | `dashboard.publicURL` | URL used to expose the dashboard. Needs to be a fully qualified domain name (FQDN) | `https://dashboard.example.com` |
 | `dashboard.replicas` | Replicas of the dashboard | `1` |
 | `dashboard.resources` | Resource limits and requests for the dashboard pods | See [values.yaml](./values.yaml) |
+| `dashboard.signingKeySecret` | Name of signing key secret for sessions. Can be left blank for development, see https://docs.openfaas.com/openfaas-pro/dashboard/ for production and staging. | `""` |
 
 ### OIDC / SSO (OpenFaaS Pro)
 

--- a/chart/openfaas/templates/NOTES.txt
+++ b/chart/openfaas/templates/NOTES.txt
@@ -8,3 +8,9 @@ To retrieve the admin password, run:
 
   echo $(kubectl -n {{ .Release.Namespace }} get secret basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode)
 {{- end }}
+
+{{- if and .Values.dashboard.enabled (not .Values.dashboard.signingKeySecret) }}
+
+Warning: The dashboard is using auto generated signing keys.
+These should only be used for development. See: https://docs.openfaas.com/openfaas-pro/dashboard/
+{{- end}}

--- a/chart/openfaas/templates/dashboard-dep.yaml
+++ b/chart/openfaas/templates/dashboard-dep.yaml
@@ -32,9 +32,11 @@ spec:
       - name: license
         secret:
           secretName: openfaas-license
+      {{- if .Values.dashboard.signingKeySecret }}
       - name: dashboard-jwt
         secret:
-          secretName: dashboard-jwt
+          secretName: {{ .Values.dashboard.signingKeySecret }}
+      {{- end }}
       containers:
       - name:  dashboard
         resources:
@@ -79,13 +81,14 @@ spec:
           readOnly: true
           mountPath: "/var/secrets/gateway"
         {{- end }}
-
         - name: license
           readOnly: true
           mountPath: "/var/secrets/license"
+        {{- if .Values.dashboard.signingKeySecret }}
         - name: dashboard-jwt
           readOnly: true
           mountPath: "/var/secrets/dashboard-jwt"
+        {{- end }}
 
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -49,8 +49,11 @@ autoscaler:
 ## To use with port-forwarding, set publicURL to 
 ## http://127.0.0.1
 dashboard:
-  image: ghcr.io/openfaasltd/openfaas-dashboard:0.1.1
+  image: ghcr.io/openfaasltd/openfaas-dashboard:0.2.0
   publicURL: https://dashboard.example.com
+  # Name of signing key secret for sessions.
+  # Leave blank for development, see https://docs.openfaas.com/openfaas-pro/dashboard/ for production and staging.
+  signingKeySecret: ""
   replicas: 1
   enabled: false
   resources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a helm parameter `dashboard.signingKeySecret` to select the signing keys secret for the dashboard.

Impact: Users currently using the dashboard in staging or production will have to set the `dashboard.signingKeySecret` parameter to select their current signing key secret.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows users to select the secret with the signing keys or leave blank to have the keys generated automatically by the dashboard.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Used the chart to deploy the dashboard both with and without the `dashboard.signingKeySecret` parameter set and verified the dashboard-jwt volume is only mounted when the parameter is set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
