### PR TITLE
Remove alertmanager from OpenFaaS Pro deployment.

### DIFF
--- a/chart/openfaas/templates/alertmanager-cfg.yaml
+++ b/chart/openfaas/templates/alertmanager-cfg.yaml
@@ -1,4 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if not .Values.openfaasPro }}
 {{- if .Values.alertmanager.create }}
 ---
 kind: ConfigMap
@@ -44,4 +45,5 @@ data:
               username: admin
               password_file: /var/secrets/basic-auth-password
           {{- end -}}
+{{- end }}
 {{- end }}

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -1,4 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if not .Values.openfaasPro }}
 {{- if .Values.alertmanager.create }}
 ---
 apiVersion: apps/v1
@@ -105,4 +106,5 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/chart/openfaas/templates/alertmanager-svc.yaml
+++ b/chart/openfaas/templates/alertmanager-svc.yaml
@@ -1,4 +1,5 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if not .Values.openfaasPro }}
 {{- if .Values.alertmanager.create }}
 ---
 apiVersion: v1
@@ -19,4 +20,5 @@ spec:
       protocol: TCP
   selector:
     app: alertmanager
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Alert manager is only used in OpenFaaS CE, remove it from the OpenFaaS Pro deployment.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Alertmanager is not used by OpenFaaS Pro.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Installed the chart for CE and Pro. Verified alertmanager resources are only deployed with OpenFaaS CE

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
