### PR TITLE
Always mount license in autoscaler

### DIFF
--- a/chart/openfaas/templates/autoscaler-dep.yaml
+++ b/chart/openfaas/templates/autoscaler-dep.yaml
@@ -51,15 +51,17 @@ spec:
           value: "prometheus.{{ .Release.Namespace }}"
         - name: prometheus_port
           value: "9090"
-        {{- if .Values.basic_auth }}
         - name: secret_mount_path
           value: "/var/secrets/autoscaler"
+        {{- if .Values.basic_auth }}
         - name: basic_auth
-          value: "{{ .Values.basic_auth }}"
+          value: "true"
+        {{- end }}
         volumeMounts:
         - name: license
           readOnly: true
           mountPath: "/var/secrets/license"
+        {{- if .Values.basic_auth }}
         - name: auth
           readOnly: true
           mountPath: "/var/secrets/autoscaler"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -32,7 +32,7 @@ openfaasImagePullPolicy: "Always"
 ## Advanced auto-scaler for scaling functions on RPS, CPU and in-flight requests
 ## Includes: scale to zero
 autoscaler:
-  image: ghcr.io/openfaasltd/autoscaler:0.2.7
+  image: ghcr.io/openfaasltd/autoscaler:0.2.9
   replicas: 1
   enabled: true
   resources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Always mount license mount the OpenFaaS license in the autoscaler container. The secret was not mounted when the `basic_auth` parameter was set to false in the chart.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The autoscaler would not start when basic auth is disabled in the chart.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the auth secret is always mounted:

```bash
helm template chart/openfaas \
    --namespace openfaas \
    --set basic_auth=false \
    -f chart/openfaas/values-pro.yaml \
    --show-only templates/autoscaler-dep.yaml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
