### PR TITLE
Add additional probing parameters to the openfaas chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -479,9 +479,12 @@ yaml) |
 | `faasnetes.livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) is initiated  | `2` |
 | `faasnetes.livenessProbe.periodSeconds` | How often (in seconds) to perform the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `2` |
 | `faasnetes.livenessProbe.timeoutSeconds` | Number of seconds after which the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) times out | `1` |
+| `faasnetes.livenessProbe.failureThreshold` | After a [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) fails failureThreshold times in a row, Kubernetes considers that the overall check has failed. | `3 `|
 | `faasnetes.readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) is initiated | `2` |
 | `faasnetes.readinessProbe.periodSeconds` | How often (in seconds) to perform the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `2` |
 | `faasnetes.readinessProbe.timeoutSeconds` | Number of seconds after which the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) times out | `1` |
+| `faasnetes.readinessProbe.successThreshold` | Minimum consecutive successes for the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) to be considered successful after having failed. | `1` |
+| `faasnetes.readinessProbe.failureThreshold` | After a [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) fails failureThreshold times in a row, Kubernetes considers that the overall check has failed. | `3 `|
 | `faasnetes.readTimeout` | Read timeout for the faas-netes API | `""` (defaults to gateway.readTimeout)|
 | `faasnetes.resources` | Resource limits and requests for faas-netes container | See [values.yaml](./values.yaml) |
 | `faasnetes.setNonRootUser` | Force all function containers to run with user id `12000` | `false` |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -473,27 +473,32 @@ yaml) |
 
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
-| `faasnetes.httpProbe` | Use a httpProbe instead of exec | `true` |
 | `faasnetes.image` | Container image used for provider API | See [values.yaml](./values.yaml) |
-| `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
-| `faasnetes.livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) is initiated  | `2` |
-| `faasnetes.livenessProbe.periodSeconds` | How often (in seconds) to perform the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `2` |
-| `faasnetes.livenessProbe.timeoutSeconds` | Number of seconds after which the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) times out | `1` |
-| `faasnetes.livenessProbe.failureThreshold` | After a [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) fails failureThreshold times in a row, Kubernetes considers that the overall check has failed. | `3 `|
-| `faasnetes.readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) is initiated | `2` |
-| `faasnetes.readinessProbe.periodSeconds` | How often (in seconds) to perform the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `2` |
-| `faasnetes.readinessProbe.timeoutSeconds` | Number of seconds after which the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) times out | `1` |
-| `faasnetes.readinessProbe.successThreshold` | Minimum consecutive successes for the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) to be considered successful after having failed. | `1` |
-| `faasnetes.readinessProbe.failureThreshold` | After a [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) fails failureThreshold times in a row, Kubernetes considers that the overall check has failed. | `3 `|
 | `faasnetes.readTimeout` | Read timeout for the faas-netes API | `""` (defaults to gateway.readTimeout)|
 | `faasnetes.resources` | Resource limits and requests for faas-netes container | See [values.yaml](./values.yaml) |
-| `faasnetes.setNonRootUser` | Force all function containers to run with user id `12000` | `false` |
 | `faasnetes.writeTimeout` | Write timeout for the faas-netes API | `""` (defaults to gateway.writeTimeout) |
 | `faasnetesPro.image` | Container image used for faas-netes when `openfaasPro=true` | See [values.yaml](./values.yaml) |
 | `operator.create` | Use the OpenFaaS operator CRD controller, default uses faas-netes as the Kubernetes controller | `false` |
 | `operator.image` | Container image used for the openfaas-operator | See [values.yaml](./values.yaml) |
 | `operator.resources` | Resource limits and requests for openfaas-operator containers | See [values.yaml](./values.yaml) |
 | `operatorPro.image` | Container image used for the openfaas-operator when `openfaasPro=true` | See [values.yaml](./values.yaml) |
+
+### Functions
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `functions.httpProbe` | Use a httpProbe instead of exec | `true` |
+| `functions.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
+| `functions.livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) is initiated  | `2` |
+| `functions.livenessProbe.periodSeconds` | How often (in seconds) to perform the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `2` |
+| `functions.livenessProbe.timeoutSeconds` | Number of seconds after which the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) times out | `1` |
+| `functions.livenessProbe.failureThreshold` | After a [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) fails failureThreshold times in a row, Kubernetes considers that the overall check has failed. | `3 `|
+| `functions.readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) is initiated | `2` |
+| `functions.readinessProbe.periodSeconds` | How often (in seconds) to perform the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `2` |
+| `functions.readinessProbe.timeoutSeconds` | Number of seconds after which the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) times out | `1` |
+| `functions.readinessProbe.successThreshold` | Minimum consecutive successes for the [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) to be considered successful after having failed. | `1` |
+| `functions.readinessProbe.failureThreshold` | After a [probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) fails failureThreshold times in a row, Kubernetes considers that the overall check has failed. | `3 `|
+| `functions.setNonRootUser` | Force all function containers to run with user id `12000` | `false` |
 
 ### Autoscaler (OpenFaaS Pro)
 

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -216,29 +216,29 @@ spec:
           - name: write_timeout
             value: "{{ $providerWriteTimeout }}"
           - name: image_pull_policy
-            value: {{ .Values.faasnetes.imagePullPolicy | quote }}
+            value: {{ .Values.functions.imagePullPolicy | quote }}
           - name: http_probe
-            value: "{{ .Values.faasnetes.httpProbe }}"
+            value: "{{ .Values.functions.httpProbe }}"
           - name: set_nonroot_user
-            value: "{{ .Values.faasnetes.setNonRootUser }}"
+            value: "{{ .Values.functions.setNonRootUser }}"
           - name: readiness_probe_initial_delay_seconds
-            value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
+            value: "{{ .Values.functions.readinessProbe.initialDelaySeconds }}"
           - name: readiness_probe_timeout_seconds
-            value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
+            value: "{{ .Values.functions.readinessProbe.timeoutSeconds }}"
           - name: readiness_probe_period_seconds
-            value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+            value: "{{ .Values.functions.readinessProbe.periodSeconds }}"
           - name: readiness_probe_success_threshold
-            value: "{{ .Values.faasnetes.readinessProbe.successThreshold }}"
+            value: "{{ .Values.functions.readinessProbe.successThreshold }}"
           - name: readiness_probe_failure_threshold
-            value: "{{ .Values.faasnetes.readinessProbe.failureThreshold }}"
+            value: "{{ .Values.functions.readinessProbe.failureThreshold }}"
           - name: liveness_probe_initial_delay_seconds
-            value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
+            value: "{{ .Values.functions.livenessProbe.initialDelaySeconds }}"
           - name: liveness_probe_timeout_seconds
-            value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
+            value: "{{ .Values.functions.livenessProbe.timeoutSeconds }}"
           - name: liveness_probe_period_seconds
-            value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
+            value: "{{ .Values.functions.livenessProbe.periodSeconds }}"
           - name: liveness_probe_failure_threshold
-            value: "{{ .Values.faasnetes.livenessProbe.failureThreshold }}"
+            value: "{{ .Values.functions.livenessProbe.failureThreshold }}"
           - name: cluster_role
             value: "{{ .Values.clusterRole }}"
         ports:
@@ -284,29 +284,29 @@ spec:
         - name: write_timeout
           value: "{{ $providerWriteTimeout }}"
         - name: image_pull_policy
-          value: {{ .Values.faasnetes.imagePullPolicy | quote }}
+          value: {{ .Values.functions.imagePullPolicy | quote }}
         - name: http_probe
-          value: "{{ .Values.faasnetes.httpProbe }}"
+          value: "{{ .Values.functions.httpProbe }}"
         - name: set_nonroot_user
-          value: "{{ .Values.faasnetes.setNonRootUser }}"
+          value: "{{ .Values.functions.setNonRootUser }}"
         - name: readiness_probe_initial_delay_seconds
-          value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
+          value: "{{ .Values.functions.readinessProbe.initialDelaySeconds }}"
         - name: readiness_probe_timeout_seconds
-          value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
+          value: "{{ .Values.functions.readinessProbe.timeoutSeconds }}"
         - name: readiness_probe_period_seconds
-          value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+          value: "{{ .Values.functions.readinessProbe.periodSeconds }}"
         - name: readiness_probe_success_threshold
-          value: "{{ .Values.faasnetes.readinessProbe.successThreshold }}"
+          value: "{{ .Values.functions.readinessProbe.successThreshold }}"
         - name: readiness_probe_failure_threshold
-          value: "{{ .Values.faasnetes.readinessProbe.failureThreshold }}"
+          value: "{{ .Values.functions.readinessProbe.failureThreshold }}"
         - name: liveness_probe_initial_delay_seconds
-          value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
+          value: "{{ .Values.functions.livenessProbe.initialDelaySeconds }}"
         - name: liveness_probe_timeout_seconds
-          value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
+          value: "{{ .Values.functions.livenessProbe.timeoutSeconds }}"
         - name: liveness_probe_period_seconds
-          value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
+          value: "{{ .Values.functions.livenessProbe.periodSeconds }}"
         - name: liveness_probe_failure_threshold
-          value: "{{ .Values.faasnetes.livenessProbe.failureThreshold }}"
+          value: "{{ .Values.functions.livenessProbe.failureThreshold }}"
         - name: cluster_role
           value: "{{ .Values.clusterRole }}"
         volumeMounts:

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -227,12 +227,18 @@ spec:
             value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
           - name: readiness_probe_period_seconds
             value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+          - name: readiness_probe_success_threshold
+            value: "{{ .Values.faasnetes.readinessProbe.successThreshold }}"
+          - name: readiness_probe_failure_threshold
+            value: "{{ .Values.faasnetes.readinessProbe.failureThreshold }}"
           - name: liveness_probe_initial_delay_seconds
             value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
           - name: liveness_probe_timeout_seconds
             value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
           - name: liveness_probe_period_seconds
             value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
+          - name: liveness_probe_failure_threshold
+            value: "{{ .Values.faasnetes.livenessProbe.failureThreshold }}"
           - name: cluster_role
             value: "{{ .Values.clusterRole }}"
         ports:
@@ -289,12 +295,18 @@ spec:
           value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
         - name: readiness_probe_period_seconds
           value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+        - name: readiness_probe_success_threshold
+          value: "{{ .Values.faasnetes.readinessProbe.successThreshold }}"
+        - name: readiness_probe_failure_threshold
+          value: "{{ .Values.faasnetes.readinessProbe.failureThreshold }}"
         - name: liveness_probe_initial_delay_seconds
           value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
         - name: liveness_probe_timeout_seconds
           value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
         - name: liveness_probe_period_seconds
           value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
+        - name: liveness_probe_failure_threshold
+          value: "{{ .Values.faasnetes.livenessProbe.failureThreshold }}"
         - name: cluster_role
           value: "{{ .Values.clusterRole }}"
         volumeMounts:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -146,10 +146,10 @@ gateway:
     successThreshold: 1
 
 faasnetesPro:
-  image: ghcr.io/openfaasltd/faas-netes:0.2.9
+  image: ghcr.io/openfaasltd/faas-netes:0.3.1
 
 operatorPro:
-  image: ghcr.io/openfaasltd/faas-netes:0.2.9
+  image: ghcr.io/openfaasltd/faas-netes:0.3.1
 
 faasnetes:
   image: ghcr.io/openfaas/faas-netes:0.16.7
@@ -157,11 +157,11 @@ faasnetes:
   httpProbe: true              # Setting to true will use HTTP for readiness and liveness probe on function pods
   setNonRootUser: false        # It's recommended to set this to "true", but test your images before committing to it
   readinessProbe:
-    initialDelaySeconds: 2
+    initialDelaySeconds: 0
     timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
     periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
   livenessProbe:
-    initialDelaySeconds: 2
+    initialDelaySeconds: 0
     timeoutSeconds: 1
     periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
   resources:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -151,8 +151,8 @@ faasnetesPro:
 operatorPro:
   image: ghcr.io/openfaasltd/faas-netes:0.3.1
 
-faasnetes:
-  image: ghcr.io/openfaas/faas-netes:0.16.7
+
+functions:
   imagePullPolicy: "Always"    # Image pull policy for deployed functions
   httpProbe: true              # Setting to true will use HTTP for readiness and liveness probe on function pods
   setNonRootUser: false        # It's recommended to set this to "true", but test your images before committing to it
@@ -160,10 +160,16 @@ faasnetes:
     initialDelaySeconds: 0
     timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
     periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+    successThreshold: 1
+    failureThreshold: 3
   livenessProbe:
     initialDelaySeconds: 0
     timeoutSeconds: 1
     periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+    failureThreshold: 3
+  
+faasnetes:
+  image: ghcr.io/openfaas/faas-netes:0.16.7
   resources:
     requests:
       memory: "120Mi"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

1) Support configuration of failure and success threshold for function liveness and readiness probes.
2) Move parameters affecting functions to separate section

    Parameters used to configure default values for function deployments are
    included in the `faasnetes` section. This is counter intuitive. This
    change moves those parameters to a separate section named `functions`.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1) Make liveness and readiness probes on functions as tune-able as they are in Kubernetes.
2) Make the location of functions configuration parameters more intuitive.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Used this chart version while testing the the accompanying changes to faas-netes pro.

Deployed OpenFaaS with custom probing values and verified they are used for function deployments.

```yaml
functions:
  imagePullPolicy: 'IfNotPresent'
  setNonRootUser: true
  readinessProbe:
    initialDelaySeconds: 1
    timeoutSeconds: 2
    periodSeconds: 3
    failureThreshold: 4
    successThreshold: 5
  livenessProbe:
    initialDelaySeconds: 6
    timeoutSeconds: 7
    periodSeconds: 8
    failureThreshold: 9
```

![Screenshot 2023-06-01 at 14 17 35](https://github.com/openfaas/faas-netes/assets/16267532/d9ff77c5-c843-4f99-9af4-93004f410445)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Before publishing this change the chart version should be bumped to the next major version.

User that set one of the following parameters should rename them:

```diff
+functions:
+  imagePullPolicy: "Always"
+  httpProbe: true
+  setNonRootUser: false
+  readinessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1
+    periodSeconds: 2
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1
+    periodSeconds: 2
+    failureThreshold: 3

faasnetes:
-  imagePullPolicy: "Always"
-  httpProbe: true
-  setNonRootUser: false
-  readinessProbe:
-    initialDelaySeconds: 2
-    timeoutSeconds: 1
-    periodSeconds: 2
-    successThreshold: 1
-    failureThreshold: 3
-  livenessProbe:
-    initialDelaySeconds: 2
-    timeoutSeconds: 1
-    periodSeconds: 2
-    failureThreshold: 3
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
