### PR TITLE
Remove check for openfaasPro for operator in Helm template

### DIFF
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: OpenFaaS - Serverless Functions Made Simple
 name: openfaas
-version: 13.0.0
+version: 13.0.1
 sources:
 - https://github.com/openfaas/faas
 - https://github.com/openfaas/faas-netes

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -197,9 +197,7 @@ spec:
         command:
           - ./faas-netes
           - -operator=true
-        {{- if .Values.openfaasPro }}
           - "-license-file=/var/secrets/license/license"
-        {{- end }}
         env:
           - name: port
             value: "8081"
@@ -240,12 +238,10 @@ spec:
         ports:
         - containerPort: 8081
           protocol: TCP
-        {{- if .Values.openfaasPro }}
         volumeMounts:
         - name: license
           readOnly: true
           mountPath: "/var/secrets/license"
-        {{- end }}
 
       {{- else }}
       - name: faas-netes


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Remove check for openfaasPro for operator

## Why is this needed?

There is no need to check for openfaasPro when operator.create is set to true, because it's only available for openfaasPro customers.

This is some additional optimisation from previous commits.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The following gave no errors:

```
helm template chart/openfaas --set operator.create=true
helm template chart/openfaas --set operator.create=true --set openfaasPro=true
```

## Types of changes

Refactoring
