### PR TITLE
Remove check for openfaasPro for operator

### DIFF
--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -1,6 +1,11 @@
 {{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
 {{- $providerReadTimeout :=  default .Values.gateway.readTimeout .Values.faasnetes.readTimeout }}
 {{- $providerWriteTimeout :=  default .Values.gateway.writeTimeout .Values.faasnetes.writeTimeout }}
+
+{{- if and .Values.operator.create (not .Values.openfaasPro) }}
+  {{- fail "enabling 'operator.create' is only supported for OpenFaaS Pro" }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -213,9 +213,7 @@ spec:
         command:
           - ./faas-netes
           - -operator=true
-        {{- if .Values.openfaasPro }}
           - "-license-file=/var/secrets/license/license"
-        {{- end }}
         env:
           - name: port
             value: "8081"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove individual checks for openfaasPro when operator.create
is set to true, because it's only available for openfaasPro
customers.

Use a single check to fail when CE users set `operator.create=true`

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Don't allow CE users to deploy OpenFaaS with unsupported settings for the operator. Fail during helm deploy with a clear message.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified helm fails  when running helm upgrade with `openfaasPro=false` and `operator.create=true `
```
Error: UPGRADE FAILED: execution error at (openfaas/templates/gateway-dep.yaml:6:6): enabling 'operator.create' is only supported for OpenFaaS Pro
```

Verified deploying with `openfaasPro=true` and `operator.create=true ` succeeds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

CE users will get a clear message when using an unsupported config.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.