### PR TITLE
Add default OAuth scopes

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -561,7 +561,7 @@ yaml) |
 | `iam.dashboardIssuer.url` | URL of the OpenID connect provider to used by the dashboard | `https://example.eu.auth0.com` |
 | `iam.dashboardIssuer.clientId` | OAuth Client Id for the dashboard | `""` |
 | `iam.dashboardIssuer.clientSecret` | Name of the Kubernetes secret that contains the OAuth client secret for the dashboard | `""` |
-| `iam.dashboardIssuer.scopes` | OpenID Connect (OIDC) scopes for the dashboard | `[]` |
+| `iam.dashboardIssuer.scopes` | OpenID Connect (OIDC) scopes for the dashboard | `[openid, email, profile]` |
 
 ### Dashboard (OpenFaaS Pro)
 

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -227,7 +227,10 @@ iam:
     url: https://example.eu.auth0.com
     clientId: ""
     clientSecret: ""
-    scopes: []
+    scopes:
+      - openid
+      - profile
+      - email
 
 prometheus:
   image: prom/prometheus:v2.44.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a default list of required and common OAuth scopes to the dashboard issuer.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ensure the dashboard is deployed with the common OAuth scopes by default.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the chart can be deployed successfully with IAM enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
