### PR TITLE
Fix mounting the client secret for the dashboard

### DIFF
--- a/chart/openfaas/templates/dashboard-dep.yaml
+++ b/chart/openfaas/templates/dashboard-dep.yaml
@@ -113,7 +113,7 @@ spec:
         - name: aes-key
           readOnly: true
           mountPath: "/var/secrets/dashboard-aes"
-        {{- if .Values.dashboard.oauthClientSecret }}
+        {{- if .Values.iam.dashboardIssuer.clientSecret}}
         - name: oauth-client-secret
           readOnly: true
           mountPath: "/var/secrets/dashboard-oauth"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use the correct parameter to check the client secret ref is provided.

The template was still using the old parameter `.Values.dashboard.oauthClientSecret` instead of `.Values.iam.dashboardIssuer.clientSecret`

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ensure the oauth client secret is mounted in the dashboard when `.iam.dashboardIssuer.clientSecret` is set.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the deployment succeeds and the oauth-client-secret is mounted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
