### PR TITLE
Support token-based auth for cron-connector

### DIFF
--- a/chart/cron-connector/README.md
+++ b/chart/cron-connector/README.md
@@ -18,6 +18,21 @@ arkade install cron-connector
 arkade install cron-connector --set openfaasPro=true
 ```
 
+## Configure for token-based auth with [OpenFaaS IAM](https://docs.openfaas.com/openfaas-pro/iam/overview/)
+
+```yaml
+openfaasPro: true
+
+iam:
+  enabled: true
+  systemIssuer:
+  # URL for the OpenFaaS OpenID connect provider for system components. This is usually the public url of the gateway.
+    url: "https://gateway.example.com"
+  # Scope of access for the connector.
+  # By default it operates on all function namespaces.
+  resource: ["*"]
+```
+
 ## Install via the published chart
 
 - Add OpenFaaS chart repo to helm and install using the following command.
@@ -53,6 +68,10 @@ helm upgrade --install --namespace openfaas \
 | `gatewayURL`        | The URL for the API gateway.                                                 | `"http://gateway.openfaas:8080"` |
 | `basicAuth`         | Enable or disable basic auth                                                 | `true`                           |
 | `asyncInvocation`   | Invoke via the asynchronous function endpoint                                | `false`                          |
+| `iam.enabled` | Enable token-based authentication for use with OpenFaaS IAM | `false` |
+| `iam.systemIssuer.url` | URL for the OpenFaaS OpenID connect provider for system components. This is usually the public url of the gateway. | `"https://gateway.example.com"` |
+| `iam.resource` | Permission scope for the connecter. By default the connecter has access to all namespaces. | `["*"]` |
+
 | `contentType`       | Set a contentType for all invocations                                        | `text/plain`                     |
 | `logs.debug`        | Print debug logs (pro feature)                                               | `false`                          |
 | `logs.format`       | The log encoding format. Supported values: `json` or `console` (pro feature) | `console`                        |

--- a/chart/cron-connector/README.md
+++ b/chart/cron-connector/README.md
@@ -70,6 +70,7 @@ helm upgrade --install --namespace openfaas \
 | `asyncInvocation`   | Invoke via the asynchronous function endpoint                                | `false`                          |
 | `iam.enabled` | Enable token-based authentication for use with OpenFaaS IAM | `false` |
 | `iam.systemIssuer.url` | URL for the OpenFaaS OpenID connect provider for system components. This is usually the public url of the gateway. | `"https://gateway.example.com"` |
+| `iam.kubernetesIssuer.url` | URL for the Kubernetes service account issuer. | `"https://kubernetes.default.svc.cluster.local"` |
 | `iam.resource` | Permission scope for the connecter. By default the connecter has access to all namespaces. | `["*"]` |
 
 | `contentType`       | Set a contentType for all invocations                                        | `text/plain`                     |

--- a/chart/cron-connector/templates/_helpers.tpl
+++ b/chart/cron-connector/templates/_helpers.tpl
@@ -30,3 +30,15 @@ Create chart name and version as used by the chart label.
 {{- define "connector.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "connector.labels" -}}
+helm.sh/chart: {{ include "connector.chart" . }}
+app.kubernetes.io/name: {{ include "connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: cron-connector
+app.kubernetes.io/part-of: openfaas
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/chart/cron-connector/templates/deployment.yaml
+++ b/chart/cron-connector/templates/deployment.yaml
@@ -8,10 +8,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- include "connector.labels" . | nindent 4 }}
   name: {{ template "connector.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-
 spec:
   replicas: 1
   selector:
@@ -26,62 +25,84 @@ spec:
         name: {{ template "connector.name" . }}
         component: cron-connector
     spec:
-      containers:
-      - name: cron-connector
-        {{- if .Values.openfaasPro }}
-        image: {{ .Values.pro.image }}
-        {{- else }}
-        image: {{ .Values.image }}
-        {{- end }}
-        {{- if .Values.openfaasPro }}
-        command:
-          - "/usr/bin/cron-connector"
-          - "-license-file=/var/secrets/license/license"
-        {{- end }}
-        env:
-          - name: gateway_url
-            value: {{ .Values.gatewayURL | quote }}
-          - name: asynchronous_invocation
-            value: {{ .Values.asyncInvocation | quote }}
-          - name: content_type
-            value: {{ .Values.contentType | quote }}
-          {{- if .Values.basicAuth }}
-          - name: basic_auth
-            value: "true"
-          - name: secret_mount_path
-            value: "/var/secrets"
-          {{- end }}
-          {{- if .Values.rebuildInterval }}
-          - name: rebuild_interval
-            value: {{ .Values.rebuildInterval | quote }}
-          {{- end }}
-          - name: "debug"
-            value: "{{ .Values.logs.debug }}"
-          - name: "log_encoding"
-            value: "{{ .Values.logs.format }}"
-        volumeMounts:
-        {{- if .Values.openfaasPro }}
-          - name: license
-            readOnly: true
-            mountPath: "/var/secrets/license"
-        {{- end }}
-          - name: auth
-            readOnly: true
-            mountPath: "/var/secrets/"
-        resources:
-          {{- .Values.resources | toYaml | nindent 10 }}
-      {{- if .Values.basicAuth }}
+      {{- if .Values.iam.enabled }}
+      serviceAccountName: {{ template "connector.fullname" . }}
+      {{- end }}
       volumes:
-      - name: auth
-        secret:
-          secretName: basic-auth
-      {{- if .Values.openfaasPro }}
-      - name: license
-        secret:
-          secretName: openfaas-license
-      {{- end }}
-
-      {{- end }}
+        {{- if .Values.basicAuth }}
+        - name: auth
+          secret:
+            secretName: basic-auth
+        {{- end }}
+        {{- if .Values.openfaasPro }}
+        - name: license
+          secret:
+            secretName: openfaas-license
+        {{- end }}
+        {{- if .Values.iam.enabled }}
+        - name: openfaas-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: openfaas-token
+                expirationSeconds: 7200
+                audience: {{ .Values.iam.systemIssuer.url }}
+        {{- end }}
+      containers:
+        - name: cron-connector
+          {{- if .Values.openfaasPro }}
+          image: {{ .Values.pro.image }}
+          {{- else }}
+          image: {{ .Values.image }}
+          {{- end }}
+          {{- if .Values.openfaasPro }}
+          command:
+            - "/usr/bin/cron-connector"
+            - "-license-file=/var/secrets/license/license"
+          {{- end }}
+          env:
+            - name: gateway_url
+              value: {{ .Values.gatewayURL | quote }}
+            - name: asynchronous_invocation
+              value: {{ .Values.asyncInvocation | quote }}
+            - name: content_type
+              value: {{ .Values.contentType | quote }}
+            {{- if .Values.basicAuth }}
+            - name: basic_auth
+              value: "true"
+            - name: secret_mount_path
+              value: "/var/secrets"
+            {{- end }}
+            {{- if .Values.rebuildInterval }}
+            - name: rebuild_interval
+              value: {{ .Values.rebuildInterval | quote }}
+            {{- end }}
+            - name: "debug"
+              value: "{{ .Values.logs.debug }}"
+            - name: "log_encoding"
+              value: "{{ .Values.logs.format }}"
+            {{- if .Values.iam.enabled }}
+            - name: system_issuer
+              value: {{ .Values.iam.systemIssuer.url }}
+            {{- end }}
+          resources:
+            {{- .Values.resources | toYaml | nindent 10 }}
+          volumeMounts:
+            {{- if .Values.openfaasPro }}
+            - name: license
+              readOnly: true
+              mountPath: "/var/secrets/license"
+            {{- end }}
+            {{- if .Values.basicAuth }}
+            - name: auth
+              readOnly: true
+              mountPath: "/var/secrets"
+            {{- end }}
+            {{- if .Values.iam.enabled }}
+            - name: openfaas-token
+              readOnly: true
+              mountPath: /var/secrets/tokens
+            {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/chart/cron-connector/templates/policy.yaml
+++ b/chart/cron-connector/templates/policy.yaml
@@ -1,0 +1,21 @@
+
+{{- if .Values.iam.enabled }}
+
+apiVersion: iam.openfaas.com/v1
+kind: Policy
+metadata:
+  name: {{ template "connector.fullname" . }}
+  namespace: openfaas
+  labels:
+    {{- include "connector.labels" . | nindent 4 }}
+spec:
+  statement:
+  - sid: 1-list
+    action:
+    - Function:List
+    - Namespace:List
+    effect: Allow
+    resource:
+      {{- toYaml .Values.iam.resource | nindent 6 }}
+
+{{- end }}

--- a/chart/cron-connector/templates/role.yaml
+++ b/chart/cron-connector/templates/role.yaml
@@ -16,6 +16,6 @@ spec:
   condition:
     StringEqual:
       jwt:iss:
-        - "https://kubernetes.default.svc.cluster.local"
+        - {{.Values.iam.kubernetesIssuer.url}}
 
 {{- end }}

--- a/chart/cron-connector/templates/role.yaml
+++ b/chart/cron-connector/templates/role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.iam.enabled }}
+
+apiVersion: iam.openfaas.com/v1
+kind: Role
+metadata:
+  name: {{ template "connector.fullname" . }}
+  namespace: openfaas
+  labels:
+    {{- include "connector.labels" . | nindent 4 }}
+spec:
+  policy:
+  - {{ template "connector.fullname" . }}
+  principal:
+    jwt:sub:
+      - "system:serviceaccount:{{ .Release.Namespace }}:{{ template "connector.fullname" . }}"
+  condition:
+    StringEqual:
+      jwt:iss:
+        - "https://kubernetes.default.svc.cluster.local"
+
+{{- end }}

--- a/chart/cron-connector/templates/serviceaccount.yaml
+++ b/chart/cron-connector/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.iam.enabled }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "connector.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "connector.labels" . | nindent 4 }}
+{{- end }}

--- a/chart/cron-connector/values.yaml
+++ b/chart/cron-connector/values.yaml
@@ -5,7 +5,7 @@ gatewayURL: http://gateway.openfaas:8080
 openfaasPro: false
 
 pro:
-  image: ghcr.io/openfaasltd/cron-connector:0.1.2
+  image: ttl.sh/welteki/cron-connector-pro:0.1.2-2-gb657abe-amd64
 
 logs:
   # Log debug messages
@@ -29,6 +29,12 @@ tolerations: []
 affinity: {}
 
 basicAuth: true
+
+iam:
+  enabled: false
+  systemIssuer:
+    url: "https://gateway.example.com"
+  resource: ["*"]
 
 resources:
   requests:

--- a/chart/cron-connector/values.yaml
+++ b/chart/cron-connector/values.yaml
@@ -5,7 +5,7 @@ gatewayURL: http://gateway.openfaas:8080
 openfaasPro: false
 
 pro:
-  image: ttl.sh/welteki/cron-connector-pro:0.1.2-2-gb657abe-amd64
+  image: ghcr.io/openfaasltd/cron-connector:0.2.0
 
 logs:
   # Log debug messages
@@ -32,8 +32,13 @@ basicAuth: true
 
 iam:
   enabled: false
+  # URL for the OpenFaaS system components issuer.
+  # This is usually the public url of the gateway.
   systemIssuer:
     url: "https://gateway.example.com"
+  # URL for the Kubernetes service account issuer.
+  kubernetesIssuer:
+    url: https://kubernetes.default.svc.cluster.local
   resource: ["*"]
 
 resources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for token based authentication with OpenFaaS IAM to the cron-connector chart.

When IAM is enabled a projected ServiceAccount token volume is mounted into the pod. The connector can exchange this token for an OpenFaaS token that is in turn used to authenticate with the gateway API.

The chart automatically creates the required `Policy`, `Role` and `ServiceAccount` to authenticate the connector with minimal privileges.

The configuration for IAM is included under the `iam` section in the values file:

```yaml
openfaasPro: true

iam:
  enabled: true
  systemIssuer:
    url: "https://gateway.openfaas.example.com"
  resource:
    - "dev:*"
```

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

- Enables the connector to access the Gateway with minimal privilege
- Restrict the resources a connector deployment can operate on. Useful for multi-tenancy.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the connector can be used with basic auth, token based authentication for IAM and with authentication disabled.

Verified the correct `Role`, `Policy` and `ServiceAccount` based on the release name are created.

values.yaml file;

```yaml
openfaasPro: true

basicAuth: false

iam:
  enabled: true
  resource:
    - "dev:*"
```

Run template and verify output:
```
helm template --namespace openfaas \
  cron-connector \
  ./chart/cron-connector \
  -f values.yaml
```
output:

```yaml
---
# Source: cron-connector/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: cron-connector
  namespace: "openfaas"
  labels:
    helm.sh/chart: cron-connector-0.6.4
    app.kubernetes.io/name: cron-connector
    app.kubernetes.io/instance: cron-connector
    app.kubernetes.io/component: cron-connector
    app.kubernetes.io/part-of: openfaas
    app.kubernetes.io/managed-by: Helm
---
# Source: cron-connector/templates/role.yaml
apiVersion: iam.openfaas.com/v1
kind: Role
metadata:
  name: cron-connector
  namespace: openfaas
  labels:
    helm.sh/chart: cron-connector-0.6.4
    app.kubernetes.io/name: cron-connector
    app.kubernetes.io/instance: cron-connector
    app.kubernetes.io/component: cron-connector
    app.kubernetes.io/part-of: openfaas
    app.kubernetes.io/managed-by: Helm
spec:
  policy:
  - cron-connector
  principal:
    jwt:sub:
      - "system:serviceaccount:openfaas:cron-connector"
  condition:
    StringEqual:
      jwt:iss:
        - https://kubernetes.default.svc.cluster.local
---
# Source: cron-connector/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    # Original Helm labels v
    app: cron-connector
    component: cron-connector
    chart: cron-connector-0.6.4
    heritage: Helm
    release: cron-connector
    helm.sh/chart: cron-connector-0.6.4
    app.kubernetes.io/name: cron-connector
    app.kubernetes.io/instance: cron-connector
    app.kubernetes.io/component: cron-connector
    app.kubernetes.io/part-of: openfaas
    app.kubernetes.io/managed-by: Helm
  name: cron-connector
  namespace: "openfaas"
spec:
  replicas: 1
  selector:
    matchLabels:
      app: cron-connector
      name: cron-connector
      component: cron-connector
  template:
    metadata:
      labels:
        app: cron-connector
        name: cron-connector
        component: cron-connector
    spec:
      serviceAccountName: cron-connector
      volumes:
        - name: license
          secret:
            secretName: openfaas-license
        - name: openfaas-token
          projected:
            sources:
            - serviceAccountToken:
                path: openfaas-token
                expirationSeconds: 7200
                audience: https://gateway.example.com
      containers:
        - name: cron-connector
          image: ghcr.io/openfaasltd/cron-connector:0.2.0
          command:
            - "/usr/bin/cron-connector"
            - "-license-file=/var/secrets/license/license"
          env:
            - name: gateway_url
              value: "http://gateway.openfaas:8080"
            - name: asynchronous_invocation
              value: "false"
            - name: content_type
              value: "text/plain"
            - name: rebuild_interval
              value: "30s"
            - name: "debug"
              value: "false"
            - name: "log_encoding"
              value: "console"
            - name: system_issuer
              value: https://gateway.example.com
          resources:
          requests:
            cpu: 100m
            memory: 64Mi
          volumeMounts:
            - name: license
              readOnly: true
              mountPath: "/var/secrets/license"
            - name: openfaas-token
              readOnly: true
              mountPath: /var/secrets/tokens
---
# Source: cron-connector/templates/policy.yaml
apiVersion: iam.openfaas.com/v1
kind: Policy
metadata:
  name: cron-connector
  namespace: openfaas
  labels:
    helm.sh/chart: cron-connector-0.6.4
    app.kubernetes.io/name: cron-connector
    app.kubernetes.io/instance: cron-connector
    app.kubernetes.io/component: cron-connector
    app.kubernetes.io/part-of: openfaas
    app.kubernetes.io/managed-by: Helm
spec:
  statement:
  - sid: 1-list
    action:
    - Function:List
    - Namespace:List
    effect: Allow
    resource:
      - dev:*
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
