### PR TITLE
Add namespace create, update and delete permissions

### DIFF
--- a/chart/openfaas/templates/controller-rbac.yaml
+++ b/chart/openfaas/templates/controller-rbac.yaml
@@ -90,6 +90,14 @@ rules:
       - "get"
       - "list"
       - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - update
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -138,6 +138,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "namespaces", "endpoints"]
     verbs: ["get", "list", "watch"]
+# Required for namespace CRUD
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "update", "delete"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add namespace create, update and delete permissions

## Why is this needed?

These are required when operating in OpenFaaS for Enterprises mode, with a ClusterRole. So that customers can manage namespaces from the OpenFaaS API.

It does not affect Community Edition users, however for OpenFaaS Standard users, their operator pod will now receive additional permissions.

## Who is this for?

To begin with both Kubiya and E2E Networks will use this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Along side WIP changes for OfE - after the change the operator could manage namespaces, before it, it could not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
