### PR TITLE
Add kubernetes issuer to openfaas chart

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -562,6 +562,9 @@ yaml) |
 | `iam.dashboardIssuer.clientId` | OAuth Client Id for the dashboard | `""` |
 | `iam.dashboardIssuer.clientSecret` | Name of the Kubernetes secret that contains the OAuth client secret for the dashboard | `""` |
 | `iam.dashboardIssuer.scopes` | OpenID Connect (OIDC) scopes for the dashboard | `[openid, email, profile]` |
+| `iam.kubernetesIssuer.create` | Create a JwtIssuer object for the kubernetes service account issuer | `true` |
+| `iam.kubernetesIssuer.tokenExpiry` | Expiry time of OpenFaaS access tokens exchanged for tokens issued by the Kubernetes issuer. | `2h` | 
+| `iam.kubernetesIssuer.url` | URL for the Kubernetes service account issuer. | `https://kubernetes.default.svc.cluster.local` |
 
 ### Dashboard (OpenFaaS Pro)
 

--- a/chart/openfaas/templates/kubernetes-jwtissuer.yaml
+++ b/chart/openfaas/templates/kubernetes-jwtissuer.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.iam.enabled .Values.iam.kubernetesIssuer.create }}
+
+apiVersion: iam.openfaas.com/v1
+kind: JwtIssuer
+metadata:
+  name: kubernetes
+  namespace: openfaas
+spec:
+  iss: {{.Values.iam.kubernetesIssuer.url}}
+  aud:
+  - {{.Values.iam.systemIssuer.url}}
+  tokenExpiry: {{.Values.iam.kubernetesIssuer.tokenExpiry}}
+
+{{- end }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -232,6 +232,12 @@ iam:
       - profile
       - email
 
+  # kubernetesIssuer represents the Kubernetes service account issuer.
+  kubernetesIssuer:
+    create: true
+    url: https://kubernetes.default.svc.cluster.local
+    tokenExpiry: 2h
+
 prometheus:
   image: prom/prometheus:v2.45.0
   create: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Create a JwtIssuer object for the Kubernetes service account issuer through the helm chart.

New chart parameters:

| Parameter               | Description                           | Default                                                    |
| ------------------- | ----------------------------| -------------------------------------- |
| `iam.kubernetesIssuer.create` | Create a JwtIssuer object for the kubernetes service account issuer | `true` |
| `iam.kubernetesIssuer.tokenExpiry` | Expiry time of OpenFaaS access tokens exchanged for tokens issued by the Kubernetes issuer. | `2h` | 
| `iam.kubernetesIssuer.url` | URL for the Kubernetes service account issuer. | `https://kubernetes.default.svc.cluster.local` |

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Connectors and internal OpenFaaS components will gradually be converted to use projected service account tokens to authenticate with the OpenFaaS API when IAM is enabled. The Kubernetes service account issuer needs to be registered with OpenFaaS to accept these tokens.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the JwtIssuer Object is created by default when IAM is enabled:

```bash
$ kctl get jwtissuers

NAME        ISSUER                                        AUDIENCE                         EXPIRY
system      https://gw.exit.welteki.dev                   ["https://gw.exit.welteki.dev"]  30m
kubernetes  https://kubernetes.default.svc.cluster.local  ["https://gw.exit.welteki.dev"]  2h
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
