### PR TITLE
Support setting the backoff algorithm for retries

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -547,6 +547,7 @@ yaml) |
 | `queueWorker.replicas` | Replicas of the queue-worker, pick more than `1` for HA | `1` |
 | `queueWorker.resources` | Resource limits and requests for the queue-worker pods | See [values.yaml](./values.yaml) |
 | `queueWorker.queueGroup` | The name of the queue group used to process asynchronous function invocations | `faas` |
+| `queueWorkerPro.backoff` | The backoff algorithm used for retries. Must be one off `exponential`, `full` or `equal`| `exponential` |
 | `queueWorkerPro.httpRetryCodes` | Comma-separated list of HTTP status codes the queue-worker should retry | `408,429,500,502,503,504` |
 | `queueWorkerPro.image` | Container image used for the Pro version of the queue-worker | See [values.yaml](./values.yaml) |
 | `queueWorkerPro.initialRetryWait` | Time to wait for the first retry | `10s` |

--- a/chart/openfaas/templates/jetstream-queueworker-dep.yaml
+++ b/chart/openfaas/templates/jetstream-queueworker-dep.yaml
@@ -79,6 +79,8 @@ spec:
           value: "{{ .Values.jetstreamQueueWorker.logs.format }}"
         - name: upstream_timeout
           value: "{{ .Values.gateway.upstreamTimeout }}"
+        - name: backoff
+          value: "{{ .Values.queueWorkerPro.backoff }}"
 
         # OpenFaaS PRO license required
         - name: "max_retry_attempts"

--- a/chart/queue-worker/README.md
+++ b/chart/queue-worker/README.md
@@ -40,6 +40,7 @@ helm upgrade slow-queue chart/queue-worker \
 | `maxRetryWait` | The maximum amount of time to wait between retries | `120s` |
 | `initialRetryWait` | The amount of time to wait for the first retry | `10s` |
 | `httpRetryCodes` | A comma-separated list of HTTP status codes which the queue worker will retry when received from a function | `408,429,500,502,503,504` |
+| `backoff` | The backoff algorithm used for retries. Must be one off `exponential`, `full` or `equal`| `exponential` |
 | `gateway.host` | The host at which the OpenFaaS gateway can be reached | `http://gateway.openfaas` |
 | `insecureTLS` | Enable insecure tls for callbacks | `false` |
 | `gateway.port` | The port at which the OpenFaaS gateway can be reached | `8080` |

--- a/chart/queue-worker/templates/deployment.yaml
+++ b/chart/queue-worker/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: "{{ .Values.initialRetryWait }}"
             - name: "retry_http_codes"
               value: "{{ .Values.httpRetryCodes }}"
+            - name: "backoff"
+              value: "{{ .Values.backoff }}"
 
             - name: "debug"
               value: "{{ .Values.logs.debug }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support selecting different modes for the exponential backoff algorithm. The value must be one of `exponential`, `full` of `equal`.

```yaml
queueWorkerPro:
  backoff: "full"
```

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An option was added to the queue-worker to select different jitter modes for the exponential backoff algorithm. This change allows configuring these modes through the helm chart.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This version of the chart was used to deploy the queue-worker while testing the backoff mode feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
