### PR TITLE
Fix indentation of resources of cron-connector Helm chart

### DIFF
--- a/chart/cron-connector/templates/deployment.yaml
+++ b/chart/cron-connector/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
               value: {{ .Values.iam.systemIssuer.url }}
             {{- end }}
           resources:
-            {{- .Values.resources | toYaml | nindent 10 }}
+            {{- .Values.resources | toYaml | nindent 12 }}
           volumeMounts:
             {{- if .Values.openfaasPro }}
             - name: license


### PR DESCRIPTION
## Description

I changed the indentation of `.Values.resources` in `deployment.yaml` of the `cron-connector` Helm chart.

## Why is this needed?

Before that change, when trying to install `cron-connector` version `0.6.5` would fail with the following error:

```
  Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "requests" in io.k8s.api.core.v1.Container
  Error: plugin "diff" exited with error
```

## Who is this for?

Our company relies on the `cron-connector` for periodic updates and checks.

## How Has This Been Tested?

I tested this by installing the helm chart to a Kubernetes cluster with version `v1.25.3` and checked that the resources were properly set-up.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
