### PR TITLE
Add RBAC for endpoint slices for functions and leases for LeaderElection

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -495,6 +495,8 @@ yaml) |
 | `operator.image` | Container image used for the openfaas-operator | See [values.yaml](./values.yaml) |
 | `operator.kubeClientQPS` | QPS rate-limit for the Kubernetes client, (OpenFaaS for Enterprises) | `""` (defaults to 100) |
 | `operator.kubeClientBurst` | Burst rate-limit for the Kubernetes client (OpenFaaS for Enterprises) | `""` (defaults to 250) |
+| `operator.reconcileWorkers` | Number of reconciliation workers to run to convert Function CRs into Deployments | `1` |
+| `operator.leaderElection.enabled`| When set to true, only one replica of the operator within the gateway pod will perform reconciliation | `false` |
 
 ### Functions
 

--- a/chart/openfaas/templates/controller-rbac.yaml
+++ b/chart/openfaas/templates/controller-rbac.yaml
@@ -98,6 +98,9 @@ rules:
       - create
       - update
       - delete
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -178,6 +181,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/openfaas/templates/controller-rbac.yaml
+++ b/chart/openfaas/templates/controller-rbac.yaml
@@ -90,17 +90,14 @@ rules:
       - "get"
       - "list"
       - "watch"
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - create
-      - update
-      - delete
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "delete", "update"]
+{{- if .Values.openfaasPro }}
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -170,20 +167,14 @@ rules:
       - update
       - patch
       - delete
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - pods/log
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "namespaces", "endpoints"]
+    verbs: ["get", "list", "watch"]
+{{- if .Values.openfaasPro }}
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -266,6 +266,10 @@ spec:
           - name: leader_election
             value: "true"
           {{- end }}
+          {{- if eq (or .Values.operator.pprof false) true }}
+          - name: pprof
+            value: {{ .Values.operator.pprof | quote }}
+          {{- end }}
           {{- if .Values.iam.enabled }}
           - name: issuer_key_path
             value: "/var/secrets/issuer-key/issuer.key"

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -262,6 +262,10 @@ spec:
             value: "{{ .Values.operator.kubeClientQPS }}"
           - name: kube_client_burst
             value: "{{ .Values.operator.kubeClientBurst }}"
+          - name: reconcile_qps
+            value: "{{ .Values.operator.reconcileQPS }}"
+          - name: reconcile_burst
+            value: "{{ .Values.operator.reconcileBurst }}"
           {{ if .Values.operator.leaderElection.enabled }}
           - name: leader_election
             value: "true"

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -221,7 +221,7 @@ spec:
           - "-license-file=/var/secrets/license/license"
         env:
           - name: reconcile_workers
-            value: "2"
+            value: {{ .Values.operator.reconcileWorkers  }}
           - name: port
             value: "8081"
           - name: function_namespace

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -221,7 +221,7 @@ spec:
           - "-license-file=/var/secrets/license/license"
         env:
           - name: reconcile_workers
-            value: {{ .Values.operator.reconcileWorkers  }}
+            value: {{ .Values.operator.reconcileWorkers | quote }}
           - name: port
             value: "8081"
           - name: function_namespace

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -220,6 +220,8 @@ spec:
           - -operator=true
           - "-license-file=/var/secrets/license/license"
         env:
+          - name: reconcile_workers
+            value: "2"
           - name: port
             value: "8081"
           - name: function_namespace

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -262,6 +262,10 @@ spec:
             value: "{{ .Values.operator.kubeClientQPS }}"
           - name: kube_client_burst
             value: "{{ .Values.operator.kubeClientBurst }}"
+          {{ if .Values.operator.leaderElection.enabled }}
+          - name: leader_election
+            value: "true"
+          {{- end }}
           {{- if .Values.iam.enabled }}
           - name: issuer_key_path
             value: "/var/secrets/issuer-key/issuer.key"

--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -44,7 +44,7 @@ rules:
 {{- if .Values.operator.leaderElection.enabled }}
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: [ "update", "patch", "delete"]
+  verbs: [ "update", "patch", "delete", "watch"]
 {{- end }}
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
@@ -161,7 +161,7 @@ rules:
 {{- if .Values.operator.leaderElection.enabled }}
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: [ "update", "patch", "delete"]
+    verbs: [ "update", "patch", "delete", "watch"]
 {{- end }}
 # TODO: AE - remove endpoints from RBAC now that operator uses EndpointSlices
   - apiGroups: [""]

--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -41,6 +41,11 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get",  "create"]
+{{- if .Values.operator.leaderElection.enabled }}
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: [ "update", "patch", "delete"]
+{{- end }}
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -153,6 +158,11 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get",  "create"]
+{{- if .Values.operator.leaderElection.enabled }}
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: [ "update", "patch", "delete"]
+{{- end }}
 # TODO: AE - remove endpoints from RBAC now that operator uses EndpointSlices
   - apiGroups: [""]
     resources: ["pods", "pods/log", "namespaces", "endpoints"]

--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -47,6 +47,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log", "namespaces", "endpoints"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -132,6 +135,10 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
+#  Add discovery for endpointslices
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions", "apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]

--- a/chart/openfaas/templates/operator-rbac.yaml
+++ b/chart/openfaas/templates/operator-rbac.yaml
@@ -44,12 +44,18 @@ rules:
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# TODO: AE - remove endpoints from RBAC now that operator uses EndpointSlices
 - apiGroups: [""]
   resources: ["pods", "pods/log", "namespaces", "endpoints"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
   verbs: ["get", "list", "watch"]
+# AE: For leader election
+# PATCH may not be required?
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -135,7 +141,6 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
-#  Add discovery for endpointslices
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch"]
@@ -148,6 +153,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get",  "create"]
+# TODO: AE - remove endpoints from RBAC now that operator uses EndpointSlices
   - apiGroups: [""]
     resources: ["pods", "pods/log", "namespaces", "endpoints"]
     verbs: ["get", "list", "watch"]
@@ -157,6 +163,11 @@ rules:
     verbs: ["create", "update", "delete"]
   - apiGroups: [""]
     resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# AE: For leader election
+# PATCH may not be required?
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/openfaas/values-pro.yaml
+++ b/chart/openfaas/values-pro.yaml
@@ -41,7 +41,7 @@ clusterRole: true
 # you can create a HPA rule to scale on CPU, but you must not scale beyond
 # what's been purchased.
 gateway:
-  replicas: 3
+  replicas: 1
 # Required gateway configuration for Istio
   # directFunctions: true
   # probeFunctions: true

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -94,6 +94,10 @@ gateway:
 operator:
   image: ghcr.io/openfaasltd/faas-netes:0.4.23
   create: false
+  # Unnecessary when running a single replica of the gateway
+  leaderElection:
+    enabled: true
+  reconcileWorkers: 2
   resources:
     requests:
       memory: "120Mi"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -96,12 +96,18 @@ operator:
   create: false
   # Unnecessary when running a single replica of the gateway
   leaderElection:
-    enabled: true
+    enabled: false
   reconcileWorkers: 2
   resources:
     requests:
       memory: "120Mi"
       cpu: "50m"
+  # When set to true, pprof will be enabled, and the 
+  # service "faas-provider" will gain an extra port to
+  # expose the pprof endpoint, this cannot be used in production
+  # since it may bypass authentication, and should only be used
+  # for debugging purposes
+  pprof: false
 
   # For OpenFaaS for Enterprises, these numbers can be set higher,
   # if experiencing rate limiting due to a large number of functions

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -28,7 +28,7 @@ queueMode: ""                # Set to `jetstream` to run the async system backed
 psp: false
 
 # image pull policy for openfaas components, can change to `IfNotPresent` for an air-gapped environment
-openfaasImagePullPolicy: "Always"
+openfaasImagePullPolicy: "IfNotPresent"
 
 functions:
   imagePullPolicy: "Always"    # Image pull policy for deployed functions, for OpenFaaS Pro you can also set: IfNotPresent and Never.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add RBAC for endpoint slices for functions and leases for LeaderElection

EndpointSlices are more efficient than Endpoints at scale.

Both editions of OpenFaaS Pro will gain support, and CE will continue to use Endpoints.

Leader Election will be available in OpenFaaS Pro, in both editions. Only one of the replicas will perform reconciliation. All replicas will serve CRUD for Function/Secret, log tailing and invoke.

## Why is this needed?

To prevent many unnecessary updates and writes to the same object, when multiple operators try to reconcile a Function CR into a Deployment/Service.

## Who is this for?

For Patchworks to support scaling to large numbers of functions.

## How Has This Been Tested?

Endpoint Slices have had E2E testing and work, but require testing during scaling with `hey`

LeaderElection is pending and will be added to the chart in this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

