### PR TITLE
Support metering event subscriptions

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -598,6 +598,20 @@ yaml) |
 | `oidcAuthPlugin.resources` | Resource limits and requests for the oidc-auth-plugin containers | See [values.yaml](./values.yaml) |
 | `oidcAuthPlugin.verbose` | Enable verbose logging | `false` |
 
+### Event subscriptions
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `eventSubscription.endpoint` | The webhook endpoint to receive events. | `""`|
+| `eventSubscription.endpointSecret` | Name of the Kubernetes secret that contains the secret key for signing webhook requests. | `""` |
+| `eventSubscription.insecureTLS` | Enable insecure TLS for webhook invocations | `false` |
+| `eventSubscription.metering.enabled` | Enable metering events. | `false` |
+| `eventSubscription.metering.defaultRAM` | Default memory value used in function_usage events for metering when no memory limit is set on the function.  | `40Mi` |
+| `eventWorker.image` | Container image used for the events-worker | See [values.yaml](./values.yaml) |
+| `eventWorker.resources` |  Resource limits and requests for the event-worker container | See [values.yaml](./values.yaml) |
+| `eventWorker.logs.format` | Set the log format, supports `console` or `json` | `console` |
+| `eventWorker.logs.debug` | Print debug logs    | `false` |
+
 ### faas-idler (OpenFaaS Pro)
 
 Deprecated and replaced by the new autoscaler, which supports scale to zero.

--- a/chart/openfaas/templates/event-worker-dep.yaml
+++ b/chart/openfaas/templates/event-worker-dep.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.openfaasPro }}
+{{- if .Values.eventSubscription.metering.enabled }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: event-worker
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: event-worker
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.queueWorker.replicas }}
+  selector:
+    matchLabels:
+      app: event-worker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "false"
+      labels:
+        app: event-worker
+    spec:
+      volumes:
+      - name: license
+        secret:
+          secretName: openfaas-license
+      {{- if .Values.eventSubscription.endpointSecret }}
+      - name: endpoint-secret
+        secret:
+          secretName: {{.Values.eventSubscription.endpointSecret}}
+      {{- end }}
+      containers:
+      - name:  event-worker
+        resources:
+          {{- .Values.eventWorker.resources | toYaml | nindent 12 }}
+        image: {{ .Values.eventWorker.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        command:
+          - "event-worker"
+          - "-license-file=/var/secrets/license/license"
+          {{- if .Values.eventSubscription.endpointSecret }}
+          - "-webhook-secret-file=/var/secrets/webhook-secret/webhook-secret"
+          {{- end}}
+        env:
+        {{- if .Values.nats.external.enabled }}
+        - name: nats_host
+          value: "{{ .Values.nats.external.host }}"
+        - name: nats_port
+          value: "{{ .Values.nats.external.port }}"
+        {{- else }}
+        - name: nats_host
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        {{- end}}
+        - name: nats_stream_replicas
+          value: "{{ .Values.nats.streamReplication }}"
+        - name: "tls_insecure"
+          value: "{{ .Values.eventSubscription.insecureTLS }}"
+        - name: "webhook_endpoint"
+          value: "{{ .Values.eventSubscription.endpoint }}"
+        - name: "debug"
+          value: "{{ .Values.eventWorker.logs.debug }}"
+        - name: "log_encoding"
+          value: "{{ .Values.eventWorker.logs.format }}"
+
+        volumeMounts:
+        - name: license
+          readOnly: true
+          mountPath: "/var/secrets/license"
+        {{- if .Values.eventSubscription.endpointSecret }}
+        - name: endpoint-secret
+          readOnly: true
+          mountPath: "/var/secrets/webhook-secret"
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+{{- end }}
+{{- end }}

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -164,7 +164,7 @@ spec:
         - name: faas_nats_channel
           value: "{{ .Values.nats.channel }}"
         {{- else }}
-        {{- if .Values.async }}
+        {{- if or .Values.async .Values.eventSubscription.metering.enabled }}
         - name: faas_nats_address
           value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
         - name: faas_nats_port
@@ -198,6 +198,12 @@ spec:
           value: "{{ .Values.gateway.maxIdleConnsPerHost }}"
         - name: probe_functions
           value: "{{ .Values.gateway.probeFunctions }}"
+        - name: metering_default_memory 
+          value: "{{ .Values.eventSubscription.metering.defaultRAM }}"
+        - name: metering 
+          value: "{{ .Values.eventSubscription.metering.enabled }}"
+        - name: async
+          value: "{{ .Values.async }}"
         volumeMounts:
         # - name: faas-auth
         #   mountPath: /var/run/secrets/faas-auth

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.async (not .Values.nats.external.enabled) }}
+{{- if and (or .Values.async .Values.eventSubscription.metering.enabled) (not .Values.nats.external.enabled ) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/openfaas/templates/nats-svc.yaml
+++ b/chart/openfaas/templates/nats-svc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.async (not .Values.nats.external.enabled) }}
+{{- if and (or .Values.async .Values.eventSubscription.metering.enabled) (not .Values.nats.external.enabled ) }}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -91,6 +91,26 @@ gateway:
     failureThreshold: 3
     successThreshold: 1
 
+eventSubscription:
+  endpoint: ""
+  endpointSecret: ""
+  insecureTLS: false
+  metering:
+    enabled: false
+    # Default memory value used in function_usage events for metering
+    # when no memory limit is set on the function.
+    defaultRAM: 40Mi
+  
+eventWorker:
+  image: ghcr.io/openfaasltd/event-worker:0.0.1
+  logs:
+    debug: false
+    format: "console"
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
 # For OpenFaaS Pro and the Function CRD
 operator:
   image: ghcr.io/openfaasltd/faas-netes:0.5.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for the new OpenFaaS metering functionality.

- Add a deployment template for the new event-worker component.
- Support configuration for event subscriptions through the helm Chart.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the chart works on my local cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
