### PR TITLE
Support auditing event subscriptions

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -606,7 +606,8 @@ yaml) |
 | `eventSubscription.endpointSecret` | Name of the Kubernetes secret that contains the secret key for signing webhook requests. | `""` |
 | `eventSubscription.insecureTLS` | Enable insecure TLS for webhook invocations | `false` |
 | `eventSubscription.metering.enabled` | Enable metering events. | `false` |
-| `eventSubscription.metering.defaultRAM` | Default memory value used in function_usage events for metering when no memory limit is set on the function.  | `40Mi` |
+| `eventSubscription.metering.defaultRAM` | Default memory value used in function_usage events for metering when no memory limit is set on the function.  | `512Mi` |
+| `eventSubscription.metering.excludedNamespaces` | Comma-separated list of namespaces to exclude from metering for when functions are used to handle the metering webhook events | `""` |
 | `eventSubscription.auditing.enabled` | Enable auditing events | `false` |
 | `eventSubscription.auditing.httpVerbs` | Comma-separated list of HTTP methods to audit | `"PUT,POST,DELETE"`|
 | `eventWorker.image` | Container image used for the events-worker | See [values.yaml](./values.yaml) |

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -607,6 +607,8 @@ yaml) |
 | `eventSubscription.insecureTLS` | Enable insecure TLS for webhook invocations | `false` |
 | `eventSubscription.metering.enabled` | Enable metering events. | `false` |
 | `eventSubscription.metering.defaultRAM` | Default memory value used in function_usage events for metering when no memory limit is set on the function.  | `40Mi` |
+| `eventSubscription.auditing.enabled` | Enable auditing events | `false` |
+| `eventSubscription.auditing.httpVerbs` | Comma-separated list of HTTP methods to audit | `"PUT,POST,DELETE"`|
 | `eventWorker.image` | Container image used for the events-worker | See [values.yaml](./values.yaml) |
 | `eventWorker.resources` |  Resource limits and requests for the event-worker container | See [values.yaml](./values.yaml) |
 | `eventWorker.logs.format` | Set the log format, supports `console` or `json` | `console` |

--- a/chart/openfaas/templates/event-worker-dep.yaml
+++ b/chart/openfaas/templates/event-worker-dep.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.openfaasPro }}
-{{- if .Values.eventSubscription.metering.enabled }}
+{{- if or .Values.eventSubscription.metering.enabled .Values.eventSubscription.auditing.enabled }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -309,6 +309,23 @@ spec:
           - name: secret_mount_path
             value: "/var/secrets"
           {{- end }}
+          {{- if .Values.eventSubscription.auditing.enabled }}
+          {{- if .Values.nats.external.enabled }}
+          - name: nats_address
+            value: "{{ .Values.nats.external.host }}"
+          - name: nats_port
+            value: "{{ .Values.nats.external.port }}"
+          {{- else }}
+          - name: nats_address
+            value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+          - name: nats_port
+            value: "4222"
+          {{- end }}
+          - name: auditing
+            value: "{{ .Values.eventSubscription.auditing.enabled }}"
+          - name: auditing_http_verbs
+            value: "{{ .Values.eventSubscription.auditing.httpVerbs }}"
+          {{- end}}
         ports:
         - name: provider
           containerPort: 8081
@@ -400,6 +417,23 @@ spec:
         - name: secret_mount_path
           value: "/var/secrets"
         {{- end }}
+        {{- if .Values.eventSubscription.auditing.enabled }}
+        {{- if .Values.nats.external.enabled }}
+        - name: nats_address
+          value: "{{ .Values.nats.external.host }}"
+        - name: nats_port
+          value: "{{ .Values.nats.external.port }}"
+        {{- else }}
+        - name: nats_address
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        - name: nats_port
+          value: "4222"
+        {{- end }}
+        - name: auditing
+          value: "{{ .Values.eventSubscription.auditing.enabled }}"
+        - name: auditing_http_verbs
+          value: "{{ .Values.eventSubscription.auditing.httpVerbs }}"
+        {{- end}}
         volumeMounts:
         {{- if .Values.iam.enabled }}
         - name: issuer-key

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.async .Values.eventSubscription.metering.enabled) (not .Values.nats.external.enabled ) }}
+{{- if and (or .Values.async (or .Values.eventSubscription.metering.enabled .Values.eventSubscription.auditing.enabled)) (not .Values.nats.external.enabled ) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/openfaas/templates/nats-svc.yaml
+++ b/chart/openfaas/templates/nats-svc.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.async .Values.eventSubscription.metering.enabled) (not .Values.nats.external.enabled ) }}
+{{- if and (or .Values.async (or .Values.eventSubscription.metering.enabled .Values.eventSubscription.auditing.enabled)) (not .Values.nats.external.enabled ) }}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -108,6 +108,10 @@ eventSubscription:
     # Comma-separated list of namespaces to exclude from metering
     # for when functions are used to handle the metering webhook events
     excludedNamespaces: ""
+  auditing:
+    enabled: false
+    # Comma-separated list of HTTP methods to audit.
+    httpVerbs: "PUT,POST,DELETE"
   
 eventWorker:
   image: ghcr.io/openfaasltd/event-worker:0.0.4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support configuration for auditing event subscriptions through the helm Chart.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This chart has been used to verify the different configuration options while testing the auditing feature E2E on my local cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
