### PR TITLE
Support structured logging config for faas-netes (Standard/Enterprise)

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -490,6 +490,8 @@ yaml) |
 | `faasnetes.resources` | Resource limits and requests for faas-netes container | See [values.yaml](./values.yaml) |
 | `faasnetes.writeTimeout` | Write timeout for the faas-netes API | `""` (defaults to gateway.writeTimeout) |
 | `faasnetesPro.image` | Container image used for faas-netes when `openfaasPro=true` | See [values.yaml](./values.yaml) |
+| `faasnetesPro.logs.format` | Set the log format, supports `console` or `json` | `console` |
+| `faasnetesPro.logs.debug` | Print debug logs | `false` |
 | `operator.create` | Use the OpenFaaS operator CRD controller, default uses faas-netes as the Kubernetes controller | `false` |
 | `operator.image` | Container image used for the openfaas-operator | See [values.yaml](./values.yaml) |
 | `operator.resources` | Resource limits and requests for openfaas-operator containers | See [values.yaml](./values.yaml) |

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -434,6 +434,12 @@ spec:
         - name: auditing_http_verbs
           value: "{{ .Values.eventSubscription.auditing.httpVerbs }}"
         {{- end}}
+        {{- if .Values.faasnetesPro.logs}}
+        - name: "debug"
+          value: "{{ .Values.faasnetesPro.logs.debug }}"
+        - name: "log_encoding"
+          value: "{{ .Values.faasnetesPro.logs.format }}"
+        {{- end }}
         volumeMounts:
         {{- if .Values.iam.enabled }}
         - name: issuer-key

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -172,6 +172,9 @@ operator:
 
 faasnetesPro:
   image: ghcr.io/openfaasltd/faas-netes:0.5.14
+  logs:
+    debug: false
+    format: "console"
 
 # For the Community Edition
 faasnetes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support configuring the log level and format for the faas-netes controller (Standard/Enterprise)

```yaml
faasnetesPro:
  logs:
    debug: false
    format: "console"
```

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Logs for OpenFaaS IAM where moved to the debug level. This change is required to support setting the log level when running OpenFaaS IAM with the faas-netes controller mode.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the log level and format are set correctly when the chart values are updated:

```
kubectl logs -n openfaas deploy/gateway -c faas-netes
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
