### PR TITLE
Support setting resources in Profiles

### DIFF
--- a/artifacts/crds/openfaas.com_profiles.yaml
+++ b/artifacts/crds/openfaas.com_profiles.yaml
@@ -1131,6 +1131,66 @@ spec:
                             May also be set in PodSecurityContext. If set in both SecurityContext and
                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
+                resources:
+                  description: |-
+                    Resources allows customizing resource requests and limits for the function container.
+
+
+                    Resource requests and limits keys are merged with the function container resources.
+                    This will replace any existing value or previously applied Profile for that key.
+                  type: object
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+
+
+                        This field is immutable. It can only be set for containers.
+                      type: array
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                    requests:
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
                 runtimeClassName:
                   description: |-
                     RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used

--- a/chart/openfaas/templates/profile-crd.yaml
+++ b/chart/openfaas/templates/profile-crd.yaml
@@ -1133,6 +1133,66 @@ spec:
                             May also be set in PodSecurityContext. If set in both SecurityContext and
                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
+                resources:
+                  description: |-
+                    Resources allows customizing resource requests and limits for the function container.
+
+
+                    Resource requests and limits keys are merged with the function container resources.
+                    This will replace any existing value or previously applied Profile for that key.
+                  type: object
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+
+
+                        This field is immutable. It can only be set for containers.
+                      type: array
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                    requests:
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
                 runtimeClassName:
                   description: |-
                     RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used

--- a/pkg/apis/openfaas/v1/types.go
+++ b/pkg/apis/openfaas/v1/types.go
@@ -139,6 +139,14 @@ type ProfileSpec struct {
 	// https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
 	// +optional
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+
+	// Resources allows customizing resource requests and limits for the function container.
+	//
+	// Resource requests and limits keys are merged with the function container resources.
+	// This will replace any existing value or previously applied Profile for that key.
+	//
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/openfaas/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/openfaas/v1/zz_generated.deepcopy.go
@@ -258,6 +258,11 @@ func (in *ProfileSpec) DeepCopyInto(out *ProfileSpec) {
 		*out = new(corev1.PodDNSConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(corev1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/client/applyconfiguration/openfaas/v1/profilespec.go
+++ b/pkg/client/applyconfiguration/openfaas/v1/profilespec.go
@@ -22,6 +22,7 @@ type ProfileSpecApplyConfiguration struct {
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	DNSPolicy                 *v1.DNSPolicy                 `json:"dnsPolicy,omitempty"`
 	DNSConfig                 *v1.PodDNSConfig              `json:"dnsConfig,omitempty"`
+	Resources                 *v1.ResourceRequirements      `json:"resources,omitempty"`
 }
 
 // ProfileSpecApplyConfiguration constructs an declarative configuration of the ProfileSpec type for use with
@@ -87,5 +88,13 @@ func (b *ProfileSpecApplyConfiguration) WithDNSPolicy(value v1.DNSPolicy) *Profi
 // If called multiple times, the DNSConfig field is set to the value of the last call.
 func (b *ProfileSpecApplyConfiguration) WithDNSConfig(value v1.PodDNSConfig) *ProfileSpecApplyConfiguration {
 	b.DNSConfig = &value
+	return b
+}
+
+// WithResources sets the Resources field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the value of the last call.
+func (b *ProfileSpecApplyConfiguration) WithResources(value v1.ResourceRequirements) *ProfileSpecApplyConfiguration {
+	b.Resources = &value
 	return b
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update types, clientset and CRDs to support setting additional Resources  for functions using Profiles.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Support resource requests and limits for additional schedulable resources such as GPUs.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New types where used in the pro fork of faas-netes where the support for Profiles is implemented.

Changes for the OpenFaaS chart were verified while testing this feature with faas-netes pro.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
