### PR TITLE
Use faas-cli ready in e2e tests instead of bash

### DIFF
--- a/contrib/create_cluster.sh
+++ b/contrib/create_cluster.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DEVENV=${OF_DEV_ENV:-kind}
-KUBE_VERSION=v1.21.1
+KUBE_VERSION=v1.29.2
 
 EXISTS=$(kind get clusters | grep "$DEVENV")
 

--- a/contrib/deploy.sh
+++ b/contrib/deploy.sh
@@ -20,3 +20,4 @@ helm upgrade \
 
 kubectl --context "kind-$DEVENV" rollout status deploy/prometheus -n openfaas
 kubectl --context "kind-$DEVENV" rollout status deploy/gateway -n openfaas
+

--- a/contrib/get_tools.sh
+++ b/contrib/get_tools.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-KIND_VERSION="v0.11.1"
+KIND_VERSION="v0.22.0"
 # Causes a validation failure when linting due to CRDs moving to v1
 # HELM_VERSION="v3.4.0"
-HELM_VERSION="v3.0.3"
-KUBE_VERSION="v1.18.8"
-ARKADE_VERSION="0.8.11"
+HELM_VERSION="v3.14.4"
+KUBE_VERSION="v1.29.2"
+ARKADE_VERSION="0.11.9"
 
 echo "Downloading arkade"
 

--- a/contrib/run_function.sh
+++ b/contrib/run_function.sh
@@ -22,7 +22,7 @@ kubectl --context "kind-$DEVENV" port-forward deploy/gateway -n openfaas 8080:80
     echo -n "$!" > "of_${DEVENV}_portforward.pid"
 
 # Wait for the gateway to be ready
-faas-cli ready --attempts 180 --interval
+faas-cli ready --attempts=180 --interval=1s
 
 echo "Using existing password for OpenFaaS gateway retrieved from Kubernetes."
 PASSWORD=$(kubectl get secret -n openfaas basic-auth -o=go-template='{{index .data "basic-auth-password"}}' | base64 --decode)
@@ -46,4 +46,4 @@ fi
 faas-cli deploy --image=functions/alpine:latest --fprocess=cat --name "echo"
 
 # Call echo function
-faas-cli ready --attempts 180 --interval 1s echo
+faas-cli ready --attempts=180 --interval=1s echo

--- a/contrib/run_function.sh
+++ b/contrib/run_function.sh
@@ -21,9 +21,8 @@ fi
 kubectl --context "kind-$DEVENV" port-forward deploy/gateway -n openfaas 8080:8080 &>/dev/null & \
     echo -n "$!" > "of_${DEVENV}_portforward.pid"
 
-# port-forward needs some time to start
-sleep 10
-
+# Wait for the gateway to be ready
+faas-cli ready --attempts 180 --interval
 
 echo "Using existing password for OpenFaaS gateway retrieved from Kubernetes."
 PASSWORD=$(kubectl get secret -n openfaas basic-auth -o=go-template='{{index .data "basic-auth-password"}}' | base64 --decode)
@@ -47,30 +46,4 @@ fi
 faas-cli deploy --image=functions/alpine:latest --fprocess=cat --name "echo"
 
 # Call echo function
-for i in {1..180};
-do
-    Ready="$(faas-cli describe echo | awk '{ if($1 ~ /Status:/) print $2 }')"
-    if [[ $Ready == "Ready" ]];
-    then
-        exit 0
-    fi
-    sleep 1
-done
-
-# Apply a CRD to test the operator
-
-if [ "${OPERATOR}" == "1" ]; then
-    kubectl --context "kind-$DEVENV" apply ./alpine-fn.yaml
-
-    for i in {1..180};
-    do
-        Ready="$(faas-cli describe nodeinfo | awk '{ if($1 ~ /Status:/) print $2 }')"
-        if [[ $Ready == "Ready" ]];
-        then
-            exit 0
-        fi
-        sleep 1
-    done
-fi
-
-exit 1
+faas-cli ready --attempts 180 --interval 1s echo


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Use faas-cli ready in e2e tests instead of bash

## Why is this needed?

Less boilerplate code

## Who is this for?

Maintainers/contributors and for using OpenFaaS in full e2e test suites.

## How Has This Been Tested?

Tested in a GitLab CI job, and will be tested here in CI.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Refactoring/maintenance.