### PR TITLE
Add logging parameters for oidc-plugin

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -600,8 +600,9 @@ yaml) |
 | `oidcAuthPlugin.image` | Container image used for the oidc-auth-plugin | See [values.yaml](./values.yaml) |
 | `oidcAuthPlugin.insecureTLS` | Enable insecure TLS | `false` |
 | `oidcAuthPlugin.replicas` | Replicas of the oidc-auth-plugin | `1` |
+| `oidcAuthPlugin.logs.debug` | Log debug messages | `false` |
+| `oidcAuthPlugin.logs.format` | Set the log format, supports `console` or `json` | `console` |
 | `oidcAuthPlugin.resources` | Resource limits and requests for the oidc-auth-plugin containers | See [values.yaml](./values.yaml) |
-| `oidcAuthPlugin.verbose` | Enable verbose logging | `false` |
 
 ### Event subscriptions
 

--- a/chart/openfaas/templates/oidc-plugin-dep.yaml
+++ b/chart/openfaas/templates/oidc-plugin-dep.yaml
@@ -89,9 +89,6 @@ spec:
           timeoutSeconds: 5
         args:
         - "-license-file=/var/secrets/license/license"
-        {{- if .Values.oidcAuthPlugin.verbose }}
-        - "-verbose=true"
-        {{- end }}
         env:
         - name: base_host
           value: "{{- .Values.iam.systemIssuer.url}}"
@@ -101,6 +98,10 @@ spec:
           value: "{{- .Values.oidcAuthPlugin.insecureTLS}}"
         - name: issuer_key_path
           value: "/var/secrets/issuer-key/issuer.key"
+        - name: "debug"
+          value: "{{ .Values.oidcAuthPlugin.logs.debug }}"
+        - name: "log_encoding"
+          value: "{{ .Values.oidcAuthPlugin.logs.format }}"
         {{ if .Values.caBundleSecretName }}
         - name: ca_bundle_path
           value: /var/secrets/ca-bundle/ca.crt

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -296,9 +296,11 @@ dashboard:
 oidcAuthPlugin:
   image: ghcr.io/openfaasltd/openfaas-oidc-plugin:0.7.3
   insecureTLS: false
-  verbose: true # debug setting
   replicas: 1
   securityContext: true
+  logs:
+    debug: false
+    format: "console"
   resources:
     requests:
       memory: "120Mi"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support configuration parameters for structured logging for the oidc-plugin in the OpenFaaS Helm chart.

| Parameter | Description | Default |
|-----------|-------------|---------|
| `oidcAuthPlugin.logs.debug` | Log debug messages | `false` |
| `oidcAuthPlugin.logs.format` | Set the log format, supports `console` or `json` | `console` |


## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Support structured logging for the oidc-plugin.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the log level end log encoding can be configured correctly through the Helm chart.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The parameter `oidcAuthPlugin.verbose` was removed and is replaces by `oidcAuthPlugin.logs.debug`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
