### PR TITLE
Support configuring Prometheus retention

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -651,4 +651,6 @@ For legacy scaling in OpenFaaS Community Edition.
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `prometheus.create` | Create the Prometheus component | `true` |
 | `prometheus.image` | Container image used for prometheus | See [values.yaml](./values.yaml) |
+| `prometheus.retention.time` | When to remove old data from the prometheus db. | `15d` |
+| `prometheus.retention.size` | The maximum number of bytes of storage blocks to retain. Units supported: B, KB, MB, GB, TB, PB, EB. 0 meaning disabled. See: [Prometheus storage](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects)| `0` |
 | `prometheus.resources` | Resource limits and requests for prometheus containers | See [values.yaml](./values.yaml) |

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -37,6 +37,12 @@ spec:
         command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
+          {{- if .Values.prometheus.retention.time }}
+          - "--storage.tsdb.retention.time={{.Values.prometheus.retention.time}}"
+          {{- end }}
+          {{-  if .Values.prometheus.retention.size }}
+          - "--storage.tsdb.retention.size={{.Values.prometheus.retention.size}}"
+          {{- end }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         livenessProbe:
           {{- if .Values.httpProbe }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -331,6 +331,8 @@ iam:
 prometheus:
   image: prom/prometheus:v2.51.2
   create: true
+  retention:
+    time: 15d
   resources:
     requests:
       memory: "512Mi"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for configuring the Prometheus retention in the OpenFaaS Helm chart.

Parameters:

| Parameter               | Description                           | Default                                                    |
| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
| `prometheus.retention.time` | When to remove old data from the prometheus db. | `15d` |
| `prometheus.retention.size` | The maximum number of bytes of storage blocks to retain. Units supported: B, KB, MB, GB, TB, PB, EB. 0 meaning disabled. See: [Prometheus storage](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects)| `0` |

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This feature was requested by a customer and discussed in the customer community.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the chart renders correctly and the Prometheus flags use the provided helm parameter values.

```bash
helm template openfaas ./chart/openfaas \
  --show-only templates/prometheus-dep.yaml \
  --set prometheus.retention.time=20d \
  --set prometheus.retention.size=512MB
```

Output:

```yaml
        command:
          - "prometheus"
          - "--config.file=/etc/prometheus/prometheus.yml"
          - "--storage.tsdb.retention.time=20d"
          - "--storage.tsdb.retention.size=512MB"
```

Verified E2E and made sure Prometheus starts with these flags set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
