### PR TITLE
Quote ingress records from chart into ingress template

### DIFF
--- a/chart/openfaas/templates/ingress.yaml
+++ b/chart/openfaas/templates/ingress.yaml
@@ -1,7 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-  {{- $apiIsStable := eq (include "openfaas.ingress.isStable" .) "true" -}}
-  {{- $pathType := .Values.ingress.pathType | default "ImplementationSpecific" -}}
-  {{- $ingressSupportsPathType := eq (include "openfaas.ingress.supportsPathType" .) "true" -}}
 apiVersion: {{ include "openfaas.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -21,25 +18,8 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host.host }}
-      http:
-        paths:
-          - path: {{ $host.path }}
-            {{- if and $pathType $ingressSupportsPathType }}
-            pathType: {{ $pathType }}
-            {{- end }}
-            backend:
-              {{- if $apiIsStable }}
-              service:
-                name: {{ $host.serviceName }}
-                port:
-                  number: {{ $host.servicePort }}
-              {{- else }}
-              serviceName: {{ $host.serviceName }}
-              servicePort: {{ $host.servicePort }}
-    {{- end }}
-    {{- end -}}
+
+{{ toYaml .Values.ingress.hosts | indent 2 }}
   {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Quote ingress records from chart into ingress template

## Why is this needed?

The previous template was too closely tied to the beta version of ingress to work with the new format and layout of ingress v1.

Instead of trying to remap values from custom fields in the values.yaml file, this version quotes the text directly meaning it works better for the newer format.

## Who is this for?

New users of OpenFaaS on Kubernetes.

## How Has This Been Tested?

Tested e2e with a KinD cluster and inlets.

```bash
alex@bq:~$ kubectl get issuer -n openfaas
NAME                  READY   AGE
letsencrypt-prod      True    4m32s
letsencrypt-staging   True    4m32s
alex@bq:~$ kubectl get ingress -n openfaas
NAME               CLASS   HOSTS                            ADDRESS          PORTS     AGE
openfaas-ingress   nginx   gw.d.o6s.io,dashboard.d.o6s.io   134.209.188.10   80, 443   6m54s
alex@bq:~$ kubectl get svc -n default
NAME                                 TYPE           CLUSTER-IP      EXTERNAL-IP                     PORT(S)                      AGE
ingress-nginx-controller             LoadBalancer   10.96.205.130   134.209.188.10,134.209.188.10   80:32019/TCP,443:32205/TCP   27m
ingress-nginx-controller-admission   ClusterIP      10.96.188.19    <none>                          443/TCP                      27m
kubernetes                           ClusterIP      10.96.0.1       <none>                          443/TCP                      30m
alex@bq:~$ 
alex@bq:~$ curl -i https://gw.d.o6s.io
HTTP/2 403 
date: Tue, 28 May 2024 09:26:54 GMT
content-length: 0
strict-transport-security: max-age=31536000; includeSubDomains

alex@bq:~$ curl -i https://dashboard.d.o6s.io
HTTP/2 200 
date: Tue, 28 May 2024 09:26:57 GMT
content-type: text/html
strict-transport-security: max-age=31536000; includeSubDomains
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

For some people this may be a breaking change