### PR TITLE
Support scraping metrics from function pods for custom scaling types

### DIFF
--- a/chart/openfaas/templates/prometheus-pro-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-pro-cfg.yaml
@@ -170,7 +170,7 @@ data:
             target_label: __metrics_path__
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
-            target_label: kubernetes_namespace
+            target_label: kubernetes_namespacev
           - source_labels: [__meta_kubernetes_pod_name]
             action: replace
             target_label: kubernetes_pod_name
@@ -193,17 +193,17 @@ data:
     - name: load
       rules:
       - record: job:function_current_load:sum
-        expr: sum by (function_name) ( rate( gateway_function_invocation_total{}[30s] ) )  and avg by (function_name) (gateway_service_target_load{scaling_type="rps"}) > 1
+        expr: ceil(sum by (function_name) ( rate( gateway_function_invocation_total{}[30s] ) )  and avg by (function_name) (gateway_service_target_load{scaling_type="rps"}) > 1)
         labels:
           scaling_type: rps
 
       - record: job:function_current_load:sum
-        expr: sum by (function_name) ( max_over_time( gateway_function_invocation_inflight[45s:5s])) and on (function_name) avg by(function_name) (gateway_service_target_load{scaling_type="capacity"}) > bool 1
+        expr: ceil(sum by (function_name) ( max_over_time( gateway_function_invocation_inflight[45s:5s])) and on (function_name) avg by(function_name) (gateway_service_target_load{scaling_type="capacity"}) > bool 1)
         labels:
           scaling_type: capacity
 
       - record: job:function_current_load:sum
-        expr: sum(irate ( pod_cpu_usage_seconds_total{}[1m])*1000) by (function_name) * on (function_name) avg by (function_name) (gateway_service_target_load{scaling_type="cpu"}  > bool 1 )
+        expr: ceil(sum(irate ( pod_cpu_usage_seconds_total{}[1m])*1000) by (function_name) * on (function_name) avg by (function_name) (gateway_service_target_load{scaling_type="cpu"}  > bool 1 ))
         labels:
           scaling_type: cpu
 

--- a/chart/openfaas/templates/prometheus-pro-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-pro-cfg.yaml
@@ -72,9 +72,7 @@ data:
             namespaces:
               names:
                 - {{ .Release.Namespace }}
-{{- if ne $functionNs (.Release.Namespace | toString) }}
-                - {{ $functionNs }}
-{{- end }}
+
         relabel_configs:
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
@@ -138,6 +136,52 @@ data:
           replacement: '$1'
           target_label: deployment_name
         # Output fully-qualified function name fn.ns
+        - source_labels: [deployment_name, kubernetes_namespace]
+          separator: ";"
+          regex: '(.*);(.*)'
+          replacement: '${1}.${2}'
+          target_label: "function_name"
+      
+      - job_name: 'openfaas-function-pods'
+        scrape_interval: 15s
+        kubernetes_sd_configs:
+          - role: pod
+          # TODO: Insert namespace for role
+            {{- if not .Values.clusterRole }}
+            namespaces:
+              names: [ {{ $functionNs | quote }} ]
+            {{- end }}
+        relabel_configs:
+          # Only keep OpenFaaS function pods
+          - source_labels: [__meta_kubernetes_pod_labelpresent_faas_function]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: replace
+            regex: (.+)
+            source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            target_label: __metrics_path__
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+          - action: replace
+            source_labels:
+            - kubernetes_pod_name
+            regex: '^([0-9a-zA-Z-]+)+(-[0-9a-zA-Z]+-[0-9a-zA-Z]+)$'
+            replacement: '$1'
+            target_label: deployment_name
+          
+        metric_relabel_configs:
         - source_labels: [deployment_name, kubernetes_namespace]
           separator: ";"
           regex: '(.*);(.*)'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

[Scrape metrics from functions directly](https://github.com/openfaas/faas-netes/commit/c07f74833a807eb15c6ff1e9af79ea5530772a64)

Support scraping metrics from function pods directly. This allows users
to provide metrics for custom scaling types.

Function pods that have the annotation `prometheus.io.scrape: true` will get scraped. Optionally the port and endpoint can be configured through additional annotations: `prometheus.io.path:`, `prometheus.io.port`

[Ceil load values for scaling in recording rule](https://github.com/openfaas/faas-netes/commit/b9103a82a6866498d563c81f4f799e5c70ea43ae)

The load used to be sealed by the autoscaler when it queried the load
metric. To support custom load recording rules that do not need to be
ceiled ceiling is now done on the individual recording rules that need
it.


## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed function with the annotation `prometheus.io.scrape: true` in different namespaces and verified function pods were included in the Prometheus targets though the UI.

This test was repeated without a ClusterRole for Prometheus to verify function pods in the default function namespace can be scraped.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
