### PR TITLE
Support adding custom autoscaling rules.

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -671,3 +671,4 @@ For legacy scaling in OpenFaaS Community Edition.
 | `prometheus.retention.time` | When to remove old data from the prometheus db. | `15d` |
 | `prometheus.retention.size` | The maximum number of bytes of storage blocks to retain. Units supported: B, KB, MB, GB, TB, PB, EB. 0 meaning disabled. See: [Prometheus storage](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects)| `0` |
 | `prometheus.resources` | Resource limits and requests for prometheus containers | See [values.yaml](./values.yaml) |
+| `prometheus.recordingRules` | Custom recording rules for autoscaling. | `[]` |

--- a/chart/openfaas/templates/prometheus-pro-cfg.yaml
+++ b/chart/openfaas/templates/prometheus-pro-cfg.yaml
@@ -207,6 +207,10 @@ data:
         expr: ceil(sum(irate ( pod_cpu_usage_seconds_total{}[1m])*1000) by (function_name) * on (function_name) avg by (function_name) (gateway_service_target_load{scaling_type="cpu"}  > bool 1 ))
         labels:
           scaling_type: cpu
+      
+      {{- with .Values.prometheus.recordingRules }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
 
     - name: recently_started_1m
       interval: 10s

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -360,6 +360,7 @@ prometheus:
       memory: "512Mi"
       cpu: "100m"
   annotations: {}
+  recordingRules: []
 
 alertmanager:
   image: prom/alertmanager:v0.27.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support adding custom autoscaling recording rules through the OpenFaaS Helm chart.

| Parameter               | Description                           | Default                                                    |
| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
| `prometheus.recordingRules` | Custom recording rules for autoscaling. | `[]` |

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Prevent users from having to fork and modify the chart to start using custom autoscaling rules.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Used `helm template` to verify the Prometheus config templates works with and without custom rules.

values.yml:

```yaml
prometheus:
  recordingRules:
    - record: job:function_current_load:sum
      expr: |
        sum by (function_name) (rate(gateway_functions_seconds_sum{}[30s])) / sum by (function_name)  (rate( gateway_functions_seconds_count{}[30s]))
        and on (function_name) avg by(function_name) (gateway_service_target_load{scaling_type="latency"}) > bool 1
      labels:
        scaling_type: latency
    
    - record: job:function_current_load:sum
       expr: |
        ceil(sum by (function_name) (max_over_time(pod_memory_working_set_bytes[45s:5s]))
        * on (function_name) avg by (function_name) (gateway_service_target_load{scaling_type="memory"} > bool 1))
      labels:
        scaling_type: memory
```

Without custom rules:
```sh
helm template chart/openfaas  \
  --namespace openfaas  \
  -s templates/prometheus-pro-cfg.yaml
```

With custom rules:

```sh
helm template chart/openfaas  \
  --namespace openfaas  \
  --values ./values.yaml \
  -s templates/prometheus-pro-cfg.yaml
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
