### PR TITLE
OpenFaaS Chart updates to support imagePullSecret and registryPrefix

### DIFF
--- a/chart/openfaas/templates/_helpers.tpl
+++ b/chart/openfaas/templates/_helpers.tpl
@@ -45,3 +45,38 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "openfaas.ingress.supportsPathType" -}}
   {{- or (eq (include "openfaas.ingress.isStable" .) "true") (and (eq (include "openfaas.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "openfaas.ingress.kubeVersion" .))) -}}
 {{- end -}}
+
+{{/*
+Image helper that replaces registry with custom prefix if specified.
+Usage: {{ include "openfaas.image" (dict "image" .Values.someImage "registryPrefix" .Values.registryPrefix) }}
+*/}}
+{{- define "openfaas.image" -}}
+{{- $image := .image -}}
+{{- $registryPrefix := .registryPrefix -}}
+{{- if $registryPrefix -}}
+  {{- if hasPrefix "docker.io/" $image -}}
+    {{- printf "%s/%s" $registryPrefix (trimPrefix "docker.io/" $image) -}}
+  {{- else if hasPrefix "ghcr.io/" $image -}}
+    {{- printf "%s/%s" $registryPrefix (trimPrefix "ghcr.io/" $image) -}}
+  {{- else if hasPrefix "quay.io/" $image -}}
+    {{- printf "%s/%s" $registryPrefix (trimPrefix "quay.io/" $image) -}}
+  {{- else if hasPrefix "registry.k8s.io/" $image -}}
+    {{- printf "%s/%s" $registryPrefix (trimPrefix "registry.k8s.io/" $image) -}}
+  {{- else if contains "/" $image -}}
+    {{- /* Image has a registry, replace the first part */ -}}
+    {{- $parts := splitList "/" $image -}}
+    {{- if gt (len $parts) 2 -}}
+      {{- /* More than 2 parts, replace first part */ -}}
+      {{- printf "%s/%s" $registryPrefix (join "/" (rest $parts)) -}}
+    {{- else -}}
+      {{- /* Exactly 2 parts, keep the organization/repository structure */ -}}
+      {{- printf "%s/%s" $registryPrefix $image -}}
+    {{- end -}}
+  {{- else -}}
+    {{- /* No registry prefix, add our custom one */ -}}
+    {{- printf "%s/%s" $registryPrefix $image -}}
+  {{- end -}}
+{{- else -}}
+  {{- $image -}}
+{{- end -}}
+{{- end -}}

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -26,9 +26,13 @@ spec:
         sidecar.istio.io/inject: "true"
         checksum/alertmanager-config: {{ include (print $.Template.BasePath "/alertmanager-cfg.yaml") . | sha256sum | quote  }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: alertmanager
-        image: {{ .Values.alertmanager.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.alertmanager.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - "alertmanager"

--- a/chart/openfaas/templates/autoscaler-dep.yaml
+++ b/chart/openfaas/templates/autoscaler-dep.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         app: autoscaler
     spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
       volumes:
       {{- if .Values.basic_auth }}
       - name: auth
@@ -36,7 +40,7 @@ spec:
       - name:  autoscaler
         resources:
           {{- .Values.autoscaler.resources | toYaml | nindent 12 }}
-        image: {{ .Values.autoscaler.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.autoscaler.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - "/usr/bin/autoscaler"

--- a/chart/openfaas/templates/dashboard-dep.yaml
+++ b/chart/openfaas/templates/dashboard-dep.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         app: dashboard
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.basic_auth }}
       - name: auth
@@ -58,7 +62,7 @@ spec:
       - name:  dashboard
         resources:
           {{- .Values.dashboard.resources | toYaml | nindent 12 }}
-        image: {{ .Values.dashboard.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.dashboard.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
 
         command:

--- a/chart/openfaas/templates/event-worker-dep.yaml
+++ b/chart/openfaas/templates/event-worker-dep.yaml
@@ -24,6 +24,10 @@ spec:
       labels:
         app: event-worker
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: license
         secret:
@@ -37,7 +41,7 @@ spec:
       - name:  event-worker
         resources:
           {{- .Values.eventWorker.resources | toYaml | nindent 12 }}
-        image: {{ .Values.eventWorker.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.eventWorker.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - "event-worker"

--- a/chart/openfaas/templates/gateway-dep.yaml
+++ b/chart/openfaas/templates/gateway-dep.yaml
@@ -30,6 +30,10 @@ spec:
       labels:
         app: gateway
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.gateway.topologySpreadConstraints .Values.openfaasPro }}
       topologySpreadConstraints:
       {{- toYaml .Values.gateway.topologySpreadConstraints | nindent 8 }}
@@ -70,9 +74,9 @@ spec:
         resources:
           {{- .Values.gateway.resources | toYaml | nindent 12 }}
         {{- if .Values.openfaasPro }}
-        image: {{ .Values.gatewayPro.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.gatewayPro.image "registryPrefix" .Values.registryPrefix) }}
         {{- else }}
-        image: {{ .Values.gateway.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.gateway.image "registryPrefix" .Values.registryPrefix) }}
         {{- end }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
@@ -233,7 +237,7 @@ spec:
       - name: operator
         resources:
           {{- .Values.operator.resources | toYaml | nindent 12 }}
-        image: {{ .Values.operator.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.operator.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - ./faas-netes
@@ -355,11 +359,11 @@ spec:
         resources:
           {{- .Values.faasnetes.resources | toYaml | nindent 12 }}
       {{- if .Values.openfaasPro }}
-        image: {{ .Values.faasnetesPro.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.faasnetesPro.image "registryPrefix" .Values.registryPrefix) }}
       {{- else if .Values.oem }}
-        image: {{ .Values.faasnetesOem.image}}
+        image: {{ include "openfaas.image" (dict "image" .Values.faasnetesOem.image "registryPrefix" .Values.registryPrefix) }}
       {{- else }}
-        image: {{ .Values.faasnetes.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.faasnetes.image "registryPrefix" .Values.registryPrefix) }}
       {{- end }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.securityContext }}

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -23,12 +23,16 @@ spec:
       labels:
         app: ingress-operator
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: ingress-operator
       containers:
       - name: operator
         resources:
           {{- .Values.ingressOperator.resources | toYaml | nindent 10 }}
-        image: {{ .Values.ingressOperator.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.ingressOperator.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:
           - ./ingress-operator

--- a/chart/openfaas/templates/jetstream-queueworker-dep.yaml
+++ b/chart/openfaas/templates/jetstream-queueworker-dep.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         app: queue-worker
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.jetstreamQueueWorker.topologySpreadConstraints .Values.openfaasPro }}
       topologySpreadConstraints:
       {{- toYaml .Values.jetstreamQueueWorker.topologySpreadConstraints | nindent 8 }}
@@ -37,7 +41,7 @@ spec:
       - name:  queue-worker
         resources:
           {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
-        image: {{ .Values.jetstreamQueueWorker.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.jetstreamQueueWorker.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.jetstreamQueueWorker.pprof }}
         ports:

--- a/chart/openfaas/templates/nats-dep.yaml
+++ b/chart/openfaas/templates/nats-dep.yaml
@@ -22,14 +22,18 @@ spec:
       labels:
         app: nats
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name:  nats
         resources:
           {{- .Values.nats.resources | toYaml | nindent 12 }}
         {{- if eq .Values.queueMode "jetstream" }}
-        image: {{ .Values.nats.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.nats.image "registryPrefix" .Values.registryPrefix) }}
         {{- else }}
-        image: {{ .Values.stan.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.stan.image "registryPrefix" .Values.registryPrefix) }}
         {{- end }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         ports:

--- a/chart/openfaas/templates/oidc-plugin-dep.yaml
+++ b/chart/openfaas/templates/oidc-plugin-dep.yaml
@@ -24,6 +24,10 @@ spec:
       labels:
         app: oidc-plugin
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: oidc-plugin
       volumes:
       - name: oidc-plugin-temp-volume
@@ -48,7 +52,7 @@ spec:
       - name:  oidc-plugin
         resources:
           {{- .Values.oidcAuthPlugin.resources | toYaml | nindent 12 }}
-        image: {{ .Values.oidcAuthPlugin.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.oidcAuthPlugin.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: Always
         {{- if .Values.securityContext }}
         securityContext:

--- a/chart/openfaas/templates/prometheus-dep.yaml
+++ b/chart/openfaas/templates/prometheus-dep.yaml
@@ -30,6 +30,10 @@ spec:
           {{- toYaml .Values.prometheus.annotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Release.Name }}-prometheus
       {{- if .Values.prometheus.fsGroup }}
       securityContext:
@@ -39,7 +43,7 @@ spec:
       - name: prometheus
         resources:
           {{- .Values.prometheus.resources | toYaml | nindent 12 }}
-        image: {{ .Values.prometheus.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.prometheus.image "registryPrefix" .Values.registryPrefix) }}
         command:
           - "prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         app: queue-worker
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if .Values.basic_auth }}
       - name: auth
@@ -39,9 +43,9 @@ spec:
         resources:
           {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
         {{- if .Values.openfaasPro }}
-        image: {{ .Values.queueWorkerPro.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.queueWorkerPro.image "registryPrefix" .Values.registryPrefix) }}
       {{- else }}
-        image: {{ .Values.queueWorker.image }}
+        image: {{ include "openfaas.image" (dict "image" .Values.queueWorker.image "registryPrefix" .Values.registryPrefix) }}
       {{- end }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         {{- if .Values.openfaasPro }}

--- a/chart/openfaas/values-pro.yaml
+++ b/chart/openfaas/values-pro.yaml
@@ -111,3 +111,12 @@ prometheus:
     runAsNonRoot: true
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: false  # Prometheus needs to write to /prometheus/data
+
+# Only applied to Deployments installed by this chart.
+imagePullSecrets: []
+
+# imagePullSecrets:
+# - name: private-registry-pull-secret
+
+# When set, docker.io or ghcr.io will be replaced by the value contained in registryPrefix
+# registryPrefix: "ttl.sh/openfaas"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

OpenFaaS Chart updates to support imagePullSecret and registryPrefix

## Why is this needed?

Requested for improving offline installation experience by a customer.

* Use the imagePullSecret to attach a secret to each deployment in the chart
* Use the registryPrefix to replace ghcr.io/docker.io with your own prefix

## How Has This Been Tested?

Tested that the images are replaced:

```
~/go/src/github.com/openfaas/faas-netes$ helm template ./chart/openfaas --namespace openfaas |grep "image: "
        image: prom/alertmanager:v0.28.1
        image: ghcr.io/openfaas/gateway:0.27.12
        image: ghcr.io/openfaas/faas-netes:0.18.14
        image: nats-streaming:0.25.6
        image: prom/prometheus:v3.4.2
        image: ghcr.io/openfaas/queue-worker:0.14.2
```

vs

```
~/go/src/github.com/openfaas/faas-netes$ helm template ./chart/openfaas --namespace openfaas --set registryPrefix=ttl.sh/openfaas|grep "image: "
        image: ttl.sh/openfaas/prom/alertmanager:v0.28.1
        image: ttl.sh/openfaas/openfaas/gateway:0.27.12
        image: ttl.sh/openfaas/openfaas/faas-netes:0.18.14
        image: ttl.sh/openfaas/nats-streaming:0.25.6
        image: ttl.sh/openfaas/prom/prometheus:v3.4.2
        image: ttl.sh/openfaas/openfaas/queue-worker:0.14.2
```

Pull secrets added to each deployment:

With custom.yaml:

```yaml
imagePullSecrets:
- name: private-registry-pull-secret
```

```
~/go/src/github.com/openfaas/faas-netes$ helm template ./chart/openfaas --namespace openfaas -f ./chart/openfaas/values-pro.yaml -f ./custom.yaml |grep -i imagePullSecrets -A 1
      imagePullSecrets:
        - name: private-registry-pull-secret
--
      imagePullSecrets:
        - name: private-registry-pull-secret
--
      imagePullSecrets:
        - name: private-registry-pull-secret
--
      imagePullSecrets:
        - name: private-registry-pull-secret
--
      imagePullSecrets:
        - name: private-registry-pull-secret
--
      imagePullSecrets:
        - name: private-registry-pull-secret
```

6 entries patched, and 6 deployments found:

```
~/go/src/github.com/openfaas/faas-netes$ helm template ./chart/openfaas --namespace openfaas -f ./chart/openfaas/values-pro.yaml -f ./custom.yaml |grep -i "^kind: Deployment$"|wc -l
6
```

Check via kubeconform:

```
~/go/src/github.com/openfaas/faas-netes$ helm template ./chart/openfaas --namespace openfaas -f ./chart/openfaas/values-pro.yaml -f ./custom.yaml | kubeconform --strict -ignore-missing-schemas

~/go/src/github.com/openfaas/faas-netes$ echo $?
0
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
