### PR TITLE
Add adaptive concurrency parameter for queue-worker

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -581,6 +581,7 @@ See [values.yaml](./values.yaml) for detailed configuration.
 | `jetstreamQueueWorker.consumer.pullMaxMessages` | PullMaxMessages limits the number of messages to be buffered per consumer. Leave empty to use optimized default for the selected queue mode | `` |
 | `jetstreamQueueWorker.logs.debug` | Log debug messages | `false` |
 | `jetstreamQueueWorker.logs.format` | Set the log format, supports `console` or `json` | `console` |
+| `jetstreamQueueWorker.adaptiveConcurrency` | Enable adaptive concurrency limiting for functions. This setting only takes effect when `jetstreamQueueWorker.mode` is set to `function`. | `true` |
 | `nats.channel` | The name of the NATS Streaming channel or NATS JetStream stream to use for asynchronous function invocations | `faas-request` |
 | `nats.external.clusterName` | The name of the externally-managed NATS Streaming server | `""` |
 | `nats.external.enabled` | Whether to use an externally-managed NATS Streaming server | `false` |

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -99,6 +99,8 @@ spec:
         - name: ack_wait
           value: "{{ .Values.queueWorker.ackWait }}"
 
+        - name: limiter_enabled
+          value: "{{ .Values.jetstreamQueueWorker.adaptiveConcurrency }}"
         - name: upstream_timeout
           value: "{{ .Values.gateway.upstreamTimeout }}"
         - name: "max_retry_attempts"

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -222,6 +222,9 @@ faasnetes:
 jetstreamQueueWorker:
   image: ghcr.io/openfaasltd/jetstream-queue-worker:0.4.12
   mode: "static"
+  # Enable adaptive concurrency limiting for functions.
+  # This setting only takes effect when jetstreamQueueWorker.mode is set to "function".
+  adaptiveConcurrency: true
   consumer:
     inactiveThreshold: "30s"
 

--- a/chart/queue-worker/README.md
+++ b/chart/queue-worker/README.md
@@ -38,7 +38,7 @@ nats:
     name: slow-fns
   consumer:
     durableName: slow-fns-workers
-upstreamTimeout: 15m  
+upstreamTimeout: 15m 
 ```
 
 Then pass `-f ./values-slow-fns.yaml` to the `helm upgrade --install` command instead of the `--set` flags.
@@ -101,6 +101,7 @@ helm upgrade --install \
 | `queueName` | Name of the queue if you want it to be different to the stream name | `""` - when empty, defaults to `nats.stream.name` |
 | `mode` | Queue operation mode: `static` (OpenFaaS Standard) or `function` (requires OpenFaaS for Enterprises) | `static` |
 | `maxInflight` | Control the concurrent invocations | `1` |
+| `adaptiveConcurrency` | Enable adaptive concurrency limiting for functions. This setting only takes effect when `mode` is set to `function`. | `true` |
 | `queuePartitions` | Number of queue partitions | `1` |
 | `partition` | Queue partition number this queue should subscribe to | `0` |
 | `consumer.inactiveThreshold` | If a function is inactive (has no invocations) for longer than this threshold its consumer will be removed to save resources | `30s` |

--- a/chart/queue-worker/templates/deployment.yaml
+++ b/chart/queue-worker/templates/deployment.yaml
@@ -82,6 +82,8 @@ spec:
             - name: "ack_wait"
               value: "{{ .Values.nats.consumer.ackWait }}"
 
+            - name: "limiter_enabled"
+              value: "{{ .Values.adaptiveConcurrency }}"
             - name: "upstream_timeout"
               value: "{{ .Values.upstreamTimeout }}"
             - name: "max_retry_attempts"

--- a/chart/queue-worker/values.yaml
+++ b/chart/queue-worker/values.yaml
@@ -13,6 +13,9 @@ replicas: 1
 queueName: ""
 mode: static
 maxInflight: 1
+# Enable adaptive concurrency limiting for functions.
+# This setting only takes effect when mode is set to "function".
+adaptiveConcurrency: true
 
 queuePartitions: 1
 partition: 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allow users to disable the new adaptive concurrency feature for the queue-worker.

New parameter in OpenFaaS chart:

| Parameter | Description | Default |
|-----------|-------------|---------|
| `jetstreamQueueWorker.adaptiveConcurrency` | Enable adaptive concurrency limiting for functions. This setting only takes effect when `jetstreamQueueWorker.mode` is set to `function`. | `true` |

New parameter in queue-worker chart:

| Parameter | Description | Default |
|-----------|-------------|---------|
| `adaptiveConcurrency` | Enable adaptive concurrency limiting for functions. This setting only takes effect when `mode` is set to `function`. | `true` |

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Support configuration for new adaptive concurrency feature.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Used the OpenFaaS chart with the new parameter to deploy during testing. Verified the parameter was set.

Verified the queue-worker chart by running: ` helm template ./chart/queue-worker`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
