### PR TITLE
Switch to shared socket for calling buildkitd

### DIFF
--- a/chart/pro-builder/templates/deployment.yml
+++ b/chart/pro-builder/templates/deployment.yml
@@ -40,12 +40,6 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
 {{- end }}
       volumes:
-        - name: client-certs
-          secret:
-            secretName: buildkit-client-certs
-        - name: daemon-certs
-          secret:
-            secretName: buildkit-daemon-certs
         - name: registry-secret
           secret:
             defaultMode: 420
@@ -67,18 +61,17 @@ spec:
           secret:
             secretName: {{ .Values.awsCredentialsSecret }}
         {{- end}}
-{{- if .Values.serviceAccount}}
+        - name: socket-dir
+          emptyDir: {}
+      {{- if .Values.serviceAccount}}
       serviceAccountName: {{ .Values.serviceAccount | quote }}
-{{- end }}
+      {{- end }}
       containers:
       - name: pro-builder
         image: {{ .Values.proBuilder.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args:
           - "-license-file=/var/secrets/license/license"
-          - "--tlscert=/var/secrets/certs/client.crt"
-          - "--tlskey=/var/secrets/certs/client.key"
-          - "--tlscacert=/var/secrets/certs/ca.crt"
         env:
           - name: buildkit_server_name
             value: "127.0.0.1"
@@ -87,7 +80,7 @@ spec:
           - name: insecure
             value: "false"
           - name: buildkit_url
-            value: "tcp://127.0.0.1:1234"
+            value: "unix:///home/app/.local/run/buildkit/buildkitd.sock"
           - name: "disable_hmac"
             value: {{ .Values.disableHmac | quote }}
           - name: "max_inflight"
@@ -118,8 +111,13 @@ spec:
         {{- with .Values.proBuilder.securityContext }}
         securityContext:
           {{- . | toYaml | nindent 12 }}
+        {{- else }}
+        securityContext:
+          runAsGroup: 1000
         {{- end }}
         volumeMounts:
+        - name: socket-dir
+          mountPath: /home/app/.local/run/buildkit
         - name: registry-secret
           readOnly: true
           mountPath: "/home/app/.docker/"
@@ -132,9 +130,6 @@ spec:
         - name: builder-workspace
           mountPath: /tmp/
           readOnly: false
-        - name: client-certs
-          readOnly: true
-          mountPath: /var/secrets/certs
         {{- if .Values.awsCredentialsSecret }}
         - name: aws-credentials
           readOnly: true
@@ -142,14 +137,18 @@ spec:
         {{- end }}
       - name: buildkit
         args:
-          - "--addr=tcp://127.0.0.1:1234"
-          - "--tlscert=/var/secrets/certs/server.crt"
-          - "--tlskey=/var/secrets/certs/server.key"
-          - "--tlscacert=/var/secrets/certs/ca.crt"
-{{- if .Values.buildkit.rootless }}
+        {{- if .Values.buildkit.rootless }}
+          - "--addr=unix:///home/user/.local/run/buildkit/buildkitd.sock"
           - "--oci-worker-no-process-sandbox"
-{{- end }}
+        {{- else }}
+          - "--addr=unix:///run/buildkit/buildkitd.sock"
+          - "--group=1000"
+        {{- end }}
+        {{- if .Values.buildkit.rootless }}
+        image: {{ .Values.buildkitRootless.image }}
+        {{- else }}
         image: {{ .Values.buildkit.image }}
+        {{- end }}
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         ports:
         - containerPort: 1234
@@ -159,11 +158,28 @@ spec:
         {{- with .Values.buildkit.securityContext }}
         securityContext:
           {{- . | toYaml | nindent 12 }}
+        {{- else }}
+       {{- if .Values.buildkit.rootless }}
+        securityContext:
+          seccompProfile:
+            type: Unconfined
+          runAsUser: 1000
+          runAsGroup: 1000
+          privileged: false
+        {{- else }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          privileged: true
+        {{- end }}
         {{- end }}
         volumeMounts:
-        - name: daemon-certs
-          readOnly: true
-          mountPath: /var/secrets/certs
+        - name: socket-dir
+          {{- if .Values.buildkit.rootless }}
+          mountPath: /home/user/.local/run/buildkit
+          {{- else }}
+          mountPath: /run/buildkit/
+          {{- end }}
         - name: buildkit-workspace
           mountPath: /tmp/
           readOnly: false

--- a/chart/pro-builder/values.yaml
+++ b/chart/pro-builder/values.yaml
@@ -19,7 +19,7 @@ proBuilder:
   image: ghcr.io/openfaasltd/pro-builder:0.5.3
 
   # Set to 0 for unlimited, or some non-zero value for a hard limit
-  # the builder will return a HTTP 429 status code, then the client 
+  # the builder will return a HTTP 429 status code, then the client
   # must retry the request.
   # A function executed via the async queue will be retried, so can be
   # a convenient way to build functions without blocking the client.
@@ -32,20 +32,24 @@ proBuilder:
     # limits:
     #   memory: "256Mi"
 
+buildkitRootless:
+  # Image used when running buildkit in rootless mode.
+  image: moby/buildkit:v0.23.2-rootless
+
 # buildkit.image is for the buildkit daemon
 # Check for the latest release on GitHub: https://github.com/moby/buildkit/releases
 #
 # Both configurations are "rootless", however the rootless: true mode does not
 # require Buildkit to run as a privileged container and is preferred.
 buildkit:
-  # A configuration which uses a privileged container for when 
+  # A configuration which uses a privileged container for when
   # your nodes have issues running in rootless mode
   #
-  # Use rootless if possible, and if not, set up a dedicated 
+  # Use rootless if possible, and if not, set up a dedicated
   # nodepool for the function builder pods, which is recycled often
   # through the use of spot instances or preemptive VMs.
   #
-  # image: moby/buildkit:v0.23.2-rootless
+  # image: moby/buildkit:v0.23.2
   # rootless: false
   # securityContext:
   #   runAsUser: 0
@@ -54,16 +58,9 @@ buildkit:
 
   # For a rootless configuration, preferred, if the configuration
   # and Kernel version of your Kubernetes nodes supports it
-  # 
-  image: moby/buildkit:v0.23.2-rootless
+  #
+  image: moby/buildkit:v0.23.2
   rootless: true
-  securityContext:
-    # Needs Kubernetes >= 1.19
-    seccompProfile:
-      type: Unconfined
-    runAsUser: 1000
-    runAsGroup: 1000
-    privileged: false
 
   resources:
     requests:
@@ -97,4 +94,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use a shared socket for communication between Buildkit and the Pro Builder containers.

Chart changes:

- `securityContext` for buildkit does not need to be set explicitly in the values.yaml file anymore. The appropriate default values are selected  based on the value of the `buildkit.rootless` parameter.

- BREAKING CHANGE: The `buildkit.image` parameter is now only used to set the image when `buildkit.rootless` is `false`. A new parameter `buildkitRootless.image` is used to set the image for rootless mode.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This simplifies the deployment and removes the need to create and manage mTLS certificates.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified both the root and rootless mode are working on a local k3d cluster.
Verified the builder in rootless mode on an EKS cluster pushing to ECR with IRSA.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
