### PR TITLE
Change ingress example to use Traefik

### DIFF
--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -486,13 +486,14 @@ ingress:
               number: 8080
 
   # annotations:
-    # This annotation is deprecated, use IngressClass in the spec instead
-    # kubernetes.io/ingress.class: nginx
+    # Example Traefik annotations for HTTPS redirect and TLS
+    # traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # traefik.ingress.kubernetes.io/router.tls: "true"
   tls:
   # Secrets must be manually created in the namespace.
 
   ## You can specify the ingress controller by using the ingressClassName
-  #ingressClassName: nginx
+  #ingressClassName: traefik
 
 # ingressOperator (optional) – component to have specific FQDN and TLS for Functions
 # https://github.com/openfaas/ingress-operator

--- a/chart/sns-connector/README.md
+++ b/chart/sns-connector/README.md
@@ -40,7 +40,7 @@ You can configure permissions using a dedicated IAM user. The user needs a polic
 
 To receive http calls from AWS SNS the callback url has to be publicly accessible.
 
-The below instructions show how to set up Ingress with a TLS certificate using Ingress Nginx. You can also use any other ingress-controller, inlets-pro or an Istio Gateway. Reach out to us if you need a hand.
+The below instructions show how to set up Ingress with a TLS certificate using Traefik. You can also use any other ingress-controller, inlets-pro or an Istio Gateway. Reach out to us if you need a hand.
 
 Install [cert-manager](https://cert-manager.io/docs/), which is used to manage TLS certificates.
 
@@ -50,10 +50,10 @@ You can use Helm, or [arkade](https://github.com/alexellis/arkade):
 arkade install cert-manager
 ```
 
-Install ingress-nginx using arkade or Helm:
+Install Traefik using arkade or Helm:
 
 ```bash
-arkade install ingress-nginx
+arkade install traefik2
 ```
 
 Create an ACME certificate issuer:
@@ -76,7 +76,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: traefik
 EOF
 ```
 
@@ -96,11 +96,11 @@ metadata:
   name: sns-connector
   namespace: openfaas
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/issuer: letsencrypt-prod
   labels:
     app: sns-connector
 spec:
+  ingressClassName: traefik
   tls:
   - hosts:
     - $DOMAIN


### PR DESCRIPTION
## Description

Update ingress examples and documentation to use Traefik instead of Nginx as the ingress controller reference.

Changes:
- Update `values.yaml` ingress annotations and `ingressClassName` example to Traefik
- Update SNS connector README ingress instructions to use Traefik

## Why is this needed?

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Ingress Nginx will be retired in March 2026. Traefik is now the recommended ingress controller. The examples and docs should reflect this.

## How Has This Been Tested?

Reviewed the changed documentation and Helm values for correctness.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.