### PR TITLE
Disable allowPrivilegeEscalation across all charts

### DIFF
--- a/chart/cron-connector/templates/deployment.yaml
+++ b/chart/cron-connector/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
         {{- end }}
       containers:
         - name: cron-connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           {{- if .Values.openfaasPro }}
           image: {{ .Values.pro.image }}
           {{- else }}

--- a/chart/cron-connector/values.yaml
+++ b/chart/cron-connector/values.yaml
@@ -47,3 +47,6 @@ resources:
     cpu: "100m"
   # limits:
   #   memory: "256Mi"
+
+securityContext:
+  allowPrivilegeEscalation: false

--- a/chart/gcp-pubsub-connector/values.yaml
+++ b/chart/gcp-pubsub-connector/values.yaml
@@ -65,4 +65,5 @@ tolerations: []
 
 affinity: {}
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false

--- a/chart/headroom-controller/README.md
+++ b/chart/headroom-controller/README.md
@@ -63,6 +63,8 @@ kubectl create secret generic \
 Install with defaults:
 
 ```bash
+helm repo update
+
 helm upgrade --install headroom-controller \
   openfaas/headroom-controller \
   --namespace default
@@ -78,6 +80,8 @@ rbac:
 Then install with custom values:
 
 ```bash
+helm repo update
+
 helm upgrade --install headroom-controller \
   openfaas/headroom-controller \
   --namespace default \

--- a/chart/headroom-controller/values.yaml
+++ b/chart/headroom-controller/values.yaml
@@ -27,7 +27,8 @@ serviceAccount:
 
 podAnnotations: {}
 podSecurityContext: {}
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 
 resources:
   limits:

--- a/chart/kafka-connector/templates/deployment.yml
+++ b/chart/kafka-connector/templates/deployment.yml
@@ -66,6 +66,10 @@ spec:
       {{- end}}
       containers:
         - name: connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image }}
           command:
            - "/usr/bin/kafka-connector"

--- a/chart/kafka-connector/values.yaml
+++ b/chart/kafka-connector/values.yaml
@@ -89,6 +89,9 @@ resources:
   # limits:
   #   memory: "256Mi"
 
+securityContext:
+  allowPrivilegeEscalation: false
+
 # Use TLS Encryption, this is usually set to true.
 tls: true
 

--- a/chart/mqtt-connector/templates/deployment.yml
+++ b/chart/mqtt-connector/templates/deployment.yml
@@ -41,6 +41,10 @@ spec:
       {{- end }}
       containers:
         - name: connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image }}
           command:
           - "/usr/bin/mqtt-connector"

--- a/chart/mqtt-connector/values.yaml
+++ b/chart/mqtt-connector/values.yaml
@@ -33,3 +33,6 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+securityContext:
+  allowPrivilegeEscalation: false

--- a/chart/nats-connector/templates/deployment.yml
+++ b/chart/nats-connector/templates/deployment.yml
@@ -34,6 +34,10 @@ spec:
     spec:
       containers:
         - name: nats-connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image }}
           env:
             {{- if .Values.upstream_timeout }}

--- a/chart/nats-connector/values.yaml
+++ b/chart/nats-connector/values.yaml
@@ -35,3 +35,6 @@ resources:
   # limits:
   #   memory: "256Mi"
   #   cpu: "100m"
+
+securityContext:
+  allowPrivilegeEscalation: false

--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -121,6 +121,13 @@ If you wish to use the OpenFaaS Pro dashboard, [you must run the steps to "Creat
 
 Review the recommended Pro values in [values-pro.yaml](values-pro.yaml). These are overlaid on top of the default values in [values.yaml](values.yaml), which is used as a base for all installations.
 
+For OpenFaaS Pro, the recommended baseline includes container-level hardening. This hardening is applied to the control plane components:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+```
+
 Now deploy OpenFaaS from the helm chart repo:
 
 ```sh

--- a/chart/openfaas/templates/alertmanager-dep.yaml
+++ b/chart/openfaas/templates/alertmanager-dep.yaml
@@ -32,6 +32,10 @@ spec:
       {{- end }}
       containers:
       - name: alertmanager
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         image: {{ include "openfaas.image" (dict "image" .Values.alertmanager.image "registryPrefix" .Values.registryPrefix) }}
         imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
         command:

--- a/chart/openfaas/templates/ingress-operator-dep.yaml
+++ b/chart/openfaas/templates/ingress-operator-dep.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: ingress-operator
       containers:
       - name: operator
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           {{- .Values.ingressOperator.resources | toYaml | nindent 10 }}
         image: {{ include "openfaas.image" (dict "image" .Values.ingressOperator.image "registryPrefix" .Values.registryPrefix) }}

--- a/chart/openfaas/templates/queueworker-ce-dep.yaml
+++ b/chart/openfaas/templates/queueworker-ce-dep.yaml
@@ -34,6 +34,10 @@ spec:
       {{- end }}
       containers:
       - name: queue-worker
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
         image: {{ include "openfaas.image" (dict "image" .Values.queueWorker.image "registryPrefix" .Values.registryPrefix) }}

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -27,7 +27,8 @@ rbac: true                    # Kubernetes RBAC, no good reason to disable this
 generateBasicAuth: true       # Set to false if applying credentials separately from the chart, otherwise set to true
 
 # Define a securityContext for the containers deployed by this helm chart.
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 
 exposeServices: true
 serviceType: NodePort        # serviceType for OpenFaaS gateway

--- a/chart/postgres-connector/templates/deployment.yml
+++ b/chart/postgres-connector/templates/deployment.yml
@@ -47,6 +47,10 @@ spec:
       {{- end}}
       containers:
         - name: connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image }}
           command:
             - "/usr/bin/connector"

--- a/chart/postgres-connector/values.yaml
+++ b/chart/postgres-connector/values.yaml
@@ -49,6 +49,9 @@ resources:
   #   memory: "256Mi"
   #   cpu: "100m"
 
+securityContext:
+  allowPrivilegeEscalation: false
+
 nodeSelector: {}
 
 tolerations: []

--- a/chart/pro-builder/templates/deployment.yml
+++ b/chart/pro-builder/templates/deployment.yml
@@ -126,6 +126,7 @@ spec:
         {{- else }}
         securityContext:
           runAsGroup: 1000
+          allowPrivilegeEscalation: false
         {{- end }}
         volumeMounts:
         - name: socket-dir
@@ -182,6 +183,7 @@ spec:
             type: Unconfined
           runAsUser: 1000
           runAsGroup: 1000
+          allowPrivilegeEscalation: false
           privileged: false
         {{- else }}
         securityContext:

--- a/chart/queue-worker/templates/deployment.yaml
+++ b/chart/queue-worker/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           secretName: openfaas-license
       containers:
       - name:  queue-worker
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 10 }}
         image: {{ .Values.image }}

--- a/chart/queue-worker/values.yaml
+++ b/chart/queue-worker/values.yaml
@@ -68,3 +68,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+securityContext:
+  allowPrivilegeEscalation: false

--- a/chart/rabbitmq-connector/values.yaml
+++ b/chart/rabbitmq-connector/values.yaml
@@ -70,7 +70,8 @@ tolerations: []
 
 affinity: {}
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 
 # Authentication
 

--- a/chart/sns-connector/templates/deployment.yml
+++ b/chart/sns-connector/templates/deployment.yml
@@ -47,6 +47,10 @@ spec:
       {{- end}}
       containers:
         - name: connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image }}
           command:
             - "/usr/bin/connector"

--- a/chart/sns-connector/values.yaml
+++ b/chart/sns-connector/values.yaml
@@ -66,6 +66,9 @@ resources:
   #   memory: "256Mi"
   #   cpu: "100m"
 
+securityContext:
+  allowPrivilegeEscalation: false
+
 nodeSelector: {}
 
 tolerations: []

--- a/chart/sqs-connector/templates/deployment.yml
+++ b/chart/sqs-connector/templates/deployment.yml
@@ -47,6 +47,10 @@ spec:
       {{- end}}
       containers:
         - name: connector
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.image }}
           command:
             - "/usr/bin/sqs-connector"

--- a/chart/sqs-connector/values.yaml
+++ b/chart/sqs-connector/values.yaml
@@ -77,6 +77,9 @@ resources:
   #   memory: "256Mi"
   #   cpu: "100m"
 
+securityContext:
+  allowPrivilegeEscalation: false
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disable allowPrivilegeEscalation across all charts

## Why is this needed?

The "allowPrivilegeEscalation" setting has already been in effect for 10 months for the openfaas Helm chart.

This PR aims to add belt and braces for any other/additional charts and components.

allowPrivilegeEscalation is part of defense in depth to address exploits like CVE-2026-31431 aka "copy.fail"

## Who is this for?

All OpenFaaS Standard/Enterprise customers

## How Has This Been Tested?

This is an innocuous security setting, no testing needed, beyond linting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
