### PR TITLE
Propagate gateway timeouts to dashboard deployment

### DIFF
--- a/chart/openfaas/templates/dashboard-dep.yaml
+++ b/chart/openfaas/templates/dashboard-dep.yaml
@@ -85,6 +85,8 @@ spec:
       {{- end }}
         - name: gateway_url
           value: "http://gateway.{{ .Release.Namespace }}:8080/"
+        - name: upstream_timeout
+          value: "{{ .Values.gateway.upstreamTimeout }}"
         - name: metrics_window
           value: 60m
         - name: prometheus_host

--- a/chart/openfaas/templates/dashboard-dep.yaml
+++ b/chart/openfaas/templates/dashboard-dep.yaml
@@ -87,6 +87,10 @@ spec:
           value: "http://gateway.{{ .Release.Namespace }}:8080/"
         - name: upstream_timeout
           value: "{{ .Values.gateway.upstreamTimeout }}"
+        - name: read_timeout
+          value: "{{ .Values.gateway.readTimeout }}"
+        - name: write_timeout
+          value: "{{ .Values.gateway.writeTimeout }}"
         - name: metrics_window
           value: 60m
         - name: prometheus_host


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Propagates three gateway timeout environment variables to the dashboard deployment in the Helm chart:

- `upstream_timeout` -  so the dashboard can compare each function's `exec_timeout` against the gateway's upstream timeout and show a warning when the function timeout exceeds it.
- `read_timeout` and `write_timeout` - these must match the gateway's values for dashboard invocations to work correctly. If the dashboard's timeouts are shorter, it can close the connection before the gateway completes the request.

## Why is this needed?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

The `upstream_timeout` is required for the gateway timeout warning feature added to the dashboard. The `read_timeout` and `write_timeout` were not correctly propagated to the dashboard, which could cause the dashboard to close connections prematurely before the gateway finished handling a request.

## Who is this for?

What company is this for? Are you listed in the [ADOPTERS.md](https://github.com/openfaas/faas/blob/master/ADOPTERS.md) file?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.