### PR TITLE
Add allowedCallbackURLs parameter for queue-worker

### DIFF
--- a/chart/openfaas/README.md
+++ b/chart/openfaas/README.md
@@ -582,6 +582,7 @@ See [values.yaml](./values.yaml) for detailed configuration.
 | `jetstreamQueueWorker.logs.debug` | Log debug messages | `false` |
 | `jetstreamQueueWorker.logs.format` | Set the log format, supports `console` or `json` | `console` |
 | `jetstreamQueueWorker.adaptiveConcurrency` | Enable adaptive concurrency limiting for functions. This setting only takes effect when `jetstreamQueueWorker.mode` is set to `function`. | `true` |
+| `queueWorkerPro.allowedCallbackURLs` | List of glob patterns for URLs allowed to receive async callbacks. Defaults to `["*"]` (allow all). Set to empty list `[]` to deny all | `["*"]` |
 | `nats.channel` | The name of the NATS Streaming channel or NATS JetStream stream to use for asynchronous function invocations | `faas-request` |
 | `nats.external.clusterName` | The name of the externally-managed NATS Streaming server | `""` |
 | `nats.external.enabled` | Whether to use an externally-managed NATS Streaming server | `false` |

--- a/chart/openfaas/templates/queueworker-dep.yaml
+++ b/chart/openfaas/templates/queueworker-dep.yaml
@@ -113,6 +113,8 @@ spec:
           value: "{{ .Values.queueWorkerPro.httpRetryCodes }}"
         - name: backoff
           value: "{{ .Values.queueWorkerPro.backoff }}"
+        - name: "allowed_callback_urls"
+          value: "{{ join "," .Values.queueWorkerPro.allowedCallbackURLs }}"
 
         {{- if .Values.securityContext }}
         securityContext:

--- a/chart/openfaas/values.yaml
+++ b/chart/openfaas/values.yaml
@@ -271,6 +271,7 @@ queueWorkerPro:
   printResponseBody: false
   # Control the concurrent invocations
   maxInflight: 50
+  allowedCallbackURLs: ["*"]
 
 # Community Edition, maxInflight is 1
 # Name of shared queue is "faas-request"

--- a/chart/queue-worker/README.md
+++ b/chart/queue-worker/README.md
@@ -115,6 +115,7 @@ helm upgrade --install \
 | `gateway.host` | The host at which the OpenFaaS gateway can be reached | `http://gateway.openfaas` |
 | `gateway.port` | The port at which the OpenFaaS gateway can be reached | `8080` |
 | `insecureTLS` | Enable insecure tls for callbacks | `false` |
+| `allowedCallbackURLs` | List of glob patterns for URLs allowed to receive async callbacks. Defaults to `["*"]` (allow all). Set to empty list `[]` to deny all | `["*"]` |
 | `nats.host` | The host at which the NATS JetStream server can be reached | `nats.openfaas` |
 | `nats.port` | The port at which the NATS JetStream server can be reached | `4222` |
 | `nats.stream.name` | Name of the NATS JetStream stream to use | `faas-request` |

--- a/chart/queue-worker/templates/deployment.yaml
+++ b/chart/queue-worker/templates/deployment.yaml
@@ -96,6 +96,8 @@ spec:
               value: "{{ .Values.httpRetryCodes }}"
             - name: "backoff"
               value: "{{ .Values.backoff }}"
+            - name: "allowed_callback_urls"
+              value: "{{ join "," .Values.allowedCallbackURLs }}"
         volumeMounts:
         - name: license
           readOnly: true

--- a/chart/queue-worker/values.yaml
+++ b/chart/queue-worker/values.yaml
@@ -6,6 +6,8 @@
 
 image: ghcr.io/openfaasltd/jetstream-queue-worker:0.5.8
 
+allowedCallbackURLs: ["*"]
+
 replicas: 1
 
 # Change this to your queue name.


### PR DESCRIPTION
## Description

Allow users to restrict which hosts receive async function callbacks via a list of glob patterns. The `allowedCallbackURLs` parameter is added to both the main openfaas chart and the standalone queue-worker chart.

- Defaults to `["*"]` for backwards compatibility (allow all)
- Set to empty list `[]` to deny all callbacks
- Accepts a list of URLs like `*.example.com` or `api.internal`

## Why is this needed?

Prevents SSRF-style attacks where malicious callback URLs could be used to reach internal services. Users can now restrict callbacks to trusted domains only.

- [x] I have raised an issue to propose this change

## How Has This Been Tested?

This chart was used and validated during E2E testing.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have signed-off my commits with `git commit -s`